### PR TITLE
Remove additional DLL search directories in Python package init

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -4,17 +4,6 @@ import os
 if sys.version_info < (3, 8):
     raise ImportError("Dr.Jit requires Python >= 3.8")
 
-if os.name == 'nt':
-    # Specify DLL search path for windows (no rpath on this platform..)
-    d = __file__
-    for i in range(3):
-        d = os.path.dirname(d)
-    try: # try to use Python 3.8's DLL handling
-        os.add_dll_directory(d)
-    except AttributeError:  # otherwise use PATH
-        os.environ['PATH'] += os.pathsep + d
-    del d, i
-
 # Implementation details accessed by both C++ and Python
 import drjit.detail as detail # noqa
 

--- a/resources/generate_stub_files.py
+++ b/resources/generate_stub_files.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 """
-Usage: generate_stub_files.py {dest_dir} {drjit_path}
+Usage: generate_stub_files.py {dest_dir}
 
 This script generates stub files for Python type information for the `drjit`
 package.  It recursively traverses the `drjit` package and writes all the
 objects (clases, methods, functions, enums, etc.) it finds to the `dest_dir`
 folder. The stub files contain both the signatures and the docstrings of the
-objects. The second argument of this script, `drjit_path`, is optional and
-indicates the path to the `drjit` package folder if it is not installed or
-included in the user's $PYTHONPATH envvar.
+objects.
 """
 
 import os
@@ -120,7 +118,7 @@ def process_class(obj):
         v = getattr(obj, k)
         if type(v).__name__ == 'instancemethod':
             methods.append((k, v))
-        elif type(v).__name__ == 'function' and v.__code__.co_varnames[ 0] == 'self':
+        elif type(v).__name__ == 'function' and v.__code__.co_varnames[0] == 'self':
             py_methods.append((k, v))
         elif type(v).__name__ == 'property':
             properties.append((k, v))
@@ -236,7 +234,7 @@ def process_py_function(name, obj, indent=0):
 
     if has_doc:
         doc = obj.__doc__.splitlines()
-        if len(doc) > 0:  # first line is always empty
+        if len(doc) > 0: # first line is always empty
             w(f'{indent}    \"\"\"')
             for l in doc:
                 w(f'{indent}    {l.strip()}')
@@ -258,7 +256,7 @@ def process_module(m, top_module=False):
     w('import drjit as dr')
     w('')
 
-    # Ignore initilization errors of invalid variants on this system
+    # Ignore initialization errors of invalid variants on this system
     try:
         dir(m)
     except Exception:
@@ -280,8 +278,7 @@ def process_module(m, top_module=False):
             if k.startswith('_'):
                 continue
             process_properties(k, v)
-        elif type(v).__bases__[0].__name__ == 'module' or type(
-                v).__name__ == 'module':
+        elif type(v).__bases__[0].__name__ == 'module' or type(v).__name__ == 'module':
             if k in ['dr']:
                 continue
             if not v.__name__.startswith('drjit'):
@@ -306,17 +303,13 @@ if __name__ == '__main__':
     logging.info('Generating stub files for the drjit package.')
 
     if len(sys.argv) < 2:
-        raise RuntimeError("At least one argument is expected: the output "
+        raise RuntimeError("Exactly one argument is expected: the output "
                            "directory of the generated stubs")
     stub_folder = sys.argv[1]
 
-    if len(sys.argv) > 2:
-        drjit_folder = sys.argv[2]
-        sys.path.append(drjit_folder)
-
     import drjit as dr
 
-    os.makedirs(f'{stub_folder}/stubs', exist_ok=True)
+    os.makedirs(os.path.join(stub_folder, 'stubs'), exist_ok=True)
 
     logging.debug(f'Processing drjit root module')
     buffer, submodules = process_module(dr, top_module=True)
@@ -333,7 +326,7 @@ if __name__ == '__main__':
         logging.debug(f'Processing submodule: {v.__name__}')
         buffer, new_submodules = process_module(v)
 
-        with open(f'{stub_folder}stubs/{k}.pyi', 'w') as f:
+        with open(f'{os.path.join(stub_folder, "stubs", k + ".pyi")}', 'w') as f:
             f.write(buffer)
 
         submodules = submodules[1:] + new_submodules

--- a/resources/generate_stub_files.py
+++ b/resources/generate_stub_files.py
@@ -313,7 +313,7 @@ if __name__ == '__main__':
 
     logging.debug(f'Processing drjit root module')
     buffer, submodules = process_module(dr, top_module=True)
-    with open(f'{stub_folder}__init__.pyi', 'w') as f:
+    with open(os.path.join(stub_folder, '__init__.pyi'), 'w') as f:
         f.write(buffer)
 
     processed_submodules = set()

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -87,9 +87,19 @@ if (DRJIT_MASTER_PROJECT)
         find_package(Python COMPONENTS Interpreter REQUIRED)
     endif()
 
-    add_custom_target(drjit_stub_file_generation ALL COMMAND
-        "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
-        ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/ ${CMAKE_CURRENT_BINARY_DIR}/../../ DEPENDS drjit-python)
+    if (MSVC)
+        add_custom_target(drjit_stub_file_generation ALL COMMAND
+            ${CMAKE_COMMAND} -E env
+            "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/../../;$ENV{PYTHONPATH}"
+            "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
+            ${CMAKE_CURRENT_BINARY_DIR}/../../drjit DEPENDS drjit-python)
+    else()
+        add_custom_target(drjit_stub_file_generation ALL COMMAND
+            ${CMAKE_COMMAND} -E env
+            "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/../../:$ENV{PYTHONPATH}"
+            "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
+            ${CMAKE_CURRENT_BINARY_DIR}/../../drjit DEPENDS drjit-python)
+    endif()
 
     if (NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
         add_dependencies(drjit_stub_file_generation copy-python-files)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -93,15 +93,23 @@ if (DRJIT_MASTER_PROJECT)
   endif()
   file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/../.." DRJIT_STUBS_ENV_PYTHONPATH)
 
-  add_custom_target(drjit_stub_file_generation ALL COMMAND
-    ${CMAKE_COMMAND} -E env
-    "PYTHONPATH=${DRJIT_STUBS_ENV_PYTHONPATH}${PATH_SEP}$ENV{PYTHONPATH}"
-    "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
-    ${CMAKE_CURRENT_BINARY_DIR}/../../drjit DEPENDS drjit-python)
-
+  set(DRJIT_STUB_FILE_DEPENDENCIES drjit-python)
+  list(APPEND DRJIT_STUB_FILE_DEPENDENCIES ${DRJIT_COPY_FILES})
   if (NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
-    add_dependencies(drjit_stub_file_generation copy-python-files)
+    list(APPEND DRJIT_STUB_FILE_DEPENDENCIES copy-python-files)
   endif()
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/__init__.pyi
+    COMMAND ${CMAKE_COMMAND} -E env
+      "PYTHONPATH=${DRJIT_STUBS_ENV_PYTHONPATH}${PATH_SEP}$ENV{PYTHONPATH}"
+      "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
+      ${CMAKE_CURRENT_BINARY_DIR}/../../drjit
+    DEPENDS ${DRJIT_STUB_FILE_DEPENDENCIES}
+  )
+  add_custom_target(drjit_stub_file_generation ALL
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/__init__.pyi
+  )
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/__init__.pyi DESTINATION drjit)
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/stubs/ DESTINATION drjit/stubs)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -83,31 +83,29 @@ endif()
 # ----------------------------------------------------------
 
 if (DRJIT_MASTER_PROJECT)
-    if (NOT Python_EXECUTABLE)
-        find_package(Python COMPONENTS Interpreter REQUIRED)
-    endif()
+  if (NOT Python_EXECUTABLE)
+    find_package(Python COMPONENTS Interpreter REQUIRED)
+  endif()
 
-    if (MSVC)
-        add_custom_target(drjit_stub_file_generation ALL COMMAND
-            ${CMAKE_COMMAND} -E env
-            "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/../../;$ENV{PYTHONPATH}"
-            "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
-            ${CMAKE_CURRENT_BINARY_DIR}/../../drjit DEPENDS drjit-python)
-    else()
-        add_custom_target(drjit_stub_file_generation ALL COMMAND
-            ${CMAKE_COMMAND} -E env
-            "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/../../:$ENV{PYTHONPATH}"
-            "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
-            ${CMAKE_CURRENT_BINARY_DIR}/../../drjit DEPENDS drjit-python)
-    endif()
+  set(PATH_SEP ":")
+  if(MSVC)
+    set(PATH_SEP ";")
+  endif()
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/../.." DRJIT_STUBS_ENV_PYTHONPATH)
 
-    if (NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
-        add_dependencies(drjit_stub_file_generation copy-python-files)
-    endif()
+  add_custom_target(drjit_stub_file_generation ALL COMMAND
+    ${CMAKE_COMMAND} -E env
+    "PYTHONPATH=${DRJIT_STUBS_ENV_PYTHONPATH}${PATH_SEP}$ENV{PYTHONPATH}"
+    "${Python_EXECUTABLE}" -Xutf8 ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/generate_stub_files.py
+    ${CMAKE_CURRENT_BINARY_DIR}/../../drjit DEPENDS drjit-python)
 
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/__init__.pyi DESTINATION drjit)
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/stubs/ DESTINATION drjit/stubs)
-    
-    file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/py.typed CONTENT "partial\n")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/py.typed DESTINATION drjit)
+  if (NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
+    add_dependencies(drjit_stub_file_generation copy-python-files)
+  endif()
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/__init__.pyi DESTINATION drjit)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/stubs/ DESTINATION drjit/stubs)
+
+  file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/py.typed CONTENT "partial\n")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/../../drjit/py.typed DESTINATION drjit)
 endif()


### PR DESCRIPTION
This PR is somewhat of a followup to this issue: https://github.com/mitsuba-renderer/mitsuba3/issues/228

Currently, `drjit` has a `os.add_dll_directory` statement in its `__init__.py` file. Unfortunately, this functionality is not well supported by Conda on Windows (https://github.com/conda/conda/issues/10897). Moreover, this code is only useful when building **Mitsuba** and serves no purpose when using Dr.Jit on its own.
This PR removes the `os.add_dll_directory` statement.

This PR also refactors the Python stub file generation such that it expected the `drjit` package to already be located on the `PYTHONPATH`. This is not a necessary change, but rather for consistency with the work done in https://github.com/mitsuba-renderer/mitsuba3/pull/245.