### PR TITLE
Update drjit-core submodule (fix for vectorized call bounds checking)

### DIFF
--- a/src/extra/call.cpp
+++ b/src/extra/call.cpp
@@ -352,7 +352,8 @@ static void ad_call_symbolic(JitBackend backend, const char *domain,
         jit_new_scope(backend);
 
         jit_var_call(
-            combined.c_str(), symbolic, index, mask.index(), (uint32_t) callable_count_final,
+            combined.c_str(), symbolic, index, mask.index(),
+            (uint32_t) callable_count_final, (uint32_t) callable_count,
             inst_id.data(), (uint32_t) args3.size(), args3.data(),
             (uint32_t) rv3.size(), rv3.data(), checkpoints.data(), rv4.data());
 


### PR DESCRIPTION
Follow-up to https://github.com/mitsuba-renderer/drjit-core/pull/98