### PR TITLE
Tensor: fix constructor selection logic

### DIFF
--- a/src/python/tensor.h
+++ b/src/python/tensor.h
@@ -13,13 +13,13 @@ template <typename T> auto bind_tensor(py::module m) {
        .def(py::init([](py::object o) -> Tensor {
             std::string mod = py::cast<std::string>(o.get_type().attr("__module__"));
             const char *mod_s = mod.c_str();
+            bool is_drjit = strncmp(mod_s, "drjit", 5) || py::hasattr(o, "IsDrJit");
             if (strncmp(mod_s, "numpy", 5) == 0 ||
                 strncmp(mod_s, "torch", 5) == 0 ||
                 strncmp(mod_s, "jax.interpreters.xla", 20) == 0 ||
                 strncmp(mod_s, "jaxlib", 6) == 0 ||
                 strncmp(mod_s, "tensorflow", 10) == 0 ||
-                (strncmp(mod_s, "drjit", 5) != 0
-                 && py::hasattr(o, "__array_interface__"))) {
+                (!is_drjit && py::hasattr(o, "__array_interface__"))) {
                 o = tensor_init(py::type::of<Tensor>(), o);
                 return py::cast<Tensor>(o);
             } else {


### PR DESCRIPTION
Hi!

This is a small fix for the `Tensor` constructor selection logic.
Currently, the following could happen, which is very confusing:

```py
import mitsuba as mi

color = mi.Color3f(2.)
dr.enable_grad(color)

tensor = mi.TensorXf(color)
assert dr.grad_enabled(tensor)  # <-- fails
```

The issue is that `Tensor` should not be constructible from `Color3f` in the first place, but because the constructor selection logic does not realize that `Color3f` is a kind of DrJit Array, it falls back to the `__array_interface__` constructor.

I changed the logic to use the `IsDrJit` attribute, which is the criterion used by `dr.is_array_v()`.