### PR TITLE
`dr.detach`: Make sure we return copy of gradient disabled variables

### DIFF
--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -111,13 +111,17 @@ static nb::object detach(nb::handle h, bool preserve_type_ = true) {
         void operator()(nb::handle h1, nb::handle h2) override {
             const ArraySupplement &s1 = supp(h1.type()),
                                   &s2 = supp(h2.type());
-            if (s1.is_diff)
+
+            if (s2.index)
                 s2.init_index((uint32_t) s1.index(inst_ptr(h1)), inst_ptr(h2));
+            else {
+                nb::object o = nb::borrow(h1);
+                nb::inst_replace_move(h2, o);
+            }
         }
     };
 
-    if ((is_drjit_array(h) && !supp(h.type()).is_diff) ||
-        (preserve_type_ && !grad_enabled(h)))
+    if ((is_drjit_array(h) && !supp(h.type()).is_diff))
         return nb::borrow(h);
 
     Detach d(preserve_type_);

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -95,6 +95,7 @@ def test002_detach(t):
     a = Foo()
     dr.enable_grad(a)
     b = dr.detach(a, preserve_type=False)
+    assert dr.all(b.y == dr.scalar.Array3f(1))
     assert type(a.x) is not type(b.x)
     assert type(a.y) is type(b.y)
 


### PR DESCRIPTION
Picked up when running through the tutorials. Suppose we have

```python
opt = mi.ad.SGD(lr=0.25, params=params)
...
y = mi.Float(2.0)
opt['y'] = y  # A copy should be made here
opt['y'] += 1.0
```
Internally, the `Optimizer` `__setitem__` would perform

```python
...
self.variables[key] = dr.detach(value, True)
```

So in the case that value is  not grad-enabled. we still want a copy of the variable to be stored rather than a reference to the original value.

