### PR TITLE
Add missing mulhi_scalar()

### DIFF
--- a/include/drjit/array_utils.h
+++ b/include/drjit/array_utils.h
@@ -290,7 +290,7 @@ DRJIT_INLINE T mulhi_(T x, T y) {
         if constexpr (std::is_signed_v<T>) {
             int32_t x1 = (int32_t) (x >> 32);
             int32_t y1 = (int32_t) (y >> 32);
-            uint32_t x0y0_hi = mulhi_scalar(x0, y0);
+            uint32_t x0y0_hi = mulhi_(x0, y0);
             int64_t t = x1 * (int64_t) y0 + x0y0_hi;
             int64_t w1 = x0 * (int64_t) y1 + (t & mask);
 


### PR DESCRIPTION
This PR addresses #188 that `mulhi_scalar()` is missing when it's called within `array_utils.h`:

https://github.com/mitsuba-renderer/drjit/blob/c71ebb792c88abf2460e296e213cbcb8069388a8/include/drjit/array_utils.h#L293

which was previously defined in Enoki's [array_fallbacks.h](https://github.com/mitsuba-renderer/enoki/blob/2a18afa2402e0677887c8439fa3d6a270ea15726/include/enoki/array_fallbacks.h#l339-L383).