### PR TITLE
Add `matrix_t` and fix-up `diag`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -217,6 +217,7 @@ _______________________
 .. autofunction:: expr_t
 .. autofunction:: array_t
 .. autofunction:: tensor_t
+.. autofunction:: matrix_t
 
 Bit-level operations
 --------------------

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -582,9 +582,8 @@ def diag(arg, /):
         for i in range(len(arg)):
             result[i] = arg[i, i]
         return result
-    elif is_array_v(arg) and 'Array' in tp.__name__:
-        import sys
-        mat_tp = getattr(sys.modules[tp.__module__], tp.__name__.replace('Array', 'Matrix'), None)
+    elif is_array_v(arg):
+        mat_tp = matrix_t(arg)
         if mat_tp is None:
             raise Exception('drjit.diag(): unsupported type!')
         result = zeros(mat_tp, width(arg))

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -168,6 +168,26 @@
     Returns:
         type: Returns a compatible tensor type or ``None``.
 
+.. topic:: matrix_t
+
+    Return a matrix type that corresponds to the provided Dr.Jit array type.
+
+    This type trait is used internally by :py:func:`diag` to initialize a matrix
+    from a Dr.Jit array type.
+
+    Example usage:
+
+    .. code-block:: python
+
+       x = dr.llvm.Array3f(...)
+       tp = dr.matrix_t(type(x)) # <-- returns dr.llvm.Matrix3f
+
+    Args:
+        arg (object): An arbitrary Python object
+
+    Returns:
+        type: Returns a compatible matrix type or ``None``.
+
 .. topic:: mask_t
 
     Return the *mask type* associated with the provided Dr.Jit array or type (i.e., the

--- a/src/python/traits.cpp
+++ b/src/python/traits.cpp
@@ -124,6 +124,22 @@ nb::object tensor_t(nb::handle h) {
     return nb::none();
 }
 
+nb::object matrix_t(nb::handle h) {
+    nb::handle tp = h.is_type() ? h : h.type();
+    if (is_drjit_type(tp)) {
+        ArrayMeta m = supp(tp);
+        if (m.is_matrix || m.is_vector) {
+            m.is_vector = false;
+            m.is_matrix = true;
+            // Make sure corresponding Matrix binding is available
+            nb::handle t = meta_get_type(m, false);
+            if (t.is_valid())
+                return nb::borrow(t);
+        }
+    }
+    return nb::none();
+}
+
 void export_traits(nb::module_ &m) {
     m.attr("Dynamic") = -1;
 
@@ -334,6 +350,8 @@ void export_traits(nb::module_ &m) {
     m.def("itemsize_v", &itemsize_v, doc_itemsize_v);
 
     m.def("tensor_t", &tensor_t, doc_tensor_t);
+
+    m.def("matrix_t", &matrix_t, doc_matrix_t);
 
     m.def("reinterpret_array_t",
           [](nb::handle h, VarType vt) { return reinterpret_array_t(h, vt); },

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -86,6 +86,16 @@ def test01_traits(t):
         assert mn == 'Bool'
         assert dr.array_t(t).__name__ == "Float"
         assert dr.array_t(m).__name__ == "Bool"
+        assert dr.matrix_t(t) is None
+
+    if tn == 'Array3f':
+        assert dr.matrix_t(t).__name__ == "Matrix3f"
+
+    if tn == 'Array1f':
+        assert dr.matrix_t(t) is None
+
+    if tn == 'Array334f':
+        assert dr.matrix_t(t).__name__ == "Matrix34f"
 
     if scalar_type is int:
         assert dr.is_integral_v(t) and dr.is_integral_v(v)


### PR DESCRIPTION
Fix for [1250](https://github.com/mitsuba-renderer/mitsuba3/issues/1250) . Previous logic couldn't handle aliased types (e.g. `mi.Vector3f`)