### PR TITLE
`meta_promote`: Handle promotion from vec4 to quaternion

### DIFF
--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -137,6 +137,11 @@ ArrayMeta meta_promote(ArrayMeta a, ArrayMeta b) noexcept {
             r.shape[r.ndim++] = DRJIT_DYNAMIC;
     }
 
+    if (r.is_quaternion && r.is_vector && r.shape[0] == 4)
+        r.is_vector = 0;
+    else if (r.is_complex && r.is_vector && r.shape[0] == 2)
+        r.is_vector = 0;
+
     return r;
 }
 
@@ -377,6 +382,7 @@ void promote(nb::object *o, size_t n, bool select) {
             m.type = (uint16_t) VarType::Bool;
             m.is_quaternion = 0;
             m.is_matrix = 0;
+            m.is_complex = 0;
             h2 = meta_get_type(m);
         }
 

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -222,6 +222,38 @@ def test06_select():
                          { 'a' : l.Float(-1), 'b' : l.Float(-2) })
         assert str(result) == "{'a': [-1, -1, 1, 1], 'b': [-2, -2, 2, 2]}"
 
+        a = l.Quaternion4f(1.0, 2.0, 3.0, 4.0)
+        b = l.Quaternion4f(4.0, 3.0, 2.0, 1.0)
+        result = dr.select(dr.isnan(a), b, a)
+        assert isinstance(result, l.Quaternion4f)
+        result = dr.select(dr.isnan(a), a, 0)
+        assert isinstance(result, l.Quaternion4f)
+        result = dr.select(dr.isnan(a), 0, a)
+        assert isinstance(result, l.Quaternion4f)
+        result = dr.select(True, a, 0)
+        assert isinstance(result, l.Quaternion4f)
+        result = dr.select(l.Array4b([True, False], [False, True], [True, False], [True, True]), a, 0)
+        assert isinstance(result, l.Quaternion4f)
+        assert str(result) == '[1i+3k+4,\n 2j+4]'
+        with pytest.raises(RuntimeError) as e:
+            result = dr.select(l.Array2b(True, False), a, 0)
+
+        a = l.Complex2f(1.0, 2.0)
+        b = l.Complex2f(4.0, 3.0)
+        result = dr.select(dr.isnan(a), b, a)
+        assert isinstance(result, l.Complex2f)
+        result = dr.select(dr.isnan(a), a, 0)
+        assert isinstance(result, l.Complex2f)
+        result = dr.select(dr.isnan(a), 0, a)
+        assert isinstance(result, l.Complex2f)
+        result = dr.select(True, a, 0)
+        assert isinstance(result, l.Complex2f)
+        result = dr.select(l.Array2b([True, False], [False, True]), a, 0)
+        assert isinstance(result, l.Complex2f)
+        assert(str(result) == '[1,\n 2j]')
+        with pytest.raises(RuntimeError) as e:
+            result = dr.select(l.Array4b(True, False, True, True), a, 0)
+
 @pytest.test_arrays('type=float32,shape=(*)')
 def test07_power(t):
     assert dr.allclose(t(2)**0, t(1))

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -85,8 +85,6 @@ def test3_binop_promote_misc():
 
     with pytest.raises(RuntimeError, match="Incompatible arguments."):
         x = dr.zeros(dr.scalar.Complex2f64) + dr.zeros(dr.llvm.Array3f)
-    with pytest.raises(RuntimeError, match="Incompatible arguments."):
-        x = dr.zeros(dr.scalar.Complex2f64) + dr.zeros(dr.llvm.Array2f)
 
     a = dr.scalar.Array3i(1)
     with pytest.raises(RuntimeError) as ei:


### PR DESCRIPTION
Motivated by usage of quaternion with `dr.select`. We should be able to support the case where the mask is a vec4 while the other args are quaternions.