### PR TITLE
Handle list comprehensions in `@dr.syntax`

### DIFF
--- a/drjit/ast.py
+++ b/drjit/ast.py
@@ -147,6 +147,34 @@ class _SyntaxVisitor(ast.NodeTransformer):
             self.var_w.add(node.id)
         return node
 
+    def visit_comp(self,
+                   node: Union[ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp]) -> ast.AST:
+        var_r, var_w = self.var_r, set(self.var_w)
+        self.var_r = set()
+        result = self.generic_visit(node)
+
+        comp_targets = set()
+        for comp in node.generators:
+            comp_targets.add(comp.target.id)
+
+        # Targets should not be considered, and no assigments can be made
+        self.var_r = (self.var_r - comp_targets) | var_r
+        self.var_w = var_w
+
+        return result
+
+    def visit_ListComp(self, node: ast.ListComp) -> ast.AST:
+        return self.visit_comp(node)
+
+    def visit_SetComp(self, node: ast.DictComp) -> ast.AST:
+        return self.visit_comp(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> ast.AST:
+        return self.visit_comp(node)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> ast.AST:
+        return self.visit_comp(node)
+
     # def visit_Attribute(self, node: ast.Attribute) -> ast.AST:
     #     n = node
     #     seq = []

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,0 +1,25 @@
+import drjit as dr
+import pytest
+
+@pytest.test_arrays('shape=(*), uint32, jit')
+@dr.syntax
+def test01_comprehensions(t):
+    # Before PR #252, the j variable would incorrectly be considered part of the
+    # loop state, breaking compilation. However, variables in comprehensions
+    # are isolated and hence the variable 'j' isn't set until we're inside the
+    # loop.
+
+    n = 3
+    [j for j in range(n)] # List comprehension
+    {j: 'value' for j in range(n)} # Dict comprehension
+    {j for j in range(n)} # Set comprehension
+    (j for j in range(n) if j > 2) # Generator expression
+
+    i = dr.zeros(t, 1)
+    result = dr.zeros(t)
+    while i < 2:
+        for j in range(n):
+            result += i * j
+        i += 1
+
+    assert result[0] == 3


### PR DESCRIPTION
This PR fixes #252.

List comprehensions and other generators define statement-local variables that can never be part of the state loop. This PR guarantees this by ignoring those variables names during the AST traversal of `@dr.syntax`.

I've added a test that isn't much more than a regressions test - it doesn't actually verify that the generator's variables become part of the loop state.

I think this is a fairly safe change @wjakob, but I'm also a bit adverse to introducing more and more handling of these edge cases in `@dr.syntax`