### PR TITLE
Fixed LoopOp out of bounds read with extra non-grad variables

### DIFF
--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -483,6 +483,8 @@ public:
                 uint32_t ad_index = (uint32_t) (state[i] >> 32);
                 input.is_diff = true;
                 input.has_grad_in = add_index(m_backend, ad_index, true);
+                if(input.has_grad_in)
+                    input.grad_in_index = m_input_indices.size() - 1;
                 input.grad_in_offset = (uint32_t) m_diff_count++;
             }
 
@@ -805,10 +807,8 @@ public:
                 continue;
 
             if (in.has_grad_in) {
-                ad_accum_grad(
-                    combine(m_input_indices[in.grad_in_offset]),
-                    (uint32_t) m_state[offset]
-                );
+                ad_accum_grad(combine(m_input_indices[in.grad_in_index]),
+                              (uint32_t) m_state[offset]);
             }
 
             offset++;
@@ -840,7 +840,8 @@ private:
         /// Does the loop op. produce gradients for this variable?
         bool has_grad_out;
 
-        uint32_t grad_in_offset; // position in m_input_indices
+        uint32_t grad_in_index; // position in m_input_indices
+        uint32_t grad_in_offset; // offset in m_state
         uint32_t grad_out_offset; // position in m_output_indices
     };
     dr::vector<Input> m_inputs;

--- a/src/python/tracker.cpp
+++ b/src/python/tracker.cpp
@@ -545,6 +545,8 @@ bool VariableTracker::Impl::traverse(Context &ctx, nb::handle h) {
 }
 
 uint64_t VariableTracker::Context::_traverse_write(uint64_t idx) {
+    if(!idx)
+        return 0;
     if (index_offset >= indices.size())
         nb::raise("internal error after state variable '%s': ran "
                   "out of indices", label.c_str());
@@ -580,8 +582,9 @@ uint64_t VariableTracker::Context::_traverse_write(uint64_t idx) {
 }
 
 void VariableTracker::Context::_traverse_read(uint64_t index) {
-    ad_var_inc_ref(index);
-    indices.push_back(index);
+    if(!index)
+        return;
+    indices.push_back(ad_var_inc_ref(index));
     index_offset++;
 }
 

--- a/tests/test_while_loop_ad.py
+++ b/tests/test_while_loop_ad.py
@@ -211,7 +211,7 @@ def test09_sum_loop_extra(t, mode):
     # after the differentiable ones.
 
     @dr.syntax
-    def loop(l: list, t):
+    def loop(l: list, t, mode):
         mod = sys.modules[t.__module__]
         Float = mod.Float
         UInt = mod.UInt
@@ -234,7 +234,7 @@ def test09_sum_loop_extra(t, mode):
     dr.enable_grad(l[1])
 
     for _ in range(10):
-        y = loop(l, t)
+        y = loop(l, t, mode)
 
         loss = dr.mean(dr.square(y))
 


### PR DESCRIPTION
This PR fixes 3 issues with loops.

First, when adding loop state variables to a differentiable `LoopOp`, and some of them do not have gradients attached, the `grad_in_offset` might not correspond to the index in `m_input_indices`.
When indexing into this array using that index an out-of-bounds access occurs.
This is fixed by adding another index `grad_in_index` to the `Input` struct that always tracks the index in `m_input_indices`.

Second, AD-variables that are added to the loop state in a suspended scope, from a opaque C++ object, would not get their AD refcount incremented. It would however be decremented when releasing the temporary state arrays, causing refcounting problems.

Third, this PR enables adding non-initialized variables from the opaque C++ traversal, which is necessary for traversing shapes which might or might not have vertex normals attached.

