### PR TITLE
Avoid generating stubs twice on Windows

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -241,15 +241,21 @@ if (NOT (DRJIT_SANITIZE_ASAN OR DRJIT_SANITIZE_UBSAN))
   endif()
 endif()
 
-foreach (NAME __init__ ad)
-  add_custom_command(
-    OUTPUT ${DRJIT_PYTHON_DST_DIR}/auto/${NAME}.pyi
-    DEPENDS ${DRJIT_PYTHON_DST_DIR}/llvm/${NAME}.pyi
-    COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/auto-stub.cmake
-      ${DRJIT_PYTHON_DST_DIR}/llvm/${NAME}.pyi
-      ${DRJIT_PYTHON_DST_DIR}/auto/${NAME}.pyi
-  )
-endforeach()
+add_custom_command(
+  OUTPUT ${DRJIT_PYTHON_DST_DIR}/auto/__init__.pyi
+  DEPENDS drjit-stub-llvm
+  COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/auto-stub.cmake
+    ${DRJIT_PYTHON_DST_DIR}/llvm/__init__.pyi
+    ${DRJIT_PYTHON_DST_DIR}/auto/__init__.pyi
+)
+
+add_custom_command(
+  OUTPUT ${DRJIT_PYTHON_DST_DIR}/auto/ad.pyi
+  DEPENDS drjit-stub-llvm-ad
+  COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/auto-stub.cmake
+    ${DRJIT_PYTHON_DST_DIR}/llvm/ad.pyi
+    ${DRJIT_PYTHON_DST_DIR}/auto/ad.pyi
+)
 
 add_custom_command(
   OUTPUT


### PR DESCRIPTION
As with Mitsuba PR [1317](https://github.com/mitsuba-renderer/mitsuba3/pull/1317), the Dr.Jit stubs were similarly being generated twice on Windows.

Although less frequent, there are examples on the Windows CI of failed builds that appear to be because of race conditions as stub files are attempted to be written into by two independent processes.