### PR TITLE
Fixes the conversion of Matrix43f and similar types to NumPy

### DIFF
--- a/drjit/generic.py
+++ b/drjit/generic.py
@@ -1559,10 +1559,10 @@ def export_(a, migrate_to_host, version, owner_supported=True):
             temp *= shape[i]
 
         if a.IsMatrix:
-            if len(shape) == 4 and shape[1] == shape[2] and shape[2] == shape[3]:
-                strides[-3:] = strides[-3:][::-1]
-            else:
-                strides[-2:] = strides[-2:][::-1]
+            temp = a.Type.Size
+            for i in range(1, ndim):
+                strides[i] = temp
+                temp *= shape[i]
 
         # JIT array -- requires extra transformations
         b = _dr.ravel(_dr.detach(a) if a.IsDiff else a)


### PR DESCRIPTION
There is a small bug when converting Matrix43f (e.g., an RGB Mueller matrix) to NumPy.

In the current master, such a conversion doesn't quite work. Printing an identity matrix produces the following output:

```
>>> import drjit as dr
>>> import numpy as np
>>> print(np.array(dr.llvm.ad.Matrix43f(1.0)))
[[[[1. 0. 0. 0.]
   [1. 0. 0. 0.]
   [1. 0. 0. 0.]
   [0. 0. 0. 1.]]

  [[1. 0. 0. 0.]
   [1. 0. 0. 0.]
   [0. 0. 0. 1.]
   [0. 0. 0. 1.]]

  [[1. 0. 0. 0.]
   [0. 0. 0. 1.]
   [0. 0. 0. 1.]
   [0. 0. 0. 1.]]]]
>>> 
```
But it should be 
```
[[[[1. 0. 0. 0.]
   [0. 1. 0. 0.]
   [0. 0. 1. 0.]
   [0. 0. 0. 1.]]

  [[1. 0. 0. 0.]
   [0. 1. 0. 0.]
   [0. 0. 1. 0.]
   [0. 0. 0. 1.]]

  [[1. 0. 0. 0.]
   [0. 1. 0. 0.]
   [0. 0. 1. 0.]
   [0. 0. 0. 1.]]]]
```

This commit fixes this by slightly generalizing the existing stride recomputation.