### PR TITLE
dr.trace: Avoid modifying the matrix entries

### DIFF
--- a/drjit/matrix.py
+++ b/drjit/matrix.py
@@ -250,8 +250,8 @@ def trace(a, /):
     '''
     if not _dr.is_matrix_v(a):
         raise Exception('Unsupported type!')
-    result = a[0, 0]
-    for i in range(1, a.Size):
+    result = _dr.zeros(type(a[0][0]), _dr.width(a))
+    for i in range(a.Size):
         result += a[i, i]
     return result
 


### PR DESCRIPTION
## Issue

When calling `dr.trace` on an array of matrices, the current implementation accumulates the diagonal entries into an array that is a *reference* to the first diagonal entry. As a consequence, the first entry of the matrix is modified after running this operation.

This issue concerns all vectorized variants.

This PR fixes this by accumulating the result in a new array.

## Reproducer
```python
import drjit as dr
M = dr.cuda.Matrix3f(1.)
print(M)
#[[[1.0, 0.0, 0.0],
#  [0.0, 1.0, 0.0],
#  [0.0, 0.0, 1.0]]]
t = dr.trace(M)
print(M)
#[[[3.0, 0.0, 0.0],
#  [0.0, 1.0, 0.0],
#  [0.0, 0.0, 1.0]]]


```