### PR TITLE
Fix `detach` with nested scalar Dr.Jit types and CustomOp InputOutput fix and CustomOp InputOutput fix

### DIFF
--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -90,14 +90,20 @@ def test002_detach(t):
         def __init__(self) -> None:
             self.x = t(1)
             self.y = dr.scalar.Array3f(1)
-        DRJIT_STRUCT = { 'x': t, 'y': dr.scalar.Array3f }
+            self.z = 3.0
+        DRJIT_STRUCT = { 'x': t, 'y': dr.scalar.Array3f , 'z' : float }
 
     a = Foo()
     dr.enable_grad(a)
     b = dr.detach(a, preserve_type=False)
+    assert dr.all(a.y == dr.scalar.Array3f(1))
+    assert dr.all(a.z == 3.0)
     assert dr.all(b.y == dr.scalar.Array3f(1))
+    assert dr.all(b.z == 3.0)
     assert type(a.x) is not type(b.x)
     assert type(a.y) is type(b.y)
+    assert type(a.z) is type(b.z)
+
 
 @pytest.test_arrays('is_diff,float,-float16,shape=(*)')
 def test003_set_grad(t):


### PR DESCRIPTION
- For `detach`, if the transform callback is called then we know it's a Dr.Jit type
- Otherwise, for other types the `transform_unknown` object is returned which by default is the borrowed reference of the passed-in value
- In the case of a scalar Dr.Jit type, we should be performing a copy because otherwise a `move` will zero-out the original variable (e.g. `dr.scalar.Array3f`)

- The other fix to modify `add_generic` (CustomOp input/output variables) revolves around a missing corresponding JIT (primal) index being provided
- This is a problem for tensors, because `apply.cpp::transform` checks whether the transformed length of the underlying transformed array matches the original to preserve the original tensor shape
- Otherwise, the new tensor is flattened
- i.e. we need the JIT index to be there in order to determine the length of the new array