### PR TITLE
Backport of commits & various new fixes/features

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        python: [cp38, cp39, cp310, cp311]
+        python: [cp38, cp39, cp310, cp311, cp312]
         cibw-arch: [x86_64, arm64]
         exclude:
           - os: ubuntu-20.04
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.11.2
+          python -m pip install cibuildwheel==2.16.2
 
       - name: Local build for macOS cross-compilation
         if: runner.os == 'macOS' && matrix.cibw-arch == 'arm64'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-13]
         python: [cp38, cp39, cp310, cp311, cp312]
         cibw-arch: [x86_64, arm64]
         exclude:
@@ -34,7 +34,7 @@ jobs:
 
     name: >
       ${{ matrix.python }} wheel for ${{ matrix.os }}
-      ${{ (matrix.os == 'macos-latest' && format('({0})', matrix.cibw-arch)) || '' }}
+      ${{ (matrix.os == 'macos-13' && format('({0})', matrix.cibw-arch)) || '' }}
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: Wandalen/wretry.action@v1.0.36
+      - uses: Wandalen/wretry.action@v1.2.0
         with:
           action: actions/checkout@v3
           with: |

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -260,7 +260,13 @@ Operations for vectors and matrices
 .. autofunction:: normalize
 .. autofunction:: lerp
 .. autofunction:: sh_eval
-
+.. autofunction:: frob
+.. autofunction:: rotate
+.. autofunction:: polar_decomp
+.. autofunction:: matrix_to_quat
+.. autofunction:: quat_to_matrix
+.. autofunction:: transform_decompose
+.. autofunction:: transform_compose
 
 Operations for complex values and quaternions
 ---------------------------------------------
@@ -269,6 +275,8 @@ Operations for complex values and quaternions
 .. autofunction:: arg
 .. autofunction:: real
 .. autofunction:: imag
+.. autofunction:: quat_to_euler
+.. autofunction:: euler_to_quat
 
 Transcendental functions
 ------------------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -116,6 +116,7 @@ Miscellaneous operations
 .. autofunction:: width
 .. autofunction:: slice_index
 .. autofunction:: meshgrid
+.. autofunction:: binary_search
 .. autofunction:: make_opaque
 .. autofunction:: copy
 

--- a/docs/textures.rst
+++ b/docs/textures.rst
@@ -50,6 +50,12 @@ are specified during initialization
 Moreover the :py:func:`eval_cubic()` function provides an independent interface 
 for sampling a texture using a clamped cubic B-Spline interpolant.
 
+.. note::
+
+    When evaluating a texture, the numerical precision used during the
+    interpolation is dictated by the floating point precision of the query
+    point.
+
 Hardware acceleration
 ---------------------
 

--- a/include/drjit/array_utils.h
+++ b/include/drjit/array_utils.h
@@ -303,7 +303,7 @@ DRJIT_INLINE T mulhi_(T x, T y) {
         if constexpr (std::is_signed_v<T>) {
             int32_t x1 = (int32_t) (x >> 32);
             int32_t y1 = (int32_t) (y >> 32);
-            uint32_t x0y0_hi = mulhi_scalar(x0, y0);
+            uint32_t x0y0_hi = mulhi_(x0, y0);
             int64_t t = x1 * (int64_t) y0 + x0y0_hi;
             int64_t w1 = x0 * (int64_t) y1 + (t & mask);
 

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -504,8 +504,8 @@ struct DRJIT_TRIVIAL_ABI DiffArray
     template <size_t N, typename Index, typename Mask>
     static Array<DiffArray, N> gather_packet_(const DiffArray &src, const Index &index,
                                               const Mask &mask, ReduceMode mode) {
-        if constexpr (N & (N-1)) {
-            return Base::gather_packet_<N>(src, index, mask, mode);
+        if constexpr ((N & (N-1)) > 0) {
+            return Base::template gather_packet_<N>(src, index, mask, mode);
         } else {
             static_assert(
                 std::is_same_v<detached_t<Mask>, detached_t<mask_t<DiffArray>>>);
@@ -546,7 +546,7 @@ struct DRJIT_TRIVIAL_ABI DiffArray
                                 ReduceMode mode) {
         static_assert(
             std::is_same_v<detached_t<Mask>, detached_t<mask_t<DiffArray>>>);
-        if constexpr (N & (N-1)) {
+        if constexpr ((N & (N-1)) > 0) {
             Base::template scatter_packet_<N>(dst, source, index, mask, mode);
         } else if constexpr (IsFloat) {
             uint64_t indices[N];
@@ -587,7 +587,7 @@ struct DRJIT_TRIVIAL_ABI DiffArray
                                        ReduceOp op, ReduceMode mode) {
         static_assert(
             std::is_same_v<detached_t<Mask>, detached_t<mask_t<DiffArray>>>);
-        if constexpr (N & (N-1)) {
+        if constexpr ((N & (N-1)) > 0) {
             Base::template scatter_reduce_packet_<N>(dst, source, index, mask, op, mode);
         } else if constexpr (IsFloat) {
             uint64_t indices[N];

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -638,12 +638,12 @@ struct DRJIT_TRIVIAL_ABI DiffArray
         return steal(Detached::zero_(size).release());
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     static DiffArray full_(T value, size_t size) {
         return steal(Detached::full_(value, size).release());
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     static DiffArray opaque_(T value, size_t size) {
         return steal(Detached::opaque_(value, size).release());
     }
@@ -652,7 +652,7 @@ struct DRJIT_TRIVIAL_ABI DiffArray
         return steal(Detached::arange_(start, stop, step).release());
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     static DiffArray linspace_(T min, T max, size_t size, bool endpoint) {
         return steal(Detached::linspace_(min, max, size, endpoint).release());
     }
@@ -776,7 +776,7 @@ struct DRJIT_TRIVIAL_ABI DiffArray
         return rv;
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     void set_entry(size_t offset, T value) {
         if (grad_enabled_())
             jit_raise("DiffArray::set_entry(): not permitted on attached variables!");

--- a/include/drjit/call.h
+++ b/include/drjit/call.h
@@ -163,7 +163,10 @@ Ret call(const Self &self, const char *domain, const char *name,
 
     if constexpr (!std::is_same_v<Ret, void>) {
         Ret2 result(std::move(state->rv));
-        update_indices(result, rv_i);
+        if (!rv_i.empty())
+            update_indices(result, rv_i);
+        else
+            result = zeros<Ret2>();
 
         if (done)
             CallStateT::cleanup(state);

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -368,7 +368,7 @@ struct DRJIT_TRIVIAL_ABI JitArray
         return steal(jit_var_literal(Backend, Type, &value, size));
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     static JitArray full_(T value, size_t size) {
         ActualValue av;
         if constexpr (!IsClass)
@@ -379,7 +379,7 @@ struct DRJIT_TRIVIAL_ABI JitArray
         return steal(jit_var_literal(Backend, Type, &av, size, false));
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     static JitArray opaque_(T value, size_t size) {
         ActualValue av;
         if constexpr (!IsClass)
@@ -399,7 +399,7 @@ struct DRJIT_TRIVIAL_ABI JitArray
                      JitArray((Value) start));
     }
 
-    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>
+    template <typename T, enable_if_t<!std::is_void_v<T> && std::is_convertible_v<T, Value>> = 0>
     static JitArray linspace_(T min, T max, size_t size, bool endpoint) {
         T step = (max - min) / T(size - ((endpoint && size > 1) ? 1 : 0));
         return fmadd(JitArray(uint32_array_t<JitArray>::counter(size)),

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -458,14 +458,14 @@ struct DRJIT_TRIVIAL_ABI JitArray
 
     template <size_t N, typename Index, typename Mask>
     static Array<JitArray, N> gather_packet_(const JitArray &src, const Index &index,
-                                             const Mask &mask, ReduceMode /* mode */) {
-        if constexpr (N & (N-1)) {
-            return Base::gather_packet_(src, index, mask);
+                                             const Mask &mask, ReduceMode mode) {
+        if constexpr ((N & (N-1)) > 0) {
+            return Base::template gather_packet_<N>(src, index, mask, mode);
         } else {
             static_assert(
                 std::is_same_v<detached_t<Mask>, detached_t<mask_t<JitArray>>>);
             uint32_t tmp[N];
-            jit_var_gather_packet(src.index(), index.index(), mask.index(), tmp);
+            jit_var_gather_packet(N, src.index(), index.index(), mask.index(), tmp);
 
             Array<JitArray, N> result;
             for (size_t i = 0; i < N; ++i)
@@ -488,7 +488,7 @@ struct DRJIT_TRIVIAL_ABI JitArray
                                 ReduceMode mode) {
         static_assert(
             std::is_same_v<detached_t<Mask>, detached_t<mask_t<JitArray>>>);
-        if constexpr (N & (N-1)) {
+        if constexpr ((N & (N-1)) > 0) {
             Base::template scatter_packet_<N>(dst, source, index, mask, mode);
         } else {
             uint32_t indices[N];
@@ -516,7 +516,7 @@ struct DRJIT_TRIVIAL_ABI JitArray
                                        ReduceOp op, ReduceMode mode) {
         static_assert(
             std::is_same_v<detached_t<Mask>, detached_t<mask_t<JitArray>>>);
-        if constexpr (N & (N-1)) {
+        if constexpr ((N & (N-1)) > 0) {
             Base::template scatter_reduce_packet_<N>(dst, source, index, mask, op, mode);
         } else {
             uint32_t indices[N];

--- a/include/drjit/math.h
+++ b/include/drjit/math.h
@@ -1491,10 +1491,9 @@ template <typename Value, bool Native> Value cbrt(const Value &x) {
         if constexpr (!Single)
             r -= (r - (x / square(r))) * third;
 
-        return select(isfinite(x), r, x);
+        return select(isfinite(x) && (x != 0), r, x);
     }
 }
-
 template <typename Value, bool Native> Value erf(const Value &x) {
     if constexpr (is_detected_v<detail::has_erf, Value> && Native) {
         return x.erf_();

--- a/include/drjit/math.h
+++ b/include/drjit/math.h
@@ -1008,12 +1008,14 @@ namespace detail {
 template <typename X, typename Y> expr_t<X, Y> pow(const X &x, const Y &y) {
     static_assert(!is_special_v<X> && !is_special_v<Y>,
                   "pow(): requires a regular scalar/array argument!");
-    if constexpr ((is_dynamic_v<X> && drjit::detail::is_scalar_v<Y>) || std::is_integral_v<expr_t<X, Y>>) {
+    if constexpr (drjit::detail::is_scalar_v<Y> || std::is_integral_v<expr_t<X, Y>>) {
         if constexpr (drjit::is_floating_point_v<Y>) {
             if (detail::round_(y) == y)
                 return detail::powi(x, (int) y);
-            else
+            else if constexpr (is_dynamic_v<X>)
                 return pow(x, X(y));
+            else
+                return exp2(log2(x) * y);
         } else {
             return detail::powi(x, (int) y);
         }

--- a/include/drjit/packet_intrin.h
+++ b/include/drjit/packet_intrin.h
@@ -227,6 +227,7 @@ DRJIT_INLINE long long mm_extract_epi64(__m128i m)  {
 #if defined(DRJIT_X86_AVX2)
 template <typename T> DRJIT_INLINE T tzcnt(T v) {
     static_assert(std::is_integral_v<T>, "tzcnt(): requires an integer argument!");
+#if defined(DRJIT_X86_BMI)  // Check for BMI support for _tzcnt_u32/u64
     if (sizeof(T) <= 4) {
         return (T) _tzcnt_u32((unsigned int) v);
     } else {
@@ -239,6 +240,16 @@ template <typename T> DRJIT_INLINE T tzcnt(T v) {
         return (T) (lo != 0 ? _tzcnt_u32(lo) : (_tzcnt_u32(hi) + 32));
 #endif
     }
+#elif defined(__GNUC__) || defined(__clang__)  // GCC and Clang fallback
+    if (sizeof(T) <= 4) {
+        return (T) __builtin_ctz(v);
+    } else {
+        return (T) __builtin_ctzll(v);
+    }
+#else
+    // Some other generic fallback for other compilers or a static assertion for unsupported compilers
+    static_assert(false, "tzcnt() is not supported on this platform/compiler");
+#endif
 }
 #endif
 

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -963,6 +963,27 @@ template <typename T, size_t Size> void bind_matrix_types(ArrayBinding &b) {
     bind_array<Matrix<float64_array_t<T>, Size>>(b);
 }
 
+template <typename T, size_t VecSize, size_t Size>
+void bind_matrix_vec_types(ArrayBinding &b) {
+    using VecF16 = Array<float16_array_t<T>, VecSize>;
+    using VecF32 = Array<float32_array_t<T>, VecSize>;
+    using VecF64 = Array<float64_array_t<T>, VecSize>;
+    using VecMask = mask_t<VecF32>;
+
+    bind_array<mask_t<Array<VecMask, Size>>>(b);
+    bind_array<Array<VecF16, Size>>(b);
+    bind_array<Array<VecF32, Size>>(b);
+    bind_array<Array<VecF64, Size>>(b);
+
+    bind_array<mask_t<Array<Array<VecMask, Size>, Size>>>(b);
+    bind_array<Array<Array<VecF16, Size>,Size>>(b);
+    bind_array<Array<Array<VecF32, Size>,Size>>(b);
+    bind_array<Array<Array<VecF64, Size>,Size>>(b);
+    bind_array<Matrix<VecF16, Size>>(b);
+    bind_array<Matrix<VecF32, Size>>(b);
+    bind_array<Matrix<VecF64, Size>>(b);
+}
+
 /// Run bind_array() for arrays, matrices, quaternions, complex numbers, and tensors
 template <typename T> void bind_all(ArrayBinding &b) {
     if constexpr (!drjit::detail::is_scalar_v<T>)
@@ -978,6 +999,11 @@ template <typename T> void bind_all(ArrayBinding &b) {
     bind_matrix_types<T, 2>(b);
     bind_matrix_types<T, 3>(b);
     bind_matrix_types<T, 4>(b);
+
+    bind_matrix_vec_types<T, 1, 4>(b);
+    bind_matrix_vec_types<T, 3, 4>(b);
+    bind_matrix_vec_types<T, 4, 3>(b);
+    bind_matrix_vec_types<T, 4, 4>(b);
 
     bind_array<Complex<float32_array_t<T>>>(b);
     bind_array<Complex<float64_array_t<T>>>(b);

--- a/src/extra/call.cpp
+++ b/src/extra/call.cpp
@@ -277,6 +277,11 @@ static void ad_call_symbolic(JitBackend backend, const char *domain,
 
     {
         scoped_record guard_1(backend, name, true);
+
+        // Recording may fail due to recursion depth
+        if (!guard_1.is_valid())
+            return;
+
         scoped_isolation_boundary guard_2;
 
         // Wrap input arguments to clearly expose them as inputs of the vcall

--- a/src/extra/common.h
+++ b/src/extra/common.h
@@ -79,7 +79,8 @@ struct scoped_record {
     }
 
     ~scoped_record() {
-        jit_record_end(backend, checkpoint, cleanup);
+        if (is_valid())
+            jit_record_end(backend, checkpoint, cleanup);
     }
 
     uint32_t checkpoint_and_rewind() {
@@ -88,6 +89,8 @@ struct scoped_record {
     }
 
     void disarm() { cleanup = false; }
+
+    bool is_valid() const { return checkpoint != (uint32_t)-1; }
 
     JitBackend backend;
     uint32_t checkpoint, scope;

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -42,8 +42,17 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
     bool symbolic = jit_flag(JitFlag::SymbolicScope);
 
     try {
-        scoped_record record_guard(backend);
+        /* Postponed operations captured by the isolation scope should only
+         * be executed once we've exited the symbolic scope. We therefore
+         * need to declare the AD isolation guard before the recording guard.
+         * However, the isolation scope must also be marked as symbolic for it
+         * to correctly receive implicit dependencies from inner (nested)
+         * computations, hence the dummy recording. */
+        uint32_t checkpoint = jit_record_begin(
+            backend, "Dummy recording for loop's isolation scope");
         scoped_isolation_boundary isolation_guard;
+        jit_record_end(backend, checkpoint, true);
+        scoped_record record_guard(backend);
 
         // Rewrite the loop state variables
         JitVar loop = JitVar::steal(jit_var_loop_start(

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -734,7 +734,8 @@ nb::object matmul(nb::handle h0, nb::handle h1) {
             };
 
             auto is_matrix = [n](const ArrayMeta &m) {
-                return (m.ndim == 2 || (m.ndim == 3 && m.shape[2] == DRJIT_DYNAMIC)) &&
+                return (m.is_matrix ||
+                       (m.ndim == 2 || (m.ndim == 3 && m.shape[2] == DRJIT_DYNAMIC))) &&
                        m.shape[0] == n && m.shape[1] == n;
             };
 

--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -439,13 +439,15 @@ const char *meta_get_name(ArrayMeta meta) noexcept {
                 prefix = "Quaternion";
             } else if (meta.is_matrix) {
                 prefix = "Matrix";
-                ndim--;
             }
             buffer.put_dstr(prefix);
             suffix = type_suffix[meta.type];
         }
 
         for (int i = 0; i < ndim; ++i) {
+            if (meta.is_matrix && i == 1)
+                continue;
+
             if (meta.shape[i] == DRJIT_DYNAMIC)
                 buffer.put('X');
             else

--- a/tests/call_ext.cpp
+++ b/tests/call_ext.cpp
@@ -36,6 +36,7 @@ template <typename Float> struct Base : nb::intrusive_base {
     virtual std::pair<Float, Float> f(Float x, Float y) = 0;
     virtual std::pair<Float, Float> f_masked(const std::pair<Float, Float> &xy, Mask active) = 0;
     virtual Float g(Float, Mask) = 0;
+    virtual Float nested(Float x, UInt32 s) = 0;
     virtual void dummy() = 0;
     virtual float scalar_getter() = 0;
     virtual Float opaque_getter() = 0;
@@ -51,7 +52,6 @@ template <typename Float> struct Base : nb::intrusive_base {
         if constexpr (dr::is_jit_v<Float>)
             jit_registry_put(dr::backend_v<Float>, "Base", this);
     }
-
 
     virtual ~Base() { jit_registry_remove(this); }
 };
@@ -72,6 +72,10 @@ template <typename Float> struct A : Base<Float> {
 
     virtual Float g(Float, Mask) override {
         return value;
+    }
+
+    virtual Float nested(Float x, UInt32 /*s*/) override {
+        return x;
     }
 
     virtual std::pair<Sampler<Float> *, Float> sample(Sampler<Float> *s) override {
@@ -120,6 +124,12 @@ template <typename Float> struct B : Base<Float> {
         return value*x;
     }
 
+    virtual Float nested(Float x, UInt32 s) override {
+        using BaseArray = dr::replace_value_t<Float, Base<Float>*>;
+        BaseArray self = dr::reinterpret_array<BaseArray>(s);
+        return self->nested(x,s);
+    }
+
     virtual std::pair<Sampler<Float> *, Float> sample(Sampler<Float> *s) override {
         return { s, 0 };
     }
@@ -149,6 +159,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(Base)
     DRJIT_CALL_METHOD(f_masked)
     DRJIT_CALL_METHOD(dummy)
     DRJIT_CALL_METHOD(g)
+    DRJIT_CALL_METHOD(nested)
     DRJIT_CALL_METHOD(sample)
     DRJIT_CALL_METHOD(gather_packet)
     DRJIT_CALL_METHOD(scatter_packet)
@@ -169,6 +180,7 @@ void bind(nb::module_ &m) {
     using AT = A<Float>;
     using BT = B<Float>;
     using Mask = dr::mask_t<Float>;
+    using UInt32 = dr::uint32_array_t<Float>;
     using Sampler = ::Sampler<Float>;
 
     auto sampler = nb::class_<Sampler>(m, "Sampler")
@@ -182,6 +194,7 @@ void bind(nb::module_ &m) {
         .def("f", &BaseT::f)
         .def("f_masked", &BaseT::f_masked)
         .def("g", &BaseT::g)
+        .def("nested", &BaseT::nested)
         .def("sample", &BaseT::sample);
 
     nb::class_<AT, BaseT>(m, "A")
@@ -212,6 +225,9 @@ void bind(nb::module_ &m) {
         .def("g",
              [](BaseArray &self, Float x, Mask m) { return self->g(x, m); },
              "x"_a, "mask"_a = true)
+        .def("nested",
+             [](BaseArray &self, Float x, UInt32 s) { return self->nested(x, s); },
+             "x"_a, "s"_a)
         .def("dummy", [](BaseArray &self) { return self->dummy(); })
         .def("scalar_getter", [](BaseArray &self, Mask m) {
                 return self->scalar_getter(m);

--- a/tests/test_call_ext.py
+++ b/tests/test_call_ext.py
@@ -931,3 +931,25 @@ def test19_nested_call(t, symbolic):
         xo = dr.dispatch(c, my_func, xi, yi)
 
     assert dr.all(xo == xi)
+
+
+@pytest.mark.parametrize("symbolic", [True, False])
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test20_partial_output_eval(t, symbolic):
+    pkg = get_pkg(t)
+
+    A, B, Base, BasePtr = pkg.A, pkg.B, pkg.Base, pkg.BasePtr
+    a, b = A(), B()
+
+    c = BasePtr(a, a, None, b, b)
+
+    xi = t(1, 2, 8, 3, 4)
+    yi = t(5, 6, 8, 7, 8)
+
+    with dr.scoped_set_flag(dr.JitFlag.SymbolicCalls, symbolic):
+        xo, yo = c.f(xi, yi)
+
+    dr.eval(xo)
+    zo = xo + yo
+    assert dr.all(xo == t(10, 12, 0, 21, 24))
+    assert dr.all(zo == t(9, 10, 0, 24, 28))

--- a/tests/test_call_ext.py
+++ b/tests/test_call_ext.py
@@ -857,6 +857,20 @@ def test16_packet_gather(t):
     dr.backward_from(r)
     assert dr.all(v.grad == [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
+    v = dr.ones(t, 16) # Literal
+    dr.enable_grad(v)
+    a.value = v
+
+    c = BasePtr(a, a, a, b, b)
+    r = c.gather_packet(dr.uint32_array_t(t)(1, 2, 3, 4, 5))
+    assert(dr.all(r==[
+        [1, 1, 1, 0, 0],
+        [1, 1, 1, 0, 0],
+        [1, 1, 1, 0, 0],
+        [1, 1, 1, 0, 0]], axis=None))
+    dr.backward_from(r)
+    assert dr.all(v.grad == [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+
 
 @pytest.test_arrays('float32,is_diff,shape=(*)')
 def test17_packet_scatter(t):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test01_init_indexing_rowmajor(t):
     v = dr.value_t(t)
     a = t(1, 2, 3, 4)
@@ -17,12 +17,12 @@ def test01_init_indexing_rowmajor(t):
     a[1][0] = 5
     assert dr.all(a == t(1, 4, 5, 4), axis=None)
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test02_init_bcast(t):
     assert dr.all(t(2) == t(2, 0, 0, 2), axis=None)
     assert dr.all(t(2) + 1 == t(3, 0, 0, 3), axis=None)
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test03_add_mul(t):
     a = dr.array_t(t)
     assert dr.all(t(1, 2, 3, 4) + t(0, 1, 0, 2) == t(1, 3, 3, 6), axis=None)
@@ -34,7 +34,7 @@ def test03_add_mul(t):
     assert dr.all(dr.fma(t(1, 2, 3, 4), t(0, 1, 0, 2), t(100,100,100,100)) == t(100, 105, 100, 111), axis=None)
 
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test04_mat_vec(t):
     v = dr.value_t(t)
     assert dr.all(t(1, 2, 3, 4) @ v(1, 2) == v(5, 11))
@@ -43,7 +43,7 @@ def test04_mat_vec(t):
     assert dr.all(v(1, 2) * t(1, 2, 3, 4) == v(7, 10))
 
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test05_mat_scalar(t):
     v = dr.value_t(t)
     assert dr.all(t(1, 2, 3, 4) @ 2 == t(2, 4, 6, 8), axis=None)
@@ -52,20 +52,20 @@ def test05_mat_scalar(t):
     assert dr.all(2 @ t(1, 2, 3, 4) == t(2, 4, 6, 8), axis=None)
 
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test06_mix_backends(t):
     assert dr.all(t(1, 2, 3, 4) @ dr.scalar.Array2f(1, 2) == dr.value_t(t)(5, 11))
     assert dr.all(dr.scalar.Matrix2f(1, 2, 3, 4) @ t(0, 1, 0, 2) == t(0, 5, 0, 11), axis=None)
 
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test07_transpose(t):
     a = t(1, 2, 3, 4)
     b = t(1, 3, 2, 4)
     assert dr.all(a.T == b, axis=None)
 
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test08_invert_spot_check_2d(t):
     a = t(1, 2, 3, 4)
     b = t(-2, 1, 1.5, -0.5)
@@ -75,7 +75,7 @@ def test08_invert_spot_check_2d(t):
     assert dr.allclose(2/a, 2*b)
 
 
-@pytest.test_arrays('matrix,shape=(3')
+@pytest.test_arrays('matrix,shape=(3, 3, *)', 'matrix,shape=(3, 3)')
 def test09_invert_spot_check_3d(t):
     a = t([[1, 2, 0], [3, 4, 0], [0, 1, 1]])
     b = t([[-2, 1,  0], [1.5, -0.5, 0], [-1.5, 0.5, 1]])
@@ -83,14 +83,14 @@ def test09_invert_spot_check_3d(t):
     assert dr.allclose(dr.det(a), -2)
 
 
-@pytest.test_arrays('matrix,shape=(4')
+@pytest.test_arrays('matrix,shape=(4, 4, *)', 'matrix,shape=(4, 4)')
 def test10_invert_spot_check_4d(t):
     a = t([[1, 2, 0, 0], [3, 4, 0, 1], [0, 1, 1, 0], [1, 0, 1, 2]])
     b = t([[-9, 4, 2, -2], [5, -2, -1, 1], [-5, 2, 2, -1],  [7, -3, -2, 2]])
     assert dr.allclose(dr.rcp(a), b)
     assert dr.allclose(dr.det(a), -1)
 
-@pytest.test_arrays('matrix,shape=(2')
+@pytest.test_arrays('matrix,shape=(2, 2, *)', 'matrix,shape=(2, 2)')
 def test11_diag_trace(t):
     v = dr.value_t(t)
     assert dr.all(dr.diag(t(1,2,3,4)) == dr.value_t(t)(1, 4))
@@ -98,13 +98,13 @@ def test11_diag_trace(t):
     assert dr.all(dr.diag(dr.value_t(t)(1, 3)) == t(1,0,0,3), axis=None)
 
 
-@pytest.test_arrays('matrix,shape=(4')
+@pytest.test_arrays('matrix,shape=(4, 4, *)', 'matrix,shape=(4, 4)')
 def test12_frob(t):
     m = t(*range(1, 17))
     assert dr.frob(m) == 1496
 
 
-@pytest.test_arrays('matrix,shape=(4')
+@pytest.test_arrays('matrix,shape=(4, 4, *)', 'matrix,shape=(4, 4)')
 def test13_polar(t):
     m = t(*range(1, 17)) + dr.identity(t)
     q, r = dr.polar_decomp(m)
@@ -112,7 +112,7 @@ def test13_polar(t):
     assert dr.allclose(q @ q.T, dr.identity(t))
 
 
-@pytest.test_arrays('matrix,shape=(4')
+@pytest.test_arrays('matrix,shape=(4, 4, *)', 'matrix,shape=(4, 4)')
 def test14_transform_decompose(t):
     m = sys.modules[t.__module__]
     name = t.__name__
@@ -135,7 +135,7 @@ def test14_transform_decompose(t):
     assert dr.allclose(q, q2)
 
 
-@pytest.test_arrays('matrix,shape=(4')
+@pytest.test_arrays('matrix,shape=(4, 4, *)', 'matrix,shape=(4, 4)')
 def test15_matrix_to_quat(t):
     m = sys.modules[t.__module__]
     name    = t.__name__

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1,4 +1,5 @@
 import drjit as dr
+import re
 import pytest
 import sys
 
@@ -24,9 +25,15 @@ def test01_traits(t):
     if is_jit and "Int" in tn or "Float" in tn or "X" in tn:
         size = dr.Dynamic
 
+    def matches_re(pattern):
+        matches = re.compile(pattern).match(tn)
+        return int(matches is not None)
+
     depth = int("Array" in tn or "Complex" in tn or "Quaternion" in tn)
-    depth += int("Matrix" in tn)*2
-    depth += int("Array11" in tn or "Array22" in tn or "Array33" in tn or "Array44" in tn)
+    depth += int("Matrix" in tn) * 2
+    depth += matches_re(r'Matrix\d\d')
+    depth += matches_re(r'Array\d\d')
+    depth += matches_re(r'Array\d\d\d')
     depth += int(is_jit)
 
     assert dr.is_jit_v(t) == is_jit and dr.is_jit_v(v) == is_jit


### PR DESCRIPTION
This PR backports some commits that were on `master` but were reverted before rebasing on the `nanobind_v2` branch. They are all edge cases that were wrong in the C++ API, none of them were related to the Python API.

This PR also includes various features and fixes:
* Tests for this drjit-core PR: https://github.com/mitsuba-renderer/drjit-core/pull/91
* Changes to the texture API such that it's numerical precision is better behaved
* New types in the bindings used by Mitsuba for polarization
* Fixes for recursive calls, that would previously recurse infinitely during tracing.
* Fixes to symbolic loops when using AD operations inside of them. This fix (commit: https://github.com/mitsuba-renderer/drjit/commit/fe2526627650045b7a34f98fc75474aeda701468) is particularly hacky and I'm open to better suggestions.
* Minor other stuff (the commit messages are explicit enough)

@rtabbara I've included your fixes in this PR too