### PR TITLE
Fix forward differentiation of packet scatters

### DIFF
--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -3096,8 +3096,8 @@ public:
 
         Variable *target = state[m_output_indices[0]];
 
-        if (m_input_indices[0]) {
-            JitVar &source_grad = state[m_input_indices[0]]->grad;
+        if (m_inputs[0]) {
+            JitVar &source_grad = state[m_inputs[0]]->grad;
             if (source_grad.valid())
                 target->accum(source_grad, target->size);
         }

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -2034,3 +2034,21 @@ def test129_packet_scatter_add_bwd(t, enabled):
         dr.backward_to(x, y)
         assert dr.all(x.grad == [0,1,2,3,4,5,6,7])
         assert dr.all(dr.all(y.grad == [4,5,6,7]))
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+@pytest.test_arrays('is_diff,float,shape=(4, *),-quat')
+def test130_packet_scatter_fwd_target_disabled(t, enabled):
+    with dr.scoped_set_flag(dr.JitFlag.PacketOps, enabled):
+        Float = dr.value_t(t)
+        UInt32 = dr.uint32_array_t(Float)
+        x = dr.zeros(Float, 8)
+
+        y = t([1, 2], [3, 4], [5, 6], [7, 8])
+        dr.enable_grad(y)
+        y.grad = y * 10
+
+        dr.scatter(x, y, index=UInt32(0, 1))
+        xg = dr.forward_to(x)
+
+        assert dr.all(xg == [10, 30, 50, 70, 20, 40, 60, 80])


### PR DESCRIPTION
The target of a packet `scatter` operation has a special code path in the AD layer when forward differentiated (`PacketScatter::forward()`): 
* We first accumulate any existing gradients (prior to the `scatter`) on the target
* Secondly, we individually accumulate each of the packet's values' gradients

The first step was using the wrong JIT index to identify the existing gradients on the target.

(The backward traversal looked up the correct JIT index)

I added a simple regressions test. 