### PR TITLE
Allows functions in `wrap_ad` context to return nested structures

### DIFF
--- a/drjit/traits.py
+++ b/drjit/traits.py
@@ -813,7 +813,7 @@ def leaf_array_t(arg):
             if is_diff_v(t) and is_float_v(t):
                 break
     elif isinstance(arg, _Mapping):
-        for k, v in arg:
+        for k, v in arg.items():
             t = leaf_array_t(v)
             if is_diff_v(t) and is_float_v(t):
                 break


### PR DESCRIPTION
`torch.autograd.backward` only supports list of tensors: https://pytorch.org/docs/stable/generated/torch.autograd.backward.html . This causes the previous assumption to break as `self.res_torch` could be a nested structure.

We propose to recursively flatten eveything to be passed to the backward step. We also add a test demonstrating that it works.