### PR TITLE
Handle postponed type information in dataclasses

### DIFF
--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -956,6 +956,8 @@ nb::handle DR_STR(_traverse_write) = PyUnicode_InternFromString("_traverse_write
 nb::handle DR_STR(_traverse_read) = PyUnicode_InternFromString("_traverse_read");
 nb::handle DR_STR(_traverse_1_cb_rw) = PyUnicode_InternFromString("_traverse_1_cb_rw");
 nb::handle DR_STR(_traverse_1_cb_ro) = PyUnicode_InternFromString("_traverse_1_cb_ro");
+nb::handle DR_STR(typing) = PyUnicode_InternFromString("typing");
+nb::handle DR_STR(get_type_hints) = PyUnicode_InternFromString("get_type_hints");
 
 void export_base(nb::module_ &m) {
     // Generic type variable used in many places


### PR DESCRIPTION
This PR adds handling for postponed type hints ([PEP 563](https://peps.python.org/pep-0563/)) on Dr.Jit functions involving a `dataclass`. These are particularly useful when using Mitsuba, as a `dataclass` will most likely be defined before the variant has been set. Here's an example:
```python
from __future__ import annotations
from dataclasses import dataclass

import mitsuba as mi
import drjit as dr

@dataclass
class SampleData:
    data: mi.Float # postponed type annotation (invalid before mi.set_variant())

def main():
    sample_data = dr.alloc_local(SampleData, 10) # at this point in time `mi.Float` can be resolved

if __name__ == "__main__":
    mi.set_variant("cuda_ad_rgb")
    main()
```

The implementation relies on `typing.get_type_hints`, which is the [recommended way of resolving type hints](https://peps.python.org/pep-0563/#resolving-type-hints-at-runtime).