### PR TITLE
Fix typo in dr.float_array_t trait

### DIFF
--- a/drjit/traits.py
+++ b/drjit/traits.py
@@ -546,7 +546,7 @@ def float_array_t(arg):
         type: Result of the conversion as described above.
     '''
     if not is_array_v(arg):
-        return int
+        return float
 
     size = arg.Type.Size
     if size == 2:


### PR DESCRIPTION
This patch fixes a small typo in the implementation of the `dr.float_array_t` trait.