### PR TITLE
upsample align_corners

### DIFF
--- a/drjit/tensor.py
+++ b/drjit/tensor.py
@@ -2,12 +2,13 @@ from typing import Type
 import drjit as _dr
 from collections.abc import Sequence as _Sequence
 
-def upsample(t, shape=None, scale_factor=None):
+def upsample(t, shape=None, scale_factor=None, align_corners=False):
     '''
-    upsample(source, shape=None, scale_factor=None)
+    upsample(source, shape=None, scale_factor=None, align_corners=False)
     Up-sample the input tensor or texture according to the provided shape.
 
-    Alternatively to specifying the target shape, a scale factor can be provided.
+    Alternatively to specifying the target shape, a scale factor can be
+    provided.
 
     The behavior of this function depends on the type of ``source``:
 
@@ -17,18 +18,25 @@ def upsample(t, shape=None, scale_factor=None):
 
     2. When ``source`` is a Dr.Jit texture type, the up-sampling will be
     performed according to the filter mode set on the input texture. Target
-    ``shape`` values are not required to be multiples of the source shape values.
-    When `scale_factor` is used, its values must be integers.
+    ``shape`` values are not required to be multiples of the source shape
+    values. When `scale_factor` is used, its values must be integers.
 
     Args:
         source (object): A Dr.Jit tensor or texture type.
 
         shape (list): The target shape (optional)
 
-        scale_factor (list): The scale factor to apply to the current shape (optional)
+        scale_factor (list): The scale factor to apply to the current shape
+        (optional)
+
+        align_corners (bool): If True, the corner pixels of the input and output
+        tensors are aligned, and thus preserving the values at the corner
+        pixels. This only has effect when ``source`` is a Dr.Jit texture type
+        performing linear interpolation. (default: False)
 
     Returns:
-        object: the up-sampled tensor or texture object. The type of the output will be the same as the type of the source.
+        object: the up-sampled tensor or texture object. The type of the output
+        will be the same as the type of the source.
     '''
     if  not getattr(t, 'IsTexture', False) and not _dr.is_tensor_v(t):
         raise TypeError("upsample(): unsupported input type, expected Dr.Jit "
@@ -90,17 +98,22 @@ def upsample(t, shape=None, scale_factor=None):
         if t.shape[dim] != shape[dim]:
             raise TypeError("upsample(): channel counts doesn't match input texture!")
 
-         # Create the query coordinates
+        # Create the query coordinates
         coords = list(_dr.meshgrid(*[
-                _dr.linspace(value_type, 0.0, 1.0, shape[i], endpoint=False)
+                _dr.linspace(value_type, 0.0, 1.0, shape[i], endpoint=align_corners)
                 for i in range(dim)
             ],
             indexing='ij'
         ))
 
         # Offset coordinates by half a voxel to hit the center of the new voxels
-        for i in range(dim):
-            coords[i] += 0.5 / shape[i]
+        if align_corners:
+            for i in range(dim):
+                coords[i] *= (1 - 1 / t.shape[i])
+                coords[i] += 0.5 / t.shape[i]
+        else:
+            for i in range(dim):
+                coords[i] += 0.5 / shape[i]
 
         # Reverse coordinates order according to dr.Texture convention
         coords.reverse()

--- a/tests/python/test_tensor.py
+++ b/tests/python/test_tensor.py
@@ -413,3 +413,11 @@ def test14_upsampling_texture(pkg):
     assert dr.allclose(b.tensor().array, [1.0, 1.0, 5.0, 1.5, 1.5, 5.5, 2.0, 2.0, 6.0,
                                           2.0, 2.0, 6.0, 2.5, 2.5, 6.5, 3.0, 3.0, 7.0,
                                           3.0, 3.0, 7.0, 3.5, 3.5, 7.5, 4.0, 4.0, 8.0])
+
+    a = tex_t(t([1, 2, 3, 4], shape=(2, 2, 1)), filter_mode=dr.FilterMode.Linear)
+    b = dr.upsample(a, shape=[5, 5], scale_factor=None, align_corners=True)
+    assert dr.allclose(b.tensor().array, [1.0, 1.25, 1.5, 1.75, 2.0,
+                                          1.5, 1.75, 2.0, 2.25, 2.5,
+                                          2.0, 2.25, 2.5, 2.75, 3.0,
+                                          2.5, 2.75, 3.0, 3.25, 3.5,
+                                          3.0, 3.25, 3.5, 3.75, 4.0])


### PR DESCRIPTION
Add the optional flag `align_corners` to upsample.
This is in line with [PyTorch upsample](https://pytorch.org/docs/stable/generated/torch.nn.Upsample.html).

To upsample the following 2D texture (bi-linear interp) to be 5x5
```
[[1 2]
 [3 4]]
```
With `align_corners = False` (default), the result is
```
[[1.        1.1000001 1.5       1.9000001 2.0000002]
 [1.2       1.3000001 1.7       2.1       2.2000003]
 [2.        2.1000001 2.5       2.9       3.       ]
 [2.8000002 2.9       3.3       3.6999998 3.8000002]
 [3.        3.1000004 3.5       3.9       3.9999998]]
```
With `align_corners = True`, the result is
```
[[1.   1.25 1.5  1.75 2.  ]
 [1.5  1.75 2.   2.25 2.5 ]
 [2.   2.25 2.5  2.75 3.  ]
 [2.5  2.75 3.   3.25 3.5 ]
 [3.   3.25 3.5  3.75 4.  ]]
```