### PR TITLE
Fixed reduce_identity creating intermediate opaque

### DIFF
--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -62,7 +62,6 @@ nb::object reduce_identity(nb::type_object_t<dr::ArrayBase> tp, ReduceOp op, uin
     ArrayMeta m { };
     m.backend = (uint64_t)JitBackend::None;
     m.ndim = 1;
-    m.is_diff = s.is_diff;
     m.type = s.type;
     m.shape[0] = DRJIT_DYNAMIC;
     nb::handle tp2 = meta_get_type(m);

--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -60,19 +60,20 @@ nb::object reduce_identity(nb::type_object_t<dr::ArrayBase> tp, ReduceOp op, uin
     const ArraySupplement &s = supp(tp);
 
     ArrayMeta m { };
-    m.backend = s.backend;
+    m.backend = (uint64_t)JitBackend::None;
     m.ndim = 1;
     m.is_diff = s.is_diff;
     m.type = s.type;
     m.shape[0] = DRJIT_DYNAMIC;
     nb::handle tp2 = meta_get_type(m);
+    const ArraySupplement &s2 = supp(tp2);
 
     nb::object id_elem = nb::inst_alloc(tp2);
-    uint64_t value = jit_reduce_identity((VarType) s.type, op);
-    s.init_data(1, &value, inst_ptr(id_elem));
+    uint64_t value = jit_reduce_identity((VarType) s2.type, op);
+    s2.init_data(1, &value, inst_ptr(id_elem));
     nb::inst_mark_ready(id_elem);
 
-    nb::object result = nb::inst_alloc(tp2);
+    nb::object result = nb::inst_alloc(tp);
     s.init_const(size, false, id_elem[0].ptr(), inst_ptr(result));
     nb::inst_mark_ready(result);
 


### PR DESCRIPTION
The reduce_identity function, is constructing an intermediate variable to initialize the identity element.
With JIT variants, this was constructing an intermediate opaque value via the `init_data` function.
This PR changes the type of the intermediate value from a JIT type to a scalar type, removing the need for the intermediate opaque.

Previously:
```python
In [1]: import drjit as dr

In [2]: dr.set_log_level(dr.LogLevel.Debug)

In [3]: i = dr.detail.reduce_identity(dr.cuda.Float, dr.ReduceOp.Add, 1)
jit_var_new(): float32 r1 = data(<0x302000000>)
jit_var_mem_copy(): float32 r1[1] = copy_from(host, <0x7ffccba48230>)
jit_var_new(): float32 r2 = 0
```

Now:
```python
In [1]: import drjit as dr

In [2]: dr.set_log_level(dr.LogLevel.Debug)

In [3]: i = dr.detail.reduce_identity(dr.cuda.Float, dr.ReduceOp.Add, 1)
jit_var_new(): float32 r1 = 0
```