### PR TITLE
Fix loop state aliasing

### DIFF
--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -60,6 +60,17 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
         indices1.release();
         indices2.clear();
 
+        // Read back the indices to update the loop state variables
+        // This is necessary to catch cases where a variable is added to the
+        // loop state twice.
+        read_cb(payload, indices1);
+        for (uint32_t i : indices1) {
+            indices2.push_back((uint32_t) i);
+        }
+        jit_var_loop_update_inner_in(loop.index(), indices2.data());
+        indices1.clear();
+        indices2.clear();
+
         do {
             // Evaluate the loop condition
             uint32_t active_initial = cond_cb(payload);

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -68,7 +68,7 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
             indices2.push_back((uint32_t) i);
         }
         jit_var_loop_update_inner_in(loop.index(), indices2.data());
-        indices1.clear();
+        indices1.release();
         indices2.clear();
 
         do {

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -648,7 +648,7 @@ def test28_loop_state_aliasing(t):
     # Test that we can add a variable to a loop twice
 
     @dr.syntax
-    def loop(t, x: list[t], y: t, n = 10):
+    def loop(t, x, y: t, n = 10):
         
         i = t(0)
         while dr.hint(i < n):

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -642,3 +642,25 @@ def test27_partial_eval(t, mode):
 
     assert idx == 3 # Only evaluate loop state partially
     assert val + idx == 15 # Re-use partially evaluated state
+    
+@pytest.test_arrays('uint32,jit,shape=(*)')
+def test28_loop_state_aliasing(t):
+    # Test that we can add a variable to a loop twice
+
+    @dr.syntax
+    def loop(t, x: list[t], y: t, n = 10):
+        
+        i = t(0)
+        while dr.hint(i < n):
+            # Somewhat complicated gather that cannot be elided
+            y += dr.gather(t, x[0], y) 
+            i += 1
+
+        return y
+    
+    x = dr.arange(t, 100)
+    y = dr.arange(t, 5)
+
+    dr.make_opaque(x, y)
+    
+    y = loop(t, [x, x], y)


### PR DESCRIPTION
When adding the same variable to the loop state twice, the recording algorithm was not able to eliminate that variable from the loop state, even if it was a "loop-invariant state variable".
The reason is that for each occurrence of that variable a separate phi node is created.
When writing those indices back to the C++/Python objects, the variable only gets assigned one of them.
This causes a mismatch between the `inner_in` field and the indices acquired when traversing the C++/Py-tree.
I fixed this by reading back those indices and updating the `inner_in` field directly after writing them to the tree.