### PR TITLE
Fix array shape in dr.quat_to_matrix

### DIFF
--- a/drjit/matrix.py
+++ b/drjit/matrix.py
@@ -339,7 +339,7 @@ def matrix_to_quat(m, /):
     if not _dr.is_matrix_v(m):
         raise Exception('Unsupported type!')
 
-    name = _dr.detail.array_name('Quaternion', m.Type, [4], m.IsScalar)
+    name = _dr.detail.array_name('Quaternion', m.Type, (4, *m.Shape[2:]), m.IsScalar)
     module = _modules.get(m.__module__)
     Quat4f = getattr(module, name)
 

--- a/drjit/matrix.py
+++ b/drjit/matrix.py
@@ -298,7 +298,7 @@ def quat_to_matrix(q, size=4):
     if not _dr.is_quaternion_v(q):
         raise Exception('Unsupported type!')
 
-    name = _dr.detail.array_name('Matrix', q.Type, (size, size), q.IsScalar)
+    name = _dr.detail.array_name('Matrix', q.Type, (size, size, *q.Shape[1:]), q.IsScalar)
     module = _modules.get(q.__module__)
     Matrix = getattr(module, name)
 

--- a/drjit/router.py
+++ b/drjit/router.py
@@ -168,7 +168,7 @@ def _var_promote_select(a0, a1, a2):
     base = a0 if getattr(a0, 'Depth', 0) >= getattr(a1, 'Depth', 0) else a1
     base = base if getattr(base, 'Depth', 0) >= getattr(a2, 'Depth', 0) else a2
 
-    t0 = base.ReplaceScalar(vt0, diff)
+    t0 = base.MaskType
     t12 = base.ReplaceScalar(_builtins.max(vt1, vt2), diff)
 
     if type(a0) is not t0:

--- a/tests/python/test_quaternion.py
+++ b/tests/python/test_quaternion.py
@@ -1,7 +1,7 @@
 import math
 import drjit as dr
 from drjit.scalar import Quaternion4f as Q
-from drjit.scalar import Float, Array4f
+from drjit.scalar import Bool, Float, Array4f, Array4b
 
 
 def test01_bcast():
@@ -61,3 +61,12 @@ def test06_exp():
 def test07_power():
     assert dr.allclose(Q(1, 2, 3, 4) ** Q(0.11, 0.13, 0.19, 0.21),
                        Q(0.253509, 0.372162, 0.481497, 0.982482))
+
+def test08_select():
+    m = Bool(True)
+    t = Q(1, 1, 1, 1)
+    f = Q(0, 0, 0, 0)
+    assert(dr.allclose(dr.select(m, t, f), t))
+    m = Array4b(True, False, True, False)
+    r = Q(1, 0, 1, 0)
+    assert(dr.allclose(dr.select(m, t, f), r))


### PR DESCRIPTION
If I have a simple `mi.Quaternion4f q` in Python, the matrix type is not correctly derived when calling `dr.quat_to_matrix(q)`.