### PR TITLE
Patch/gcc11

### DIFF
--- a/include/drjit/packet_intrin.h
+++ b/include/drjit/packet_intrin.h
@@ -26,6 +26,8 @@
 #  if !defined(_IMMINTRIN_H_INCLUDED) && !defined(__clang__) && defined(__GNUC__)
      // And the same once more, for GCC..
 #    define _IMMINTRIN_H_INCLUDED
+// GCC 11
+#    define _X86GPRINTRIN_H_INCLUDED
 #  endif
 
 #  if defined(DRJIT_X86_SSE42)

--- a/include/drjit/packet_intrin.h
+++ b/include/drjit/packet_intrin.h
@@ -26,8 +26,10 @@
 #  if !defined(_IMMINTRIN_H_INCLUDED) && !defined(__clang__) && defined(__GNUC__)
      // And the same once more, for GCC..
 #    define _IMMINTRIN_H_INCLUDED
-// GCC 11
-#    define _X86GPRINTRIN_H_INCLUDED
+#    if __GNUC__ >= 11
+     // In GCC 11 and later we are expected to include a different header..
+#       define _X86GPRINTRIN_H_INCLUDED
+#    endif
 #  endif
 
 #  if defined(DRJIT_X86_SSE42)


### PR DESCRIPTION
When including the intrinsics in `include/drjit/packet_intrin.h`, GCC expects us to include the `immintrin.h` header instead of the individual headers.
In GCC 11 however, the `bmi2intrin.h` headers are expected to be included via `x86gprintrin.h`.
This PR adds the missing "workaround" definition if GCC >= 11.
