### PR TITLE
Mask stack improvements

### DIFF
--- a/tests/ad_megakernel.cpp
+++ b/tests/ad_megakernel.cpp
@@ -263,7 +263,6 @@ DRJIT_TEST(test05_vcall_symbolic_ad_loop_opt) {
     }
 }
 
-
 DRJIT_TEST(test06_vcall_symbolic_nested_ad_loop_opt) {
     if constexpr (dr::is_cuda_v<Float>)
         jit_init((uint32_t) JitBackend::CUDA);


### PR DESCRIPTION
This commit contains the Dr.Jit part of two related PRs (with the Dr.Jit-Core part being at https://github.com/mitsuba-renderer/drjit-core/pull/32)

It bundles several improvements to the mask stack. For context, the mask stack is an implicit stack of masks, whose top element is automatically applied to memory reads/writes and a few other operations to disable inactive entries of the current wavefront. That is important because undefined behavior resulting from unmasked memory operations could cause inconsistencies or even crash the program.

LLVM has an implicit default mask (even when the stack is empty) that is needed because the wavefront size might not be an exact multiple of the SIMD vector width. This means that some elements are always masked even in the absence of conditional operations that normally cause some masking (loops, vcalls).

The changes are:

- The implicit default mask on LLVM is now consistently created based on the size of the underlying wavefront. That requires changes in a few places because the size has to be determined. Previously, the default mask always had a size of 1, which made no sense and could cause serious issues when somebody actually evaluated the mask and turned into a memory-backed variable.

- Several parts of Dr.Jit fetch the top of the mask stack and combine it with an existing mask if the sizes are compatible. The commit adds a function `jit_var_mask_apply()` to factor out this repeated code.

- The ``dr::Loop::operator()`` routine was refactored.

- The `jit_var_vcall()` routine for recorded dynamic dispatch now incorporates the `jit_var_mask_apply()` logic as well as a check for whether `self == nullptr`. That means that these steps can be removed from the caller.