### PR TITLE
Missing const modifier in block_sum functions

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -1529,7 +1529,7 @@ struct DiffArray : ArrayBase<value_t<Type_>, is_mask_v<Type_>, DiffArray<Type_>>
             drjit_raise("vcall_(): not supported in scalar mode!");
     }
 
-    DiffArray block_sum_(size_t block_size) {
+    DiffArray block_sum_(size_t block_size) const {
         if constexpr (is_jit_v<Type>) {
             if (m_index)
                 drjit_raise("block_sum_(): not supported for attached arrays!");

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -551,7 +551,7 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
         }
     }
 
-    Derived block_sum_(size_t block_size) {
+    Derived block_sum_(size_t block_size) const {
         size_t input_size  = size(),
                block_count = input_size / block_size;
 


### PR DESCRIPTION
This PR just adds the `const` modifier to the definitions of the function `block_sum` inside `jit.h` and `autodiff.h` that were missing previously.