### PR TITLE
Support list/dict when wrapping function in wrap_ad

### DIFF
--- a/drjit/router.py
+++ b/drjit/router.py
@@ -5879,8 +5879,10 @@ def wrap_ad(source: str, target: str):
                             return tuple(cls.get_grads(b) for b in args)
                         elif isinstance(args, _Mapping):
                             return {k: cls.get_grads(v) for k, v in args.items()}
-                        else:
+                        elif is_torch_tensor(args):
                             return getattr(args, 'grad', None)
+                        else:
+                            return None
 
                 return _dr.custom(ToTorch, args)
 

--- a/drjit/router.py
+++ b/drjit/router.py
@@ -5869,9 +5869,18 @@ def wrap_ad(source: str, target: str):
                         grad_out_torch = drjit_to_torch(self.grad_out())
                         grad_out_torch = torch_ensure_shape(grad_out_torch, self.res_torch)
                         _torch.autograd.backward(self.res_torch, grad_out_torch)
-                        args_grad_torch = [getattr(a, 'grad', None) for a in self.args_torch]
+                        args_grad_torch = self.get_grads(self.args_torch)
                         args_grad = torch_to_drjit(args_grad_torch)
                         self.set_grad_in('args', args_grad)
+
+                    @classmethod
+                    def get_grads(cls, args):
+                        if isinstance(args, _Sequence) and not isinstance(args, str):
+                            return tuple(cls.get_grads(b) for b in args)
+                        elif isinstance(args, _Mapping):
+                            return {k: cls.get_grads(v) for k, v in args.items()}
+                        else:
+                            return getattr(args, 'grad', None)
 
                 return _dr.custom(ToTorch, args)
 

--- a/tests/python/test_wrap_ad.py
+++ b/tests/python/test_wrap_ad.py
@@ -176,10 +176,9 @@ def test08_from_torch_two_args_two_outputs(m):
     assert dr.allclose(m.Float(b.grad), [3, 3, 3])
 
 def test09_to_torch_list_of_tensors_as_args():
-    l = [
-        m.TensorXf(m.Float([1.0, 2.0, 3.0]), shape=[3]),
-        m.TensorXf(m.Float([4.0, 5.0, 6.0]), shape=[3])
-    ]
+    a = m.TensorXf(m.Float([1.0, 2.0, 3.0]), shape=[3])
+    b = m.TensorXf(m.Float([4.0, 5.0, 6.0]), shape=[3])
+    l = [a,b]
     dr.enable_grad(*l)
 
     @dr.wrap_ad(source='drjit', target='torch')

--- a/tests/python/test_wrap_ad.py
+++ b/tests/python/test_wrap_ad.py
@@ -174,3 +174,23 @@ def test08_from_torch_two_args_two_outputs(m):
     assert dr.allclose(m.Float(d), [12, 15, 18])
     assert dr.allclose(m.Float(a.grad), [4, 4, 4])
     assert dr.allclose(m.Float(b.grad), [3, 3, 3])
+
+def test09_to_torch_list_of_tensors_as_args():
+    l = [
+        m.TensorXf(m.Float([1.0, 2.0, 3.0]), shape=[3]),
+        m.TensorXf(m.Float([4.0, 5.0, 6.0]), shape=[3])
+    ]
+    dr.enable_grad(*l)
+
+    @dr.wrap_ad(source='drjit', target='torch')
+    def func(l):
+        return l[0] * 4, l[1] * 3
+
+    c, d = func(l)
+    dr.backward(dr.sum(c + d))
+
+    assert dr.allclose(c, [4, 8, 12])
+    assert dr.allclose(d, [12, 15, 18])
+    assert dr.allclose(dr.grad(a), [4, 4, 4])
+    assert dr.allclose(dr.grad(b), [3, 3, 3])
+

--- a/tests/python/test_wrap_ad.py
+++ b/tests/python/test_wrap_ad.py
@@ -175,7 +175,7 @@ def test08_from_torch_two_args_two_outputs(m):
     assert dr.allclose(m.Float(a.grad), [4, 4, 4])
     assert dr.allclose(m.Float(b.grad), [3, 3, 3])
 
-def test09_to_torch_list_of_tensors_as_args():
+def test09_to_torch_list_of_tensors_as_args(m):
     a = m.TensorXf(m.Float([1.0, 2.0, 3.0]), shape=[3])
     b = m.TensorXf(m.Float([4.0, 5.0, 6.0]), shape=[3])
     l = [a,b]


### PR DESCRIPTION
When using `wrap_ad` I noticed that the following would fail if you ran `dr.backward()` afterwards:

```
@dr.wrap_ad(source="drjit", target="torch")
def torch_func(x: List[torch.Tensor]):
    return x[0]
```

Previous assumption supposed that arguments had flattened `torch.Tensor` allowing it to just query `grad` in element of `args` . Therefore, it tried to query the attribute `grad` from a list, instead of trying to querying it from the element of the list.

We propose a recursive solution that should work for nested list/dict