### PR TITLE
Fix `dr.reinterpret_array` to vectorized class pointers

### DIFF
--- a/tests/test_call_ext.py
+++ b/tests/test_call_ext.py
@@ -955,3 +955,19 @@ def test20_partial_output_eval(t, symbolic):
     zo = xo + yo
     assert dr.all(xo == t(10, 12, 0, 21, 24))
     assert dr.all(zo == t(9, 10, 0, 24, 28))
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test21_reinterpret_class(t):
+    pkg = get_pkg(t)
+
+    A, B, BasePtr = pkg.A, pkg.B, pkg.BasePtr
+    a, b = A(), B()
+
+    U = dr.uint32_array_t(t)
+
+    uint32_rep = dr.reinterpret_array(U, BasePtr(a, a, a, b, b))
+    assert dr.all(uint32_rep == [1, 1, 1, 2, 2])
+
+    baseptr_rep = dr.reinterpret_array(BasePtr, uint32_rep)
+    assert isinstance(baseptr_rep, BasePtr)


### PR DESCRIPTION
This PR fixes the following snippet: 
```python
uint32_values = UInt32(...)
ptr = dr.reinterpret_array(BasePtr, uint32_values)
assert isinstance(ptr, BasePtr)
```
Previously, `reinterpret_array` would return a value of type `UInt32` instead of `BasePtr`.

For this to work we must allow reinterpretations of `T::IsClass` types to (and only to) vectorized `uint32_t` types. In addition, we also cannot rely on `meta_get_type` to figure out the correct return type as it is unaware of any class types that were bound by other libraries (e.g Mitsuba).

I've added a unit test covering this behavior. 