### PR TITLE
Fix `dr.backward_from`/`dr.foward_from` on special types

### DIFF
--- a/drjit/router.py
+++ b/drjit/router.py
@@ -4383,7 +4383,7 @@ def forward_from(arg, flags=_dr.ADFlag.Default):
     '''
     ta = type(arg)
     _check_grad_enabled('forward_from', ta, arg)
-    set_grad(arg, 1)
+    set_grad(arg, _dr.ones(ta))
     enqueue(_dr.ADMode.Forward, arg)
     traverse(ta, _dr.ADMode.Forward, flags)
 
@@ -4465,7 +4465,7 @@ def backward_from(arg, flags=_dr.ADFlag.Default):
     if _dr.depth_v(arg) > 1:
         arg = arg + ta(0)
 
-    set_grad(arg, 1)
+    set_grad(arg, _dr.ones(ta))
     enqueue(_dr.ADMode.Backward, arg)
     traverse(ta, _dr.ADMode.Backward, flags)
 

--- a/tests/python/test_ad.py
+++ b/tests/python/test_ad.py
@@ -1906,3 +1906,39 @@ def test76_custom_op_non_array_types(m):
     # Pushes gradients to both outputs
     assert dr.all(dr.grad(result1) == 3.5)
     assert dr.all(dr.grad(result2) == 2 * 3.5)
+
+
+def test77_forward_from_quaternion(m):
+    # Propagating from a Quaternion, propagates from all its components
+    a = m.Quaternion4f(1.0)
+    dr.enable_grad(a.y) # Gradients on `j` component
+    b = 2 * a
+    dr.forward_from(a)
+    assert dr.allclose(dr.grad(b), m.Quaternion4f(0, 2, 0, 0))
+
+
+def test78_backward_from_quaternion(m):
+    # Propagating from a Quaternion, propagates from all its components
+    a = m.Quaternion4f(1.0)
+    dr.enable_grad(a.y) # Gradients on `j` component
+    b = 2 * a
+    dr.backward_from(b)
+    assert dr.allclose(dr.grad(a), m.Quaternion4f(0, 2, 0, 0))
+
+
+def test79_forward_from_complex(m):
+    # Propagating from a Quaternion, propagates from all its components
+    a = m.Complex2f(1.0)
+    dr.enable_grad(a.imag) # Gradients on imaginary component
+    b = 2 * a
+    dr.forward_from(a)
+    assert dr.allclose(dr.grad(b), m.Complex2f(0, 2))
+
+
+def test80_backward_from_complex(m):
+    # Propagating from a Quaternion, propagates from all its components
+    a = m.Complex2f(1.0)
+    dr.enable_grad(a.imag) # Gradients on imaginary component
+    b = 2 * a
+    dr.backward_from(b)
+    assert dr.allclose(dr.grad(a), m.Complex2f(0, 2))


### PR DESCRIPTION
This PR fixes `dr.backward_from` and `dr.formward_from` when used on special types (`IsSpecial == True`).

The current behavior of these functions is to set the gradients to 1 and then propagate them. This first step is complex for certain types, as a gradient of one should be set to all components of the type. This is currently not the case, this PR applies the necessary changes.

Note: This change is specific to `backward_from` and `forward_from`. It seems tempting to fix this in `set_grad` but this could lead to misleading behaviors. For example, let's consider the case of setting the gradient of a quaternion with a single scalar value. We would want to preserve the following equivalence: `dr.set_grad(quat, 1) := dr.set_grad(quat, mi.Quaternion4f(1))`. Neither sides of this equality is setting the gradient of the equation to 1 for all of its components which is not desired behavior for `backward_from`/`forward_from`.