### PR TITLE
Allow `&` operator with masks to zero out indices

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -174,6 +174,16 @@ ternary ("``?``") operator in C/C++.
    >>> dr.select(mask, -1, a)        # select(mask, true_value, false_value)
    [-1, -1, 0, 1, -1]
 
+Masks can also be applied to arrays in order to zero out the `False` indices by
+using the `&` operator.
+
+.. code-block:: pycon
+
+   >>> a = Float([1, 2, 3])
+   >>> mask = Bool([True, False, True])
+   >>> a & mask
+   [1, 0, 3]
+
 Reductions
 ----------
 

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -413,3 +413,17 @@ def test21_int_promote(t):
     Array2i = dr.int32_array_t(Array2b)
     assert type(dr.select(Array2b(True, False), 1, 2)) is Array2i
     assert type(dr.select(Array2b(True, False), -1, 1)) is Array2i
+
+@pytest.test_arrays('-bool, shape=(*)')
+def test22_and_mask(t):
+    arr = t(1, 2, 3, 4)
+    m = arr < 3
+
+    out = arr & m
+    assert dr.all(out == t(1, 2, 0, 0))
+
+    out = arr & [True, True, False, False]
+    assert dr.all(out == t(1, 2, 0, 0))
+
+    arr &= m
+    assert dr.all(arr == t(1, 2, 0, 0))


### PR DESCRIPTION
Previously we would allow operations like `array & mask` to zero out certain indices in `array`. This PR adds this functionality again (it was already present in C++, but not in Python).