### PR TITLE
Support for indexing into zero-dim tensor

### DIFF
--- a/src/python/print.cpp
+++ b/src/python/print.cpp
@@ -107,7 +107,7 @@ static void repr_array(Buffer &buffer, nb::handle h, size_t indent,
             } else {
                 nb::object o = h[nb::tuple(index)];
 
-                if (s.is_tensor)
+                if (s.is_tensor && is_drjit_type(o.type()))
                     o = nb::steal(s.tensor_array(o.ptr()))[0];
 
                 if (PyFloat_CheckExact(o.ptr())) {

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -559,3 +559,18 @@ def test17_tensor_initialization(t):
 
     assert x.state == dr.VarState.Literal
     
+@pytest.test_arrays('is_tensor, float')
+def test18_slice_zero_dim(t):
+    x = dr.mean(t([1, 1, 4, 10], shape=(2, 2, 1)), axis=None)
+    assert x[0] == 4
+    assert type(x[0]) == float
+    assert x[0,:] == 4
+    assert x[:] == 4
+    assert x[-1] == 4
+
+    x[0] = 5
+    assert x[0] == 5
+
+    with pytest.raises(TypeError) as ei:
+        x[1]
+    assert "index 1 is out of bounds" in str(ei.value)


### PR DESCRIPTION
A common pattern in the Mitsuba tutorials is to perform a reduction on a tensor across all axes and then fetch the single scalar value. e.g.

```python
# TensorXf type of shape=()
y = dr.mean(tensor, axis=None)

# Scalar type
x = y[0]
```

The PR adds this feature to zero-index into these tensors. Note, that for consistency compatible slices (e.g. `y[-1]`) are also still valid and slice assignment is additionally supported.