### PR TITLE
Fixes to vectorized calls

### DIFF
--- a/src/extra/call.cpp
+++ b/src/extra/call.cpp
@@ -386,6 +386,8 @@ static void ad_call_reduce(JitBackend backend, const char *domain,
     }
 
     index = JitVar::steal(jit_var_and(index_, mask_combined.index()));
+    if (index.size() == 1)
+        index.resize(size);
 
     jit_var_schedule(index.index());
     index64_vector args;

--- a/src/extra/common.h
+++ b/src/extra/common.h
@@ -74,11 +74,17 @@ struct scoped_record {
                   bool new_scope = false)
         : backend(backend) {
         checkpoint = jit_record_begin(backend, name);
+        flags = jit_flags();
+        jit_set_flags(flags |
+                      (uint32_t) JitFlag::SymbolicCalls |
+                      (uint32_t) JitFlag::SymbolicLoops |
+                      (uint32_t) JitFlag::SymbolicConditionals);
         if (new_scope)
             scope = jit_new_scope(backend);
     }
 
     ~scoped_record() {
+        jit_set_flags(flags);
         jit_record_end(backend, checkpoint, cleanup);
     }
 
@@ -90,7 +96,7 @@ struct scoped_record {
     void disarm() { cleanup = false; }
 
     JitBackend backend;
-    uint32_t checkpoint, scope;
+    uint32_t checkpoint, scope, flags;
     bool cleanup = true;
 };
 

--- a/src/extra/common.h
+++ b/src/extra/common.h
@@ -74,17 +74,11 @@ struct scoped_record {
                   bool new_scope = false)
         : backend(backend) {
         checkpoint = jit_record_begin(backend, name);
-        flags = jit_flags();
-        jit_set_flags(flags |
-                      (uint32_t) JitFlag::SymbolicCalls |
-                      (uint32_t) JitFlag::SymbolicLoops |
-                      (uint32_t) JitFlag::SymbolicConditionals);
         if (new_scope)
             scope = jit_new_scope(backend);
     }
 
     ~scoped_record() {
-        jit_set_flags(flags);
         jit_record_end(backend, checkpoint, cleanup);
     }
 
@@ -96,7 +90,7 @@ struct scoped_record {
     void disarm() { cleanup = false; }
 
     JitBackend backend;
-    uint32_t checkpoint, scope, flags;
+    uint32_t checkpoint, scope;
     bool cleanup = true;
 };
 

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -873,8 +873,19 @@ bool ad_loop(JitBackend backend, int symbolic, int compress,
     if (strchr(name, '\n') || strchr(name, '\r'))
         jit_raise("'name' may not contain newline characters.");
 
-    if (symbolic == -1)
-        symbolic = (int) jit_flag(JitFlag::SymbolicLoops);
+    if (symbolic == -1) {
+        if (jit_flag(JitFlag::SymbolicScope)) {
+            // We're inside some other symbolic operation, cannot use evaluated mode
+            if (!jit_flag(JitFlag::SymbolicLoops))
+                jit_log(LogLevel::Warn,
+                        "ad_loop(\"%s\"): currently inside some other symbolic "
+                        "operation, forcefully running the loop in symbolic "
+                        "mode even though the feature flag was disabled.", name);
+            symbolic = 1;
+        } else {
+            symbolic = jit_flag(JitFlag::SymbolicLoops);
+        }
+    }
 
     if (compress == -1)
         compress = (int) jit_flag(JitFlag::CompressLoops);

--- a/src/python/apply.h
+++ b/src/python/apply.h
@@ -96,7 +96,8 @@ extern void traverse(const char *op, TraverseCallback &callback,
 /// Parallel traversal of two compatible pytrees 'h1' and 'h2'
 extern void traverse_pair(const char *op, TraversePairCallback &callback,
                           nb::handle h1, nb::handle h2, const char *name,
-                          bool report_inconsistencies = true);
+                          bool report_inconsistencies = true,
+                          bool width_consistency = true);
 
 /// Transform an input pytree 'h' into an output pytree, potentially of a different type
 extern nb::object transform(const char *op, TransformCallback &callback, nb::handle h);

--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -265,7 +265,9 @@ static void enqueue_impl(dr::ADMode mode_, nb::handle h_) {
 
 static bool check_grad_enabled(const char *name, nb::handle h, uint32_t flags) {
     bool rv = grad_enabled(h);
-    if (!rv & !(flags & (uint32_t) dr::ADFlag::AllowNoGrad))
+    if (!rv &
+        !(flags & (uint32_t) dr::ADFlag::AllowNoGrad) &
+        jit_flag(JitFlag::SymbolicCalls)) {
         nb::raise(
             "%s(): the argument does not depend on the input variable(s) being "
             "differentiated. Raising an exception since this is usually "
@@ -274,6 +276,7 @@ static bool check_grad_enabled(const char *name, nb::handle h, uint32_t flags) {
             "drjit.ADFlag.AllowNoGrad flag to the function (e.g., by "
             "specifying flags=dr.ADFlag.Default | dr.ADFlag.AllowNoGrad).",
             name);
+    }
     return rv;
 }
 

--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -207,7 +207,7 @@ static void accum_grad(nb::handle target, nb::handle source) {
     if (!o.type().is(tp))
         o = tp(o);
 
-    traverse_pair("drjit.accum_grad", sg, target, o, "target", false);
+    traverse_pair("drjit.accum_grad", sg, target, o, "target", false, false);
 }
 
 static nb::object replace_grad(nb::handle h0, nb::handle h1) {

--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -26,7 +26,7 @@
  * This function exists for Dr.Jit-internal use. You probably should not call
  * it in your own application code.
  *
- * (Note: this explanation is also part of src/python/docstr.h -- please keep
+ * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
  */
 nb::object copy(nb::handle h) {
@@ -99,7 +99,7 @@ bool can_scatter_reduce(nb::type_object_t<dr::ArrayBase> tp, ReduceOp op) {
  * This function exists for Dr.Jit-internal use. You probably should not
  * call it in your own application code.
  *
- * (Note: this explanation is also part of src/python/docstr.h -- please keep
+ * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
 */
 void collect_indices(nb::handle h, dr::vector<uint64_t> &indices, bool inc_ref) {
@@ -147,7 +147,7 @@ void collect_indices(nb::handle h, dr::vector<uint64_t> &indices, bool inc_ref) 
  * This function exists for Dr.Jit-internal use. You probably should not call
  * it in your own application code.
  *
- * (Note: this explanation is also part of src/python/docstr.h -- please keep
+ * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
  */
 nb::object update_indices(nb::handle h, const dr::vector<uint64_t> &indices) {
@@ -194,7 +194,7 @@ nb::object update_indices(nb::handle h, const dr::vector<uint64_t> &indices) {
  * function internally to release references held by a temporary copy of the
  * state tuple.
  *
- * (Note: this explanation is also part of src/python/docstr.h -- please keep
+ * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
  */
 nb::object reset(nb::handle h) {
@@ -213,15 +213,19 @@ nb::object reset(nb::handle h) {
  * Raises an exception is a mismatch is found (e.g., different types, arrays with
  * incompatible numbers of elements, dictionaries with different keys, etc.)
  *
- * (Note: this explanation is also part of src/python/docstr.h -- please keep
+ * When the ``width_consistency`` argument is enabled, an exception will also be
+ * raised if there is a mismatch of the vectorization widths of any Dr.Jit type
+ * in the pytrees.
+ *
+ * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
  */
-void check_compatibility(nb::handle h1, nb::handle h2, const char *name) {
+void check_compatibility(nb::handle h1, nb::handle h2, bool width_consistency, const char *name) {
     struct CheckCompatibility : TraversePairCallback {
         void operator()(nb::handle, nb::handle) override {
         }
     } cc;
-    traverse_pair("drjit.detail.check_compatibility", cc, h1, h2, name, true);
+    traverse_pair("drjit.detail.check_compatibility", cc, h1, h2, name, true, width_consistency);
 }
 
 static nb::handle trace_func_handle;

--- a/src/python/detail.h
+++ b/src/python/detail.h
@@ -26,7 +26,7 @@ extern nb::object copy(nb::handle h);
 extern void collect_indices(nb::handle, dr::vector<uint64_t> &,
                             bool inc_ref = false);
 extern nb::object update_indices(nb::handle, const dr::vector<uint64_t> &);
-extern void check_compatibility(nb::handle, nb::handle, const char *name);
+extern void check_compatibility(nb::handle, nb::handle, bool, const char *);
 extern void stash_ref(nb::handle h, dr::vector<StashRef> &);
 
 extern nb::object reset(nb::handle h);

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -5252,6 +5252,10 @@
     Raises an exception is a mismatch is found (e.g., different types, arrays with
     incompatible numbers of elements, dictionaries with different keys, etc.)
 
+    When the ``width_consistency`` argument is enabled, an exception will also be
+    raised if there is a mismatch of the vectorization widths of any Dr.Jit type
+    in the pytrees.
+
 .. topic:: detail_collect_indices
 
     Return Dr.Jit variable indices associated with the provided data structure.

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -3584,8 +3584,9 @@
     refer to the documentation of :py:func:`drjit.enqueue()` and the meaning of
     the ``flags`` parameter.
 
-    The implementation raises an exception when the provided array does not support
-    gradient tracking, or when gradient tracking was not previously enabled via
+    When :py:attr:`drjit.JitFlag.SymbolicCalls` is set, the implementation
+    raises an exception when the provided array does not support gradient
+    tracking, or when gradient tracking was not previously enabled via
     :py:func:`drjit.enable_grad()`, as this generally indicates the presence of
     a bug. Specify the :py:attr:`drjit.ADFlag.AllowNoGrad` flag (e.g. by
     passing ``flags=dr.ADFlag.Default | dr.ADFlag.AllowNoGrad``) to the function.
@@ -3625,8 +3626,9 @@
     refer to the documentation of :py:func:`drjit.enqueue()` and the meaning of
     the ``flags`` parameter.
 
-    The implementation raises an exception when the provided array does not support
-    gradient tracking, or when gradient tracking was not previously enabled via
+    When :py:attr:`drjit.JitFlag.SymbolicCalls` is set, the implementation
+    raises an exception when the provided array does not support gradient
+    tracking, or when gradient tracking was not previously enabled via
     :py:func:`drjit.enable_grad()`, as this generally indicates the presence of
     a bug. Specify the :py:attr:`drjit.ADFlag.AllowNoGrad` flag (e.g. by
     passing ``flags=dr.ADFlag.Default | dr.ADFlag.AllowNoGrad``) to the function.
@@ -3682,8 +3684,9 @@
     refer to the documentation of :py:func:`drjit.enqueue()` and the meaning of
     the ``flags`` parameter.
 
-    The implementation raises an exception when the provided array does not support
-    gradient tracking, or when gradient tracking was not previously enabled via
+    When :py:attr:`drjit.JitFlag.SymbolicCalls` is set, the implementation
+    raises an exception when the provided array does not support gradient
+    tracking, or when gradient tracking was not previously enabled via
     :py:func:`drjit.enable_grad()`, as this generally indicates the presence of
     a bug. Specify the :py:attr:`drjit.ADFlag.AllowNoGrad` flag (e.g. by
     passing ``flags=dr.ADFlag.Default | dr.ADFlag.AllowNoGrad``) to the function.
@@ -3723,8 +3726,9 @@
     refer to the documentation of :py:func:`drjit.enqueue()` and the meaning of
     the ``flags`` parameter.
 
-    The implementation raises an exception when the provided array does not support
-    gradient tracking, or when gradient tracking was not previously enabled via
+    When :py:attr:`drjit.JitFlag.SymbolicCalls` is set, the implementation
+    raises an exception when the provided array does not support gradient
+    tracking, or when gradient tracking was not previously enabled via
     :py:func:`drjit.enable_grad()`, as this generally indicates the presence of
     a bug. Specify the :py:attr:`drjit.ADFlag.AllowNoGrad` flag (e.g. by
     passing ``flags=dr.ADFlag.Default | dr.ADFlag.AllowNoGrad``) to the function.

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -1011,7 +1011,7 @@ void export_memop(nb::module_ &m) {
              char order) { return unravel(dtype, array, order); },
           "dtype"_a, "array"_a, "order"_a = 'A', doc_unravel,
           nb::sig("def unravel(dtype: type[ArrayT], array: AnyArray, order: Literal['A', 'C', 'F'] = 'A') -> ArrayT"))
-     .def("slice", &slice, "value"_a, "index"_a, doc_slice)
+     .def("slice", &slice, "value"_a, "index"_a = 0, doc_slice)
      .def("reshape", &reshape, "dtype"_a, "value"_a,
           "shape"_a, "order"_a = 'A', "shrink"_a = false, doc_reshape)
      .def("reshape", &reshape_2, "dtype"_a, "value"_a,

--- a/src/python/switch.cpp
+++ b/src/python/switch.cpp
@@ -160,6 +160,11 @@ nb::object switch_impl(nb::handle index_, nb::sequence targets,
         dr::detail::index64_vector rv_i;
         ::collect_indices(state->args_o, args_i);
 
+        if (mask.is_valid() && mask.type().is(&PyBool_Type)) {
+            nb::type_object mask_tp = nb::borrow<nb::type_object>(s.mask);
+            mask = mask_tp(mask);
+        }
+
         bool done = ad_call(
             (JitBackend) s.backend, nullptr, symbolic, nb::len(targets),
             label.c_str(), false, (uint32_t) s.index(inst_ptr(index)),
@@ -261,6 +266,11 @@ nb::object dispatch_impl(nb::handle_t<dr::ArrayBase> inst,
         vector<uint64_t> args_i;
         dr::detail::index64_vector rv_i;
         ::collect_indices(state->args_o, args_i);
+
+        if (mask.is_valid() && mask.type().is(&PyBool_Type)) {
+            nb::type_object mask_tp = nb::borrow<nb::type_object>(s.mask);
+            mask = mask_tp(mask);
+        }
 
         bool done = ad_call(
             (JitBackend) s.backend, state->domain_name.c_str(), symbolic, 0,

--- a/src/python/switch.cpp
+++ b/src/python/switch.cpp
@@ -140,7 +140,7 @@ nb::object switch_impl(nb::handle index_, nb::sequence targets,
                 state.targets_o[index](*state.args_o[0], **state.args_o[1]);
 
             if (state.rv_o.is_valid())
-                check_compatibility(result, state.rv_o, "result");
+                check_compatibility(result, state.rv_o, false, "result");
 
             state.rv_o = std::move(result);
             ::collect_indices(state.rv_o, rv_i);
@@ -236,7 +236,7 @@ nb::object dispatch_impl(nb::handle_t<dr::ArrayBase> inst,
                 state.target_o(self_o, *state.args_o[0], **state.args_o[1]);
 
             if (state.rv_o.is_valid())
-                check_compatibility(result, state.rv_o, "result");
+                check_compatibility(result, state.rv_o, false, "result");
 
             state.rv_o = std::move(result);
             ::collect_indices(state.rv_o, rv_i);

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -591,3 +591,29 @@ def test17_switch_uneven_buckets(t, symbolic):
         # Masked case, as keyword argument
         result = dr.switch(index, c, x, active=m)
         assert dr.allclose(result, [1, 0, 0, 40, 50, 60])
+
+
+@pytest.mark.parametrize("symbolic", [True, False])
+@pytest.test_arrays('int32,-uint32,shape=(*),jit')
+def test15_switch_scalar_mask(t, symbolic):
+    with dr.scoped_set_flag(dr.JitFlag.SymbolicCalls, symbolic):
+        Int = t
+        UInt32 = dr.uint32_array_t(Int)
+
+        c = [
+            lambda x, active: x,
+            lambda x, active: x * 10
+        ]
+
+        index = UInt32(0, 0, 1, 1, 1)
+        x = Int(1, 2, 3, 4, 5)
+
+        m = True # Use a scalar mask
+
+        # Masked case
+        result = dr.switch(index, c, x, m)
+        assert dr.allclose(result, [1, 2, 30, 40, 50])
+
+        # Masked case, as keyword argument
+        result = dr.switch(index, c, x, active=m)
+        assert dr.allclose(result, [1, 2, 30, 40, 50])

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -51,18 +51,17 @@ def test02_mutate(t, mode):
 
 @pytest.test_arrays('uint32,is_jit,shape=(*)')
 @dr.syntax
-def test03_nested_loop_disallowed_config(t):
+def test03_nested_loop_warn_config(t, capsys):
     # Can't record an evaluated loop within a symbolic recording session
-    with pytest.raises(RuntimeError) as e:
-        i, j = t(5), t(5)
-        while i < 10:
-            i += 1
-            with dr.scoped_set_flag(dr.JitFlag.SymbolicLoops, False):
-                while j < 10:
-                    j += 1
+    i, j = t(5), t(5)
+    while i < 10:
+        i += 1
+        with dr.scoped_set_flag(dr.JitFlag.SymbolicLoops, False):
+            while j < 10:
+                j += 1
 
-    err_msg='Dr.Jit is currently recording symbolic computation and cannot execute'
-    assert err_msg in str(e.value.__cause__)
+    transcript = capsys.readouterr().err
+    assert transcript.count('currently inside some other symbolic operation') == 1
 
 
 @pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])


### PR DESCRIPTION
This PR fixes various issues in vectorized calls (and some minor orther stuff).

Minor fixes unrelated to calls in:
* 88567877bb7517daa15d83ff463bb341f39e3c7a
* 72741701937ecc81bcad2026a86cba83b9bbb7d4
* ead64a42fa8ed51ed2acfc3070e69bfe2d79480b

Everything else is somehow related to vectorized calls, either only in symbolic mode, or evaluated mode, or for getters or even for`dr.dispatch`/`dr.switch`. It might be easier review this PR by looking at the individual commits as they all are independent fixes. 

Relies on a fix contained in https://github.com/mitsuba-renderer/drjit-core/pull/88