### PR TITLE
Fix potential cyclic dependencies with `dr.alloc_local`

### DIFF
--- a/src/python/local.cpp
+++ b/src/python/local.cpp
@@ -349,8 +349,27 @@ static nb::object traverse(nb::handle tp, nb::handle v1, nb::handle v2,
 
 nb::handle local_type;
 
+int local_tp_traverse(PyObject * self, visitproc visit, void *arg) {
+    Local *o = nb::inst_ptr<Local>(self);
+    Py_VISIT(o->m_dtype.ptr());
+    Py_VISIT(o->m_value.ptr());
+    return 0;
+}
+
+int local_tp_clear(PyObject *self) {
+    Local *o = nb::inst_ptr<Local>(self);
+    o->m_dtype.reset();
+    o->m_value.reset();
+    return 0;
+};
+
+PyType_Slot slots[] = { { Py_tp_traverse, (void *) local_tp_traverse },
+                        { Py_tp_clear, (void *) local_tp_clear },
+                        { 0, nullptr } };
+
 void export_local(nb::module_ &m) {
     local_type = nb::class_<Local>(m, "Local", nb::is_generic(),
+                                   nb::type_slots(slots),
                                    nb::sig("class Local(typing.Generic[T])"), doc_Local)
         .def(nb::init<Local>(), doc_Local_Local)
         .def("__len__", &Local::len, doc_Local___len__)

--- a/src/python/local.h
+++ b/src/python/local.h
@@ -11,6 +11,9 @@
 #include "common.h"
 
 class Local {
+    friend int local_tp_traverse(PyObject*, visitproc, void*);
+    friend int local_tp_clear(PyObject*);
+
 public:
     /**
      * \brief Allocate local memory to store a PyTree of type ``dtype`` with length
@@ -55,7 +58,10 @@ protected:
     nb::handle m_mask_tp;
 };
 
+
 extern nb::handle local_type;
 
 extern void export_local(nb::module_ &m);
 
+int local_tp_traverse(PyObject * self, visitproc visit, void *arg);
+int local_tp_clear(PyObject *self);


### PR DESCRIPTION
This PR fixes a potential cyclic dependency when using dataclasses in `dr.alloc_local`.

The following code snippet would leak
```python
from dataclasses import dataclass
import drjit as dr

if __name__ == "__main__":
    @dataclass
    class SampleData:
        data: dr.llvm.ad.Float

    some_float = dr.llvm.ad.Float([1, 2, 3])
    default = SampleData(some_float)

    sample_data = dr.alloc_local(SampleData, 10, default)
 ```
 The default value and `dtype` information are sources of cyclic dependencies.