### PR TITLE
DLPack: Support handling of streams

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1218,6 +1218,10 @@ Array base class
     .. automethod:: __eq__
     .. automethod:: __dlpack__
     .. automethod:: __array__
+    .. automethod:: torch
+    .. automethod:: jax
+    .. automethod:: tf
+
 
 Computation graph analysis
 --------------------------

--- a/src/python/docstr.h
+++ b/src/python/docstr.h
@@ -2848,6 +2848,57 @@ In other case, e.g. for :py:class:`drjit.llvm.Float`,
 :py:class:`drjit.scalar.Array3f`, or :py:class:`drjit.scalar.ArrayXf`, the data
 is already contiguous and a zero-copy approach is used instead.)";
 
+static const char *doc_torch = R"(
+Returns a PyTorch tensor representing the data in this array.
+
+For :ref:`flat arrays <flat_arrays>` and :ref:`tensors <tensors>`, Dr.Jit 
+performs a *zero-copy* conversion, which means that the created tensor provides 
+a *view* of the same data that will reflect later modifications to the Dr.Jit 
+array. :ref:`Nested arrays <nested_arrays>` require a temporary copy to rearrange 
+data into a compatible form.
+
+.. warning::
+   This operation converts the numerical representation but does *not* embed the 
+   resulting tensor into the automatic differentiation graph of the other 
+   framework. This means that gradients won't correctly propagate through 
+   programs combining multiple frameworks. Take a look at the function 
+   :py:func:`drjit.wrap_ad` for further information on how to accomplish this.
+)";
+
+static const char *doc_jax = R"(
+Returns a JAX tensor representing the data in this array.
+
+For :ref:`flat arrays <flat_arrays>` and :ref:`tensors <tensors>`, Dr.Jit 
+performs a *zero-copy* conversion, which means that the created tensor provides 
+a *view* of the same data that will reflect later modifications to the Dr.Jit 
+array. :ref:`Nested arrays <nested_arrays>` require a temporary copy to rearrange 
+data into a compatible form.
+
+.. warning::
+   This operation converts the numerical representation but does *not* embed the 
+   resulting tensor into the automatic differentiation graph of the other 
+   framework. This means that gradients won't correctly propagate through 
+   programs combining multiple frameworks. Take a look at the function 
+   :py:func:`drjit.wrap_ad` for further information on how to accomplish this.
+)";
+
+static const char *doc_tf = R"(
+Returns a TensorFlow tensor representing the data in this array.
+
+For :ref:`flat arrays <flat_arrays>` and :ref:`tensors <tensors>`, Dr.Jit 
+performs a *zero-copy* conversion, which means that the created tensor provides 
+a *view* of the same data that will reflect later modifications to the Dr.Jit 
+array. :ref:`Nested arrays <nested_arrays>` require a temporary copy to rearrange 
+data into a compatible form.
+
+.. warning::
+   This operation converts the numerical representation but does *not* embed the 
+   resulting tensor into the automatic differentiation graph of the other 
+   framework. This means that gradients won't correctly propagate through 
+   programs combining multiple frameworks. Take a look at the function 
+   :py:func:`drjit.wrap_ad` for further information on how to accomplish this.
+)";
+
 static const char *doc_detach = R"(
 Transforms the input variable into its non-differentiable version (*detaches* it
 from the AD computational graph).


### PR DESCRIPTION
Motivated by #198 , extending the dlpack interface to support the stream argument. This can be specified by the consumer (PyTorch, JAX) to inform the producer (Dr.Jit) which stream will be used and requests the producer performs any necessary synchronization.

Within the context of CUDA, as specified by the [Python array API standard](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html), the stream integer value has a few special values (-1, 0, 1, 2) but otherwise corresponds to the associated CUstream handle. In the latter case, rather than using `jit_sync_thread`, a new operation `jit_cuda_sync_stream` has been added in drjit-core that uses CUDA event synchronization to avoid blocking the CPU thread that would otherwise occur if we used sync_thread.

Some preliminary testing was performed in PyTorch by explicitly creating non-default streams.  i.e.

```python
s = torch.cuda.Stream()
with torch.cuda.stream(s):
   ...
```
just to primarily confirm that the new interface does indeed handle when a CUstream is provided
