### PR TITLE
Fixes to bindings, and build system

### DIFF
--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -432,7 +432,7 @@ and append the following binding declarations:
 
 .. code-block:: cpp
 
-    using FooPtr = dr::DiffPtr<JitBackend::CUDA, Foo *>;
+    using FooPtr = dr::CUDADiffArray<Foo *>;
 
     dr::ArrayBinding b;
     auto base_ptr = dr::bind_array_t<FooPtr>(b, m, "FooPtr")

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -442,8 +442,11 @@ template <typename T> NB_INLINE void bind_base(ArrayBinding &b) {
             bool success = value != Py_None && in.from_python(
                 value, (uint8_t) nb::detail::cast_flags::convert, &cleanup);
             if (success) {
-                using Out = std::conditional_t<std::is_pointer_v<Value>, Value, Value &>;
-                inst->set_entry(i, in.operator Out());
+                using Intrinsic = nb::detail::intrinsic_t<Value>;
+                using Out = std::conditional_t<std::is_pointer_v<Value>, Intrinsic*, Intrinsic &>;
+
+                Out out = in.operator Out();
+                inst->set_entry(i, (value_t<T>) out);
             }
             cleanup.release();
 

--- a/src/python/bind.cpp
+++ b/src/python/bind.cpp
@@ -185,7 +185,14 @@ nb::object bind(const ArrayBinding &b) {
 
     d.base_py = (PyTypeObject *) base_o.ptr();
 
-    // Create the type and update its supplemental information
+    // Type was already bound, let's create an alias
+    nb::handle existing = nb::detail::nb_type_lookup(b.array_type);
+    if (existing) {
+        nb::handle(d.scope).attr(name.c_str()) = existing;
+        return nb::borrow(existing);
+    }
+
+    // Create a new type and update its supplemental information
     nb::object tp = nb::steal(nb::detail::nb_type_new(&d));
     ArraySupplement &s = nb::type_supplement<ArraySupplement>(tp);
     s = b;


### PR DESCRIPTION
This PR introduces the following changes:
* Fixes such that `bind_array_t<const T*>` works (const qualifiers are lost in casts from nanobind)
* Handling of already bound types in `bind_array_t`
* ~~Project-relative copy paths for Python files in the CMake build~~ replaced by 554458219323cb6e06b60aff927c43393a2eddfc

~~It also updates `drjit-core` to point to: https://github.com/mitsuba-renderer/drjit-core/pull/81~~