### PR TITLE
Allow inplace operations on masked arrays

### DIFF
--- a/src/python/slice.cpp
+++ b/src/python/slice.cpp
@@ -194,8 +194,9 @@ PyObject *mp_subscript(PyObject *self, PyObject *key) noexcept {
         bool key_is_array = is_drjit_type(key_tp);
 
         if (key_is_array && (VarType) supp(key_tp).type == VarType::Bool) {
-            Py_INCREF(self);
-            return self;
+            nb::object out = nb::inst_alloc(self_tp.ptr());
+            nb::inst_copy(out, self);
+            return out.release().ptr();
         }
 
         if (s.is_tensor) {

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -95,6 +95,9 @@ def test05_binop_inplace(t):
     assert a is c and dr.all(a == t(3, 5, 4))
     a += 1
     assert a is c and dr.all(a == t(4, 6, 5))
+    m = dr.mask_t(t)([False, True, False])
+    a[m] += b
+    assert a is c and dr.all(a == t(4, 9, 5))
     a = 1
     c = a
     a += b


### PR DESCRIPTION
This PR fixes Python's equivalent to `dr::masked(some_dr_value, mask) += expr`.

Previous code wouldn't properly handle any sort of inplace operation on the masked value. For example:
```
a = dr.cuda.Float([1, 2, 3])
mask = dr.cuda.Bool(False)

a[mask] *= dr.cuda.Float(3)
print(f"{a=}") # Prints [3, 6, 9]
```
(This doesn't only apply to fully-masked operations, but to partial masks too).

The slot `mp_ass_subscript` would correctly produce the underlying `select`. However the `select`'s values were both always the result of the inplace operation, at which point the mask in meaningless. This PR fixes this by returning a copy of the original value in `mp_subscript`.

I think this is only really valid/correct if the masked value is a left-hand side value of the operation. But I cannot think of a case where you'd want to use it on the right-hand side.