### PR TITLE
Fix `gather_` definition for packets (avx2)

### DIFF
--- a/include/drjit/packet_sse42.h
+++ b/include/drjit/packet_sse42.h
@@ -1821,8 +1821,8 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(16)
 
 #if defined(DRJIT_X86_AVX2)
     template <typename Index, typename Mask>
-    static DRJIT_INLINE Derived gather_(const void *ptr, const Index &index, const Mask &mask, bool, ReduceMode) {
-        return Base::gather_(ptr, index, mask & mask_(), false);
+    static DRJIT_INLINE Derived gather_(const void *ptr, const Index &index, const Mask &mask, ReduceMode mode) {
+        return Base::gather_(ptr, index, mask & mask_(), mode);
     }
 #endif
 


### PR DESCRIPTION
Fixes the definition of the `gather_` function in the `packet_sse4.h` file for `X86_AVX2`.