### PR TITLE
Swizzle and implicit binding predicate fixes

### DIFF
--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -321,7 +321,9 @@ static NB_NOINLINE nb::handle tp_getattro_fallback(nb::handle h0, nb::handle h1)
                                                            : DRJIT_DYNAMIC);
 
                 try {
-                    nb::handle tp2 = meta_get_type(m2);
+                    nb::handle tp2 = swizzle_size == s0.shape[0] ?
+                        h0.type() :
+                        meta_get_type(m2);
                     const ArraySupplement &s2 = supp(tp2);
 
                     ArraySupplement::Item item = s0.item;

--- a/src/python/bind.cpp
+++ b/src/python/bind.cpp
@@ -239,10 +239,17 @@ nb::object bind(const ArrayBinding &b) {
         if (PyLong_CheckExact(o)) {
             return is_float(s);
         } else if (PySequence_Check(o)) {
+            if (s.is_tensor)
+                return true;
+
+            if (is_drjit_type(tp_o) && supp(tp_o).ndim > s.ndim)
+                return false;
+
             Py_ssize_t size = s.shape[0], len = PySequence_Length(o);
             if (len == -1)
                 PyErr_Clear();
-            return s.is_tensor || size == DRJIT_DYNAMIC || len == size;
+
+            return size == DRJIT_DYNAMIC || len == size;
         }
         return false;
     };

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -207,3 +207,13 @@ def test17_quat_to_matrix(t):
     q = t(0.72331658, 0.49242236, 0.31087897, 0.3710628)
     assert(dr.allclose(q, dr.matrix_to_quat(dr.quat_to_matrix(q, size=3))))
     assert(dr.allclose(q, dr.matrix_to_quat(dr.quat_to_matrix(q, size=4))))
+
+@pytest.test_arrays('-float16, matrix,shape=(4, 4, *)')
+def test18_init_upcast(t):
+    mod = sys.modules[t.__module__]
+    Matrix43f = getattr(mod, 'Matrix43f')
+    Matrix41f = getattr(mod, 'Matrix41f')
+    assert dr.all(Matrix43f(2) == t(2), axis=None)
+    assert dr.all(Matrix41f(2) == t(2), axis=None)
+    with pytest.raises(TypeError):
+        t(Matrix41f(2))


### PR DESCRIPTION
`dr.cross` : Cast return type back to original type
- Use of swizzle operator will return a dr.jit array type. This means for example swizzling a `mi.Vector3f` returns a `dr.*.Array3f`

For implicit conversion predicate from dr.jit types, also check dimensions are compatible
- Previously types such as `Array4f` -> `Matrix4<Color3f>` would return true as we're just simply checking that the first dimension aligns