### PR TITLE
Add `Array6*` bindings. 

### DIFF
--- a/include/drjit/array_mask.h
+++ b/include/drjit/array_mask.h
@@ -37,6 +37,30 @@ private:
     size_t index;
 };
 
+template <typename Array1, typename Array2>
+struct MaskBitPacketRecursive {
+
+    MaskBitPacketRecursive(Array1& a1, Array2& a2, size_t index) :
+        a1(a1), a2(a2), index(index) {}
+
+    operator bool() const {
+        return (index < Array1::Size) ?
+            a1.entry(index) : a2.entry(index - Array1::Size);
+    }
+
+    MaskBitPacketRecursive &operator=(bool b) {
+        if (index < Array1::Size) 
+            a1.entry(index) = b;
+        else
+            a2.entry(index - Array1::Size) = b;
+        return *this;
+    }
+
+    Array1& a1;
+    Array2& a2;
+    size_t index;
+};
+
 NAMESPACE_END(detail)
 
 template <typename Value_, size_t Size_, typename Derived_>

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -994,6 +994,7 @@ template <typename T> void bind_all(ArrayBinding &b) {
     bind_array_types<Array<T, 2>>(b);
     bind_array_types<Array<T, 3>>(b);
     bind_array_types<Array<T, 4>>(b);
+    bind_array_types<Array<T, 6>>(b);
     bind_array_types<DynamicArray<T>>(b);
 
     bind_matrix_types<T, 2>(b);


### PR DESCRIPTION
For Mitsuba suite of SGGX distribution functons we need this type to be exposed