### PR TITLE
Various fixes & improvements

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -157,6 +157,10 @@ def allclose(
 
         cond = abs(diff) <= abs(b) * rtol_c + atol_c
 
+        # plus/minus infinity
+        if is_float_v(a):
+            cond |= all(a == b, axis=None)
+
         if equal_nan:
             cond |= isnan(a) & isnan(b)
 
@@ -577,6 +581,36 @@ def diag(arg, /):
         return result
     else:
         raise Exception('drjit.diag(): unsupported type!')
+
+
+def identity(dtype, size=1):
+    '''
+    Return the identity array of the desired type and size
+
+    This function can create identity instances of various types. In
+    particular, ``dtype`` can be:
+
+    - A Dr.Jit matrix type (like :py:class:`drjit.cuda.Matrix4f`).
+
+    - A Dr.Jit complex type (like :py:class:`drjit.cuda.Quaternion4f`).
+
+    - Any other Dr.Jit array type. In this case this function is equivalent to ``full(dtype, 1, size)``
+
+    - A scalar Python type like ``int``, ``float``, or ``bool``. The ``size``
+      parameter is ignored in this case.
+
+    Args:
+        dtype (type): Desired Dr.Jit array type, Python scalar type, or
+          :ref:`custom data structure <custom-struct>`.
+
+        size (int): Size of the desired array | matrix
+
+    Returns:
+        object: The identity array of type ``dtype`` of size ``size``
+    '''
+    result = zeros(dtype, size)
+    result += dtype(1)
+    return result
 
 
 def trace(arg, /):

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -978,7 +978,7 @@ def copysign(arg0, arg1, /):
     Returns:
         float | int | drjit.ArrayBase: The values of ``arg0`` with the sign of ``arg1``
     '''
-    arg0_a = abs(a)
+    arg0_a = abs(arg0)
     return select(arg1 >= 0, arg0_a, -arg0_a)
 
 

--- a/drjit/ast.py
+++ b/drjit/ast.py
@@ -274,7 +274,7 @@ class _SyntaxVisitor(ast.NodeTransformer):
         self.op_stack.pop()
         return result
 
-    def visit_If(self, node: ast.If) -> ast.AST | tuple[ast.AST, ...]:
+    def visit_If(self, node: ast.If) -> Union[ast.AST, tuple[ast.AST, ...]]:
         (node, state_in, state_out, hints, is_scalar) = self.rewrite_and_track(node)
 
         if is_scalar:
@@ -736,7 +736,7 @@ def syntax(
     recursive: bool = False,
     print_ast: bool = False,
     print_code: bool = False,
-) -> T | Callable[[T2], T2]:
+) -> Union[T, Callable[[T2], T2]]:
     global _syntax_counter
 
     if f is None:

--- a/include/drjit/array_base.h
+++ b/include/drjit/array_base.h
@@ -249,7 +249,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct ArrayBaseT : 
             if constexpr (cond) {                                            \
                 size_t sa = derived().size();                                \
                                                                              \
-               Derived result;                                               \
+                Derived result;                                              \
                 if constexpr (Derived::Size == Dynamic)                      \
                     result = drjit::empty<Derived>(sa);                      \
                                                                              \

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -239,6 +239,9 @@ struct DRJIT_TRIVIAL_ABI DiffArray
     }
 
     template <typename T> DiffArray and_(const T &v) const {
+        if constexpr (is_mask_v<T> && !is_mask_v<DiffArray>)
+            return select(v, *this, zeros<DiffArray>(size()));
+
         if (grad_enabled_())
             jit_raise("DiffArray::and_(): not permitted on attached variables!");
         return steal(jit_var_and((uint32_t) m_index, (uint32_t) v.m_index));

--- a/include/drjit/util.h
+++ b/include/drjit/util.h
@@ -187,8 +187,8 @@ Index binary_search(scalar_t<Index> start_, scalar_t<Index> end_,
         if (iterations >= 2 && jit_flag(JitFlag::LoopRecord)) {
             Index1 index = zeros<Index1>(width(pred(start)));
 
-            tuple(start, end, index) = drjit::while_loop(
-                tuple(start, end, index),
+            drjit::tie(start, end, index) = drjit::while_loop(
+                drjit::make_tuple(start, end, index),
                 [iterations](const Index&, const Index&, const Index1& index) {
                     return index < iterations;
                 },
@@ -249,8 +249,8 @@ IndexN binary_search(typename std::enable_if_t<is_jit_v<Index1>, Index1> start_,
     if (jit_flag(JitFlag::Recording))
         jit_set_flag(JitFlag::LoopRecord, true);
 
-    tuple(start, end, index) = drjit::while_loop(
-        tuple(start, end, index),
+    drjit::tie(start, end, index) = drjit::while_loop(
+        drjit::make_tuple(start, end, index),
         [iterations](const IndexN&, const IndexN&, const Index1& index) {
             return index < iterations;
         },

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -892,6 +892,7 @@ nb::object reinterpret_array(nb::type_object_t<dr::ArrayBase> t, nb::handle_t<dr
             target_type = (VarType) mt.type;
 
     ms.type = mt.type;
+    ms.is_class = mt.is_class;
     if (ms != mt)
         nb::raise("drjit.reinterpret_array(): input and target type are incompatible.");
 

--- a/src/python/init.cpp
+++ b/src/python/init.cpp
@@ -48,9 +48,10 @@ int tp_init_array(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
             PyTypeObject *arg_tp = Py_TYPE(arg);
             bool try_sequence_import = true,
                  is_drjit_tensor = false;
+            bool arg_is_drjit = is_drjit_type(arg_tp);
 
             // Initialization from another Dr.Jit array
-            if (is_drjit_type(arg_tp)) {
+            if (arg_is_drjit) {
                 const ArraySupplement &s_arg = supp(arg_tp);
                 // Copy-constructor
                 if (arg_tp == self_tp) {
@@ -118,7 +119,7 @@ int tp_init_array(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
 
             // Try to construct from an instance created by another
             // array programming framework
-            if (is_drjit_tensor || nb::ndarray_check(arg)) {
+            if (is_drjit_tensor || (!arg_is_drjit && nb::ndarray_check(arg))) {
                 // Import flattened array in C-style ordering
                 nb::object flattened;
 
@@ -639,7 +640,7 @@ int tp_init_tensor(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
         nb::object args_2;
         if (!shape) {
             nb::object flat;
-            if (nb::ndarray_check(array)) {
+            if (!is_drjit_type(array_tp) && nb::ndarray_check(array)) {
                 // Try to construct from an instance created by another
                 // array programming framework
                 flat = import_ndarray(s, array, &shape_vec);

--- a/src/python/init.cpp
+++ b/src/python/init.cpp
@@ -65,7 +65,7 @@ int tp_init_array(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
                     // Potentially convert AD <-> non-AD arrays
                     ArrayMeta m_temp = s_arg;
                     m_temp.is_diff = m_self.is_diff;
-                    if (m_temp == m_self && m_self.ndim == 1) {
+                    if (m_temp == m_self && m_self.ndim == 1 && s_arg.index) {
                         uint32_t index = (uint32_t) s_arg.index(inst_ptr(arg));
                         s.init_index(index, inst_ptr(self));
                         nb::inst_mark_ready(self);

--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -269,6 +269,8 @@ ArrayMeta meta_get(nb::handle h) noexcept {
     } else if (h.is_none() || nb::type_check(tp)) {
         m.type = (uint8_t) VarType::UInt32;
         m.is_class = true;
+    } else if (PyNumber_Float(h.ptr())) {
+        m.type = (uint8_t) VarType::Float32;
     } else {
         m.is_valid = false;
     }

--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -303,9 +303,6 @@ ArrayMeta meta_get_general(nb::handle h) noexcept {
  * \brief Given a list of Dr.Jit arrays and scalars, determine the flavor and
  * shape of the result array and broadcast/convert everything into this form.
  *
- * \param op
- *    Name of the operation for error messages
- *
  * \param o
  *    Array of input operands of size 'n'
  *


### PR DESCRIPTION
Various changes:
- `allclose` handles inf comparisons
- added `dr.identity`
- handle reinterpreting pointer type as `UInt32`
- handle numpy (or otherwise) scalar arithmetic with JIT array
- `binary_search` fixed
- `copysign` fixed
- fix for initializations of scalar drjit arrays from other scalar drjit arrays
- allow `array & active` on `DiffArray` types
- minor formatting

These are small changes that have been stacking up from @rtabbara  and I. Would be good to get them in before it grows into an ever larger mix of independent fixes.