### PR TITLE
Add scoped_set_flag cpp counterpart which already exists in Python

### DIFF
--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1327,6 +1327,27 @@ DRJIT_INNER_REDUCTION(mean)
 
 #undef DRJIT_INNER_REDUCTION
 
+
+// -------------------------------------------------------------------
+//! @{ \name Context manager for setting JIT flags
+// -------------------------------------------------------------------
+
+struct scoped_set_flag {
+    scoped_set_flag(JitFlag flag, bool value) : 
+        flag(flag),
+        orig_value(jit_flag(flag)) {
+
+        jit_set_flag(flag, value);
+    }
+
+    ~scoped_set_flag() {
+        jit_set_flag(flag, orig_value);
+    }
+
+    JitFlag flag;
+    bool orig_value;
+};
+
 //! @}
 // -----------------------------------------------------------------------
 

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1328,29 +1328,6 @@ DRJIT_INNER_REDUCTION(mean)
 #undef DRJIT_INNER_REDUCTION
 
 
-// -------------------------------------------------------------------
-//! @{ \name Context manager for setting JIT flags
-// -------------------------------------------------------------------
-
-struct scoped_set_flag {
-    scoped_set_flag(JitFlag flag, bool value) : 
-        flag(flag),
-        orig_value(jit_flag(flag)) {
-
-        jit_set_flag(flag, value);
-    }
-
-    ~scoped_set_flag() {
-        jit_set_flag(flag, orig_value);
-    }
-
-    JitFlag flag;
-    bool orig_value;
-};
-
-//! @}
-// -----------------------------------------------------------------------
-
 // -----------------------------------------------------------------------
 //! @{ \name JIT compilation and autodiff-related
 // -----------------------------------------------------------------------
@@ -1400,6 +1377,24 @@ DRJIT_INLINE void eval(const Ts&... values) {
             eval();
     }
 }
+
+/**
+ * \brief Helper to modify JIT flags within a given scope
+ */
+struct scoped_set_flag {
+    scoped_set_flag(JitFlag flag, bool value) :
+        flag(flag),
+        original_value(jit_flag(flag)) {
+        jit_set_flag(flag, value);
+    }
+
+    ~scoped_set_flag() {
+        jit_set_flag(flag, original_value);
+    }
+
+    JitFlag flag;
+    bool original_value;
+};
 
 DRJIT_INLINE void set_device(int32_t device) {
     jit_cuda_set_device(device);


### PR DESCRIPTION
In Python we could do something like

```
with dr.scoped_set_flag(dr.JitFlag.LoopRecord, False):
 ...
```
Adding an equivalent in cpp

```
{
   dr::scoped_set_flag scope(JitFlag::LoopRecord, false);
   ...
}
```