### PR TITLE
TraversableBase intrusive interface

### DIFF
--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -54,6 +54,9 @@
 #include <drjit/math.h>
 #include <drjit-core/python.h>
 #include <nanobind/stl/array.h>
+#include <nanobind/intrusive/counter.h>
+#include "nanobind/nanobind.h"
+#include "drjit/traversable_base.h"
 
 NAMESPACE_BEGIN(drjit)
 struct ArrayBinding;
@@ -1074,6 +1077,37 @@ template <typename T, typename... Args> auto& bind_traverse(nanobind::class_<T, 
     });
 
     return cls;
+}
+
+inline void traverse_py_cb_ro(const TraversableBase *base, void *payload,
+                              void (*fn)(void *, uint64_t)) {
+    namespace nb    = nanobind;
+    nb::handle self = base->self_py();
+    if (!self)
+        return;
+
+    auto detail = nb::module_::import_("drjit.detail");
+    nb::callable traverse_py_cb_ro =
+        nb::borrow<nb::callable>(nb::getattr(detail, "traverse_py_cb_ro"));
+
+    traverse_py_cb_ro(
+        self, nb::cpp_function([&](uint64_t index) { fn(payload, index); }));
+}
+inline void traverse_py_cb_rw(TraversableBase *base, void *payload,
+                              uint64_t (*fn)(void *, uint64_t)) {
+
+    namespace nb    = nanobind;
+    nb::handle self = base->self_py();
+    if (!self)
+        return;
+
+    auto detail = nb::module_::import_("drjit.detail");
+    nb::callable traverse_py_cb_rw =
+        nb::borrow<nb::callable>(nb::getattr(detail, "traverse_py_cb_rw"));
+
+    traverse_py_cb_rw(self, nb::cpp_function([&](uint64_t index) {
+                          return fn(payload, index);
+                      }));
 }
 
 NAMESPACE_END(drjit)

--- a/include/drjit/texture.h
+++ b/include/drjit/texture.h
@@ -17,6 +17,7 @@
 #include <drjit/idiv.h>
 #include <drjit/jit.h>
 #include <drjit/tensor.h>
+#include "drjit/traversable_base.h"
 
 #pragma once
 
@@ -41,7 +42,7 @@ enum class CudaTextureFormat : uint32_t {
     Float16 = 1, /// Half precision storage format
 };
 
-template <typename _Storage, size_t Dimension> class Texture {
+template <typename _Storage, size_t Dimension> class Texture : TraversableBase {
 public:
     static constexpr bool IsCUDA = is_cuda_v<_Storage>;
     static constexpr bool IsDiff = is_diff_v<_Storage>;
@@ -1386,6 +1387,9 @@ private:
     WrapMode m_wrap_mode;
     bool m_use_accel = false;
     mutable bool m_migrated = false;
+
+    DR_TRAVERSE_CB(drjit::TraversableBase, m_value, m_shape_opaque,
+                   m_inv_resolution);
 };
 
 NAMESPACE_END(drjit)

--- a/include/drjit/traversable_base.h
+++ b/include/drjit/traversable_base.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "array_traverse.h"
+#include "drjit-core/macros.h"
+#include "nanobind/intrusive/counter.h"
+#include "nanobind/intrusive/ref.h"
+#include <drjit-core/jit.h>
+#include <drjit/map.h>
+
+NAMESPACE_BEGIN(drjit)
+
+/// Interface for traversing C++ objects.
+struct TraversableBase : nanobind::intrusive_base {
+    virtual void traverse_1_cb_ro(void *, void (*)(void *, uint64_t)) const = 0;
+    virtual void traverse_1_cb_rw(void *, uint64_t (*)(void *, uint64_t))   = 0;
+};
+
+/// Macro for generating call to traverse_1_fn_ro for a class member
+#define DR_TRAVERSE_MEMBER_RO(member)                                          \
+    drjit::log_member_open(false, #member);                                    \
+    drjit::traverse_1_fn_ro(member, payload, fn);                              \
+    drjit::log_member_close();
+/// Macro for generating call to traverse_1_fn_rw for a class member
+#define DR_TRAVERSE_MEMBER_RW(member)                                          \
+    drjit::log_member_open(true, #member);                                     \
+    drjit::traverse_1_fn_rw(member, payload, fn);                              \
+    drjit::log_member_close();
+
+inline void log_member_open(bool rw, const char *member) {
+    jit_log(LogLevel::Debug, "%s%s{", rw ? "rw " : "ro ", member);
+}
+
+inline void log_member_close() { jit_log(LogLevel::Debug, "}"); }
+
+#define DR_TRAVERSE_CB_RO(Base, ...)                                           \
+    void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t))         \
+        const override {                                                       \
+        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
+            Base::traverse_1_cb_ro(payload, fn);                               \
+        DRJIT_MAP(DR_TRAVERSE_MEMBER_RO, __VA_ARGS__)                          \
+    }
+
+#define DR_TRAVERSE_CB_RW(Base, ...)                                           \
+    void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t))     \
+        override {                                                             \
+        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
+            Base::traverse_1_cb_rw(payload, fn);                               \
+        DRJIT_MAP(DR_TRAVERSE_MEMBER_RW, __VA_ARGS__)                          \
+    }
+
+/// Macro to generate traverse_1_cb_ro and traverse_1_cb_rw methods for each
+/// member in the list.
+#define DR_TRAVERSE_CB(Base, ...)                                              \
+public:                                                                        \
+    DR_TRAVERSE_CB_RO(Base, __VA_ARGS__)                                       \
+    DR_TRAVERSE_CB_RW(Base, __VA_ARGS__)
+
+#define DR_TRAMPOLINE_TRAVERSE_CB(Base)                                        \
+public:                                                                        \
+    void traverse_1_cb_ro(void *payload, void (*fn)(void *, uint64_t))         \
+        const override {                                                       \
+        if constexpr (!std ::is_same_v<Base, drjit ::TraversableBase>)         \
+            Base ::traverse_1_cb_ro(payload, fn);                              \
+        drjit::traverse_py_cb_ro(this, payload, fn);                           \
+    }                                                                          \
+    void traverse_1_cb_rw(void *payload, uint64_t (*fn)(void *, uint64_t))     \
+        override {                                                             \
+        if constexpr (!std ::is_same_v<Base, drjit ::TraversableBase>)         \
+            Base ::traverse_1_cb_rw(payload, fn);                              \
+        drjit::traverse_py_cb_rw(this, payload, fn);                           \
+    }
+
+#if defined(_MSC_VER)
+#define DRJIT_EXPORT __declspec(dllexport)
+#else
+#define DRJIT_EXPORT __attribute__((visibility("default")))
+#endif
+
+NAMESPACE_END(drjit)

--- a/src/python/apply.h
+++ b/src/python/apply.h
@@ -57,7 +57,7 @@ struct TraverseCallback {
     // Type-erased form which is needed in some cases to traverse into opaque
     // C++ code. This one just gets called with Jit/AD variable indices, an
     // associated Python/ instance/type is not available.
-    virtual void operator()(uint64_t index);
+    virtual uint64_t operator()(uint64_t index);
 
     // Traverse an unknown object
     virtual void traverse_unknown(nb::handle h);
@@ -93,8 +93,8 @@ struct TransformPairCallback {
 };
 
 /// Invoke the given callback on leaf elements of the pytree 'h'
-extern void traverse(const char *op, TraverseCallback &callback,
-                     nb::handle h);
+extern void traverse(const char *op, TraverseCallback &callback, nb::handle h,
+                     bool rw = false);
 
 /// Parallel traversal of two compatible pytrees 'h1' and 'h2'
 extern void traverse_pair(const char *op, TraversePairCallback &callback,

--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -383,20 +383,14 @@ void export_detail(nb::module_ &) {
      .def("scope", &jit_scope, "backend"_a, doc_detail_scope)
      .def("set_scope", &jit_set_scope, "backend"_a, "scope"_a, doc_detail_set_scope);
 
-<<<<<<< HEAD
 #if defined(DRJIT_DISABLE_LEAK_WARNINGS)
     set_leak_warnings(false);
 #endif
 
     d.def("leak_warnings", &leak_warnings, doc_leak_warnings);
     d.def("set_leak_warnings", &set_leak_warnings, doc_set_leak_warnings);
-=======
     d.def("traverse_py_cb_ro", &traverse_py_cb_ro_impl);
     d.def("traverse_py_cb_rw", traverse_py_cb_rw_impl);
-
-    d.def("traverse_py_cb_ro", &traverse_py_cb_ro_impl);
-    d.def("traverse_py_cb_rw", traverse_py_cb_rw_impl);
->>>>>>> 2db44b1b (Added traversal helpers for trampoline classes)
 
     trace_func_handle = d.attr("trace_func");
 }

--- a/src/python/eval.cpp
+++ b/src/python/eval.cpp
@@ -57,12 +57,8 @@ static void make_opaque(nb::handle h) {
             if (rv)
                 result = true;
 
-            if (index != index_new) {
-                nb::object tmp = nb::inst_alloc(tp);
-                s.init_index(index_new, inst_ptr(tmp));
-                nb::inst_mark_ready(tmp);
-                nb::inst_replace_move(h, tmp);
-            }
+            if (index != index_new)
+                s.reset_index(index_new, inst_ptr(h));
 
             ad_var_dec_ref(index_new);
         }


### PR DESCRIPTION
This PR adds a `TraversableBase` class with the `traverse_1_cb_ro` and `traverse_1_cb_rw` functions and implements the `nanobind::intrusive_base` class.
The class can be implemented for any sub-class that should be traversable, and the functions can be generated by the `DR_TRAVERSE` macros.
It also changes the `TraverseCallback::operator()` function, which now returns a `uint64_t`. This is required to implement a `make_opaque` function, that is able to traverse `C++` objects.
