### PR TITLE
Fix implicit gradient tracking in dr.switch and dr.dispatch

### DIFF
--- a/drjit/detail.py
+++ b/drjit/detail.py
@@ -769,7 +769,7 @@ def traverse(traverse_static_array=True, traverse_tensor=True):
 
 
 @traverse()
-def apply_cpp(arg, func):
+def apply_cpp(arg, func, diff=True):
     '''
     Apply a C++ function to data structures containing JIT variables. The C++
     lambda must take as input the index of the JIT variable. It can optionally
@@ -780,7 +780,7 @@ def apply_cpp(arg, func):
     idx = func(arg.index)
     if isinstance(idx, int):
         res.set_index_(idx)
-        if _dr.is_diff_v(arg):
+        if diff and _dr.is_diff_v(arg):
             res.set_index_ad_(arg.index_ad)
     return res
 

--- a/src/python/switch.h
+++ b/src/python/switch.h
@@ -104,7 +104,7 @@ py::object switch_record_impl(UInt32 indices, py::list funcs, py::args args) {
     uint32_t offset = 0;
     return apply_cpp(result, py::cpp_function([&](uint32_t /*index*/) {
                          return indices_out[offset++];
-                     }));
+                     }), false);
 }
 
 // ====================================================================


### PR DESCRIPTION
This patch fixes various issues with `dr.switch` and `dr.dispatch` when the functions have an implicit dependency to variables that have gradient tracking enabled. This was not previously tested, but it is a crucial functionality that needs to be incorporated. Additionally, this PR adds the related unit tests.

