### PR TITLE
Make `__dlpack__` and `__dlpack_device__` constistent

### DIFF
--- a/src/python/dlpack.cpp
+++ b/src/python/dlpack.cpp
@@ -113,7 +113,7 @@ static nb::ndarray<> dlpack(nb::handle_t<ArrayBase> h, bool force_cpu, nb::handl
 
             if (backend == JitBackend::CUDA && !force_cpu) {
                 device_type = nb::device::cuda::value;
-                device_id = jit_var_device(index);
+                device_id = jit_cuda_device_raw();
 
                 // https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html
                 /*


### PR DESCRIPTION
Fixes https://github.com/mitsuba-renderer/mitsuba3/issues/1229

Currently, `__dlpack__` and `__dlpack_device__` are potentially inconsistent. This fix favors `jit_cuda_device_raw` over `jit_var_device`, because the latter will throw an error for JIT variables that point to memory regions allocated by other frameworks  (`jit_var_mem_map`).