### PR TITLE
Fix DLPack exporting when JIT variables get migrated to the host

### DIFF
--- a/src/python/dlpack.cpp
+++ b/src/python/dlpack.cpp
@@ -144,7 +144,12 @@ static nb::ndarray<> dlpack(nb::handle_t<ArrayBase> h, bool force_cpu, nb::handl
                 ad_scope_enter(drjit::ADScope::Resume, 0, nullptr, false);
                 s2.init_index(ad_index | new_index, inst_ptr(tmp));
                 ad_scope_leave(false);
-                nb::inst_replace_move(owner, tmp);
+                nb::inst_mark_ready(tmp);
+
+                if (backend == JitBackend::CUDA && force_cpu)
+                    owner = std::move(tmp);
+                else
+                    nb::inst_replace_move(owner, tmp);
             }
         } else {
             nb::object arr = nb::borrow(h);

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -101,11 +101,16 @@ def test08_roundtrip_vector_jax(t):
 @pytest.test_arrays('tensor, -bool, -float16, -uint64, -uint32')
 def test09_inplace_numpy(t):
     pytest.importorskip("numpy")
-    a = dr.empty(t, shape=(3, 3, 3))
+    a = dr.zeros(t, shape=(3, 3, 3))
     x = a.numpy()
     x[0,0,0] = 1
 
-    assert a[0,0,0] == x[0,0,0]
+    backend = dr.backend_v(a)
+    if backend == dr.JitBackend.LLVM or backend == dr.JitBackend.Invalid:
+        assert a[0,0,0] == x[0,0,0]
+    elif backend == dr.JitBackend.CUDA:
+        assert a[0,0,0] == 0
+        assert x[0,0,0] == 1
 
 # Test inplace modifications from torch (tensors & dynamic array)
 @pytest.test_arrays('tensor, -bool, -float16, -uint64, -uint32')


### PR DESCRIPTION
(Run for CI)

The DLPack export shouldn't replace the source Python object if it the result of a device->host migration.