### PR TITLE
Fixes for AD traversal inside of symbolic scope

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -863,7 +863,7 @@ template <typename T> struct suspend_grad {
         is_diff_v<T> && std::is_floating_point_v<scalar_t<T>>;
     suspend_grad() : condition(true) {
         if constexpr (Enabled)
-            ad_scope_enter(ADScope::Suspend, 0, nullptr);
+            ad_scope_enter(ADScope::Suspend, 0, nullptr, -1);
     }
     template <typename... Args>
     suspend_grad(bool when, const Args &... args) : condition(when) {
@@ -871,7 +871,8 @@ template <typename T> struct suspend_grad {
             if (condition) {
                 vector<uint64_t> indices;
                 (detail::collect_indices<false>(args, indices), ...);
-                ad_scope_enter(ADScope::Suspend, indices.size(), indices.data());
+                ad_scope_enter(
+                    ADScope::Suspend, indices.size(), indices.data(), -1);
             }
         } else {
             (((void) args), ...);

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -204,7 +204,7 @@ extern DRJIT_EXTRA_EXPORT const char *ad_var_graphviz();
 
 /// Indicate that the program entered a scope which modifies the AD layer's behavior
 extern DRJIT_EXTRA_EXPORT void ad_scope_enter(drjit::ADScope type, size_t size,
-                                              const uint64_t *indices);
+                                              const uint64_t *indices, int symbolic);
 
 /// Indicate that the program left a scope which modifies the AD layer's behavior
 extern DRJIT_EXTRA_EXPORT void ad_scope_leave(bool process_postponed);

--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -1614,14 +1614,18 @@ void ad_traverse(dr::ADMode mode, uint32_t flags) {
 // AD scope management
 // ==========================================================================
 
-void ad_scope_enter(ADScope type, size_t size, const Index *indices) {
+void ad_scope_enter(ADScope type, size_t size, const Index *indices, int symbolic) {
     std::vector<Scope> &scopes = local_state.scopes;
     Scope scope;
 
     if (!scopes.empty())
         scope = scopes.back();
 
-    scope.symbolic = jit_flag(JitFlag::SymbolicScope);
+    if (symbolic == -1)
+        scope.symbolic = jit_flag(JitFlag::SymbolicScope);
+    else
+        scope.symbolic = (symbolic != 0);
+
     scope.postponed.clear();
     scope.implicit_in.clear();
     scope.implicit_out.clear();

--- a/src/extra/common.h
+++ b/src/extra/common.h
@@ -39,8 +39,8 @@ private:
 
 /// RAII AD Isolation helper
 struct scoped_isolation_boundary {
-    scoped_isolation_boundary() {
-        ad_scope_enter(drjit::ADScope::Isolate, 0, nullptr);
+    scoped_isolation_boundary(int symbolic = -1) : symbolic(symbolic) {
+        ad_scope_enter(drjit::ADScope::Isolate, 0, nullptr, symbolic);
     }
 
     ~scoped_isolation_boundary() {
@@ -49,11 +49,12 @@ struct scoped_isolation_boundary {
 
     void reset() {
         ad_scope_leave(false);
-        ad_scope_enter(drjit::ADScope::Isolate, 0, nullptr);
+        ad_scope_enter(drjit::ADScope::Isolate, 0, nullptr, symbolic);
     }
 
     void disarm() { success = true; }
 
+    int symbolic = -1;
     bool success = false;
 };
 

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -44,14 +44,8 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
     try {
         /* Postponed operations captured by the isolation scope should only
          * be executed once we've exited the symbolic scope. We therefore
-         * need to declare the AD isolation guard before the recording guard.
-         * However, the isolation scope must also be marked as symbolic for it
-         * to correctly receive implicit dependencies from inner (nested)
-         * computations, hence the dummy recording. */
-        uint32_t checkpoint = jit_record_begin(
-            backend, "Dummy recording for loop's isolation scope");
-        scoped_isolation_boundary isolation_guard;
-        jit_record_end(backend, checkpoint, true);
+         * need to declare the AD isolation guard before the recording guard. */
+        scoped_isolation_boundary isolation_guard(1);
         scoped_record record_guard(backend);
 
         // Rewrite the loop state variables

--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -630,7 +630,7 @@ void export_autodiff(nb::module_ &m) {
         .def(nb::init<dr::ADScope, dr::vector<uint64_t>>())
         .def("__enter__",
              [](ADContextManager &m) {
-                 ad_scope_enter(m.scope, m.indices.size(), m.indices.data());
+                 ad_scope_enter(m.scope, m.indices.size(), m.indices.data(), -1);
              })
         .def("__exit__",
              [](ADContextManager &, nb::handle exc_type, nb::handle, nb::handle) {

--- a/src/python/print.cpp
+++ b/src/python/print.cpp
@@ -29,7 +29,7 @@ using Buffer = nanobind::detail::Buffer;
 
 struct suspend_grad_simple {
     suspend_grad_simple() {
-        ad_scope_enter(dr::ADScope::Suspend, 0, nullptr);
+        ad_scope_enter(dr::ADScope::Suspend, 0, nullptr, -1);
     }
 
     ~suspend_grad_simple() {

--- a/tests/call_ext.cpp
+++ b/tests/call_ext.cpp
@@ -75,7 +75,7 @@ template <typename Float> struct A : Base<Float> {
     }
 
     virtual Float nested(Float x, UInt32 /*s*/) override {
-        return x;
+        return x + dr::gather<Float>(value, UInt32(0));
     }
 
     virtual std::pair<Sampler<Float> *, Float> sample(Sampler<Float> *s) override {
@@ -127,7 +127,7 @@ template <typename Float> struct B : Base<Float> {
     virtual Float nested(Float x, UInt32 s) override {
         using BaseArray = dr::replace_value_t<Float, Base<Float>*>;
         BaseArray self = dr::reinterpret_array<BaseArray>(s);
-        return self->nested(x,s);
+        return self->nested(x, s);
     }
 
     virtual std::pair<Sampler<Float> *, Float> sample(Sampler<Float> *s) override {

--- a/tests/test_call_ext.py
+++ b/tests/test_call_ext.py
@@ -917,6 +917,8 @@ def test19_nested_call(t, symbolic):
 
     A, B, Base, BasePtr = pkg.A, pkg.B, pkg.Base, pkg.BasePtr
     a, b = A(), B()
+    a.value = dr.ones(t, 16)
+    dr.enable_grad(a.value)
 
     U = dr.uint32_array_t(t)
     xi = t(1, 2, 8, 3, 4)
@@ -930,7 +932,7 @@ def test19_nested_call(t, symbolic):
     with dr.scoped_set_flag(dr.JitFlag.SymbolicCalls, symbolic):
         xo = dr.dispatch(c, my_func, xi, yi)
 
-    assert dr.all(xo == xi)
+    assert dr.all(xo == xi + 1)
 
 
 @pytest.mark.parametrize("symbolic", [True, False])


### PR DESCRIPTION
This PR is a follow-up to https://github.com/mitsuba-renderer/drjit/commit/fe2526627650045b7a34f98fc75474aeda701468. That original commit only applied to symbolic loops, in this PR I've added a similar fix for calls and conditionals.

In addition, I refactored the isolation scope creation in c++ such that we can easily force it to be marked as symbolic.

The PR contains regressions tests for calls and conditionals (these could not pass prior to this fix).