### PR TITLE
Fixes to `assert_true`/`assert_false`

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -2015,8 +2015,7 @@ def assert_true(
 
     if not flag(JitFlag.Debug):
         return
-
-    if cond is False or (not detail.any_symbolic(cond) and none(cond)):
+    if cond is True or (not detail.any_symbolic(cond) and all(cond)):
         return
 
     import traceback, sys, types

--- a/src/python/print.cpp
+++ b/src/python/print.cpp
@@ -471,10 +471,8 @@ static nb::object format_impl(const char *name, const std::string &fmt,
             jit_var_dec_ref(mask_1);
             jit_var_dec_ref(mask_2);
 
-            if (kwargs.contains("active")) {
+            if (kwargs.contains("active"))
                 active &= kwargs["active"];
-                nb::del(kwargs["active"]);
-            }
 
             nb::object counter = index_tp(0),
                        slot = scatter_inc(counter, index_tp(0), active),

--- a/tests/test_assert.py
+++ b/tests/test_assert.py
@@ -1,0 +1,118 @@
+import drjit as dr
+import pytest
+
+def test01_assert_bool():
+    with dr.scoped_set_flag(dr.JitFlag.Debug, True):
+        dr.assert_true(True)
+        dr.assert_false(False)
+
+        with pytest.raises(AssertionError, match='Assertion failure!'):
+            dr.assert_true(False)
+        with pytest.raises(AssertionError, match='Assertion failure!'):
+            dr.assert_false(True)
+
+
+@pytest.test_arrays('shape=(*), uint32, jit')
+def test02_assert_vec(t):
+    with dr.scoped_set_flag(dr.JitFlag.Debug, True):
+        i = t(1, 2, 3, 4, 5, 6)
+
+        # Unanimous
+        dr.assert_true(i > 0)
+        dr.assert_false(i > 10)
+
+        # Partial
+        with pytest.raises(AssertionError, match='Assertion failure!'):
+            dr.assert_true(i >= 4)
+        with pytest.raises(AssertionError, match='Assertion failure!'):
+            dr.assert_false(i >= 4)
+
+
+@pytest.test_arrays('shape=(*), uint32, jit')
+@pytest.mark.parametrize('mode', ['symbolic', 'evaluated'])
+def test03_assert_true_loop(t, mode, capsys):
+    with dr.scoped_set_flag(dr.JitFlag.Debug, True):
+        i = t(2, 3, 4, 5)
+
+        def body_unanimous(i):
+            dr.print("{}", i, active=i > 10)
+            dr.assert_true(i > 0)
+            return (i + 1,)
+        i = dr.while_loop(
+            (i,),
+            lambda i: i<8,
+            body_unanimous,
+            mode=mode
+        )
+        dr.eval(i)
+
+        i = t(2, 3, 4, 5)
+        def body_partial_true(i):
+            dr.assert_true(i >= 4)
+            return (i + 1,)
+
+        if mode == 'evaluated':
+            with pytest.raises(RuntimeError) as e:
+                i = dr.while_loop(
+                    (i,),
+                    lambda i: i<8,
+                    body_partial_true,
+                    mode=mode
+                )
+                dr.eval(i)
+                assert "Assertion failure!" in str(e.value.__cause__)
+        else:
+            i = dr.while_loop(
+                (i,),
+                lambda i: i<8,
+                body_partial_true,
+                mode=mode
+            )
+            dr.eval(i)
+            captured = capsys.readouterr()
+            assert "Assertion failure!" in str(captured.err)
+
+
+@pytest.test_arrays('shape=(*), uint32, jit')
+@pytest.mark.parametrize('mode', ['symbolic', 'evaluated'])
+def test04_assert_false_loop(t, mode, capsys):
+    with dr.scoped_set_flag(dr.JitFlag.Debug, True):
+        i = t(2, 3, 4, 5)
+
+        def body_unanimous(i):
+            dr.print("{}", i, active=i > 10)
+            dr.assert_false(i > 10)
+            return (i + 1,)
+        i = dr.while_loop(
+            (i,),
+            lambda i: i<8,
+            body_unanimous,
+            mode=mode
+        )
+        dr.eval(i)
+
+        i = t(2, 3, 4, 5)
+        def body_partial_false(i):
+            dr.assert_false(i >= 4)
+            return (i + 1,)
+
+        if mode == 'evaluated':
+            with pytest.raises(RuntimeError) as e:
+                i = dr.while_loop(
+                    (i,),
+                    lambda i: i<8,
+                    body_partial_false,
+                    mode=mode
+                )
+                dr.eval(i)
+                assert "Assertion failure!" in str(e.value.__cause__)
+        else:
+            i = dr.while_loop(
+                (i,),
+                lambda i: i<8,
+                body_partial_false,
+                mode=mode
+            )
+            dr.eval(i)
+            captured = capsys.readouterr()
+            assert "Assertion failure!" in str(captured.err)


### PR DESCRIPTION
This PR fixes the early exit logic for ``assert_true` and `assert_false`.
It also adds tests for both functions.

:warning: This PR also introduces a small change to `dr.print`: in a symbolic context, if all lanes are masked, no message will be printed. Previously. it would **always** print a message, even if all lanes were maked. This change is necessary, as without it the assertion failure message would still have been printed even if all lanes fulfilled the assertion.