### PR TITLE
Fixed tensor initialization creating opaque

### DIFF
--- a/src/python/init.cpp
+++ b/src/python/init.cpp
@@ -677,7 +677,9 @@ int tp_init_tensor(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
         nb::object args_2;
         if (!shape) {
             nb::object flat;
-            if (!is_drjit_type(array_tp) && !is_builtin(array_tp) && nb::ndarray_check(array)) {
+            if(is_builtin(array_tp)){
+                flat = nb::borrow(array);
+            } else if (!is_drjit_type(array_tp) && nb::ndarray_check(array)) {
                 // Try to construct from an instance created by another
                 // array programming framework
                 flat = import_ndarray(s, array, &shape_vec);

--- a/src/python/init.cpp
+++ b/src/python/init.cpp
@@ -677,9 +677,7 @@ int tp_init_tensor(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
         nb::object args_2;
         if (!shape) {
             nb::object flat;
-            if(is_builtin(array_tp)){
-                flat = nb::borrow(array);
-            } else if (!is_drjit_type(array_tp) && nb::ndarray_check(array)) {
+            if (!is_drjit_type(array_tp) && !is_builtin(array_tp) && nb::ndarray_check(array)) {
                 // Try to construct from an instance created by another
                 // array programming framework
                 flat = import_ndarray(s, array, &shape_vec);

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -566,9 +566,8 @@ nb::object ravel(nb::handle h, char order,
     JitBackend backend = JitBackend::None;
     VarType vt = VarType::Float32;
     bool is_dynamic = false, is_diff = false;
-    
 
-    if(tp.is(&PyFloat_Type) || tp.is(&PyLong_Type) || tp.is(&PyBool_Type)){
+    if (tp.is(&PyFloat_Type) || tp.is(&PyLong_Type) || tp.is(&PyBool_Type)) {
         return nb::borrow(h);
     } else if (is_drjit_type(tp)) {
         const ArraySupplement &s = supp(tp);

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -566,8 +566,11 @@ nb::object ravel(nb::handle h, char order,
     JitBackend backend = JitBackend::None;
     VarType vt = VarType::Float32;
     bool is_dynamic = false, is_diff = false;
+    
 
-    if (is_drjit_type(tp)) {
+    if(tp.is(&PyFloat_Type) || tp.is(&PyLong_Type) || tp.is(&PyBool_Type)){
+        return nb::borrow(h);
+    } else if (is_drjit_type(tp)) {
         const ArraySupplement &s = supp(tp);
 
         if (s.is_tensor) {

--- a/tests/test_memop.py
+++ b/tests/test_memop.py
@@ -792,3 +792,15 @@ def test31_scatter_reduce_loop(t, mode, optimize, capsys):
 
         assert v[0] == 64 * 9
         assert dr.all(i == 10)
+
+@pytest.mark.parametrize("order", ["C", "F"])
+@pytest.test_arrays("is_jit, shape=(*)")
+def test32_ravel_builtin(t, order):
+
+    # Get value with builtin type of t
+    x = dr.ones(t, 1)[0]
+
+    y = dr.ravel(x, order = order)
+
+    assert type(x) is type(y)
+    assert x == y

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -551,3 +551,11 @@ def test16_implicit_conversion(t):
     assert dr.allclose(a.tensor(), b.tensor())
     c = tex_t([[[1],[2]], [[3],[4]]])
     assert dr.allclose(a.tensor(), c.tensor())
+
+@pytest.test_arrays('is_tensor, jit, float32')
+def test17_tensor_initialization(t):
+
+    x = t(1.0)
+
+    assert x.state == dr.VarState.Literal
+    


### PR DESCRIPTION
Fixes #267 by moving the `is_builtin` check and not using `ravel` when input is a single variable.