### PR TITLE
Fix dynamic dispatch calls which are fully masked

### DIFF
--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -272,7 +272,10 @@ typedef void (*ad_call_cleanup)(void*);
  *     Callback routine, which \c ad_call will invoke a number of times to
  *     record each callable. It is given the \c payload parameter, a \c self
  *     pointer (either a pointer to an instance in the instance registry, or a
- *     callable index encoded as <tt>void*</tt>)
+ *     callable index encoded as <tt>void*</tt>), the arguments \c args and a
+ *     vector of indices \rv it might fill with return values. The \c self
+ *     pointer can be set to \c nullptr, in which case the callback is still
+ *     expected to fill \rv with indices to variables of the correct type.
  *
  * \param cleanup
  *     A cleanup routine that deletes storage associated with \c payload.


### PR DESCRIPTION
This PR fixes evaluted dynamic dispatches which are fully masked. 

The return value (if there is one) of an evaluated dynamic dispatch which is fully masked is completely arbitrary in theory: it should never be used. In practice, JIT internals expect the return value to be properly initialized to something. The previous code would not initialize the return value, and would hence crash the user's script. This might seen like a corner case, but in reality it is extremely frequent when rendering in wavefront-mode with Mitsuba 3. 

In this PR, the return value is zero-initialized, such that it is consistent with a symbolic dispatch. 
Python `dr.dispatch` statements make use of https://github.com/mitsuba-renderer/drjit-core/pull/86 to trace an arbitrary instance. This is necessary to figure out the return value type.
Special care needs to be taken when calling a fully-masked target, even though it's return value won't be used it might still generate side-effects.
Tests were added to check the new behavior.