### PR TITLE
Changing default behaviour of reductions for tensor types.

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1562,53 +1562,6 @@ def reverse(value, axis: int = 0):
             result = tp(result)
         return result
 
-
-def mean(value: object, axis: Union[int, Tuple[int, ...], None] = 0,
-         mode: Literal['symbolic', 'evaluated', None] = None) -> object:
-    """
-    Compute the mean of the input array or tensor along one or multiple axes.
-
-    This function performs a horizontal sum reduction by adding values of the
-    input array, tensor, or Python sequence along one or multiple axes and then
-    dividing by the number of entries. By default, it sums along the outermost
-    axis; specify ``axis=None`` to sum over all of them at once. The mean
-    of an empty array is considered to be zero.
-
-    See the section on :ref:`horizontal reductions <horizontal-reductions>` for
-    important general information about their properties.
-
-    Args:
-        value (float | int | Sequence | drjit.ArrayBase): A Python or Dr.Jit arithmetic type
-
-        axis (int | None): The axis along which to reduce (Default: ``0``). A value
-            of ``None`` causes a simultaneous reduction along all axes. Currently, only
-            values of ``0`` and ``None`` are supported.
-
-    Returns:
-        float | int | drjit.ArrayBase: Result of the reduction operation)";
-    """
-    sh = shape(value)
-    ndim = len(sh)
-
-    axis2: Tuple[int, ...]
-    if axis is None:
-        axis2 = tuple(range(ndim))
-    elif isinstance(axis, int):
-        axis2 = () if ndim == 0 else (axis, )
-    else:
-        axis2 = tuple(set(axis))
-
-    size = 1
-    for i in axis2:
-        if i < 0:
-            i += ndim
-        if i < 0 or i >= ndim:
-            raise IndexError(f"drjit.mean({type(value)}): out-of-bounds axis {i}")
-        size *= sh[i]
-
-    return sum(value, axis, mode) / size
-
-
 def sh_eval(d: ArrayBase, order: int) -> list:
     """
     Evalute real spherical harmonics basis function up to a specified order.

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -747,8 +747,10 @@
         value (ArrayBase | Iterable | float | int): An input Dr.Jit array,
           tensor, iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
         mode (str | None): optional parameter to force an evaluation strategy.
           Must equal ``"evaluated"``, ``"symbolic"``, or ``None``.
@@ -769,8 +771,10 @@
         value (ArrayBase | Iterable | float | int): An input Dr.Jit array,
           tensor, iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
         mode (str | None): optional parameter to force an evaluation strategy.
           Must equal ``"evaluated"``, ``"symbolic"``, or ``None``.
@@ -795,8 +799,10 @@
         value (ArrayBase | Iterable | float | int): An input Dr.Jit array,
           tensor, iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
         mode (str | None): optional parameter to force an evaluation strategy.
           Must equal ``"evaluated"``, ``"symbolic"``, or ``None``.
@@ -821,8 +827,36 @@
         value (ArrayBase | Iterable | float | int): An input Dr.Jit array, tensor,
           iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
+
+        mode (str | None): optional parameter to force an evaluation strategy.
+          Must equal ``"evaluated"``, ``"symbolic"``, or ``None``.
+
+    Returns:
+        The reduced array or tensor as specified above.
+
+.. topic:: mean
+    Compute the mean of the input array or tensor along one or multiple axes.
+
+    This function performs a horizontal sum reduction by adding values of the
+    input array, tensor, or Python sequence along one or multiple axes and then
+    dividing by the number of entries. The mean of an empty array is considered
+    to be zero.
+
+    See the section on :ref:`horizontal reductions <horizontal-reductions>` for
+    important general information about their properties.
+
+    Args:
+        value (ArrayBase | Iterable | float | int): An input Dr.Jit array, tensor,
+          iterable, or scalar Python type.
+
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
         mode (str | None): optional parameter to force an evaluation strategy.
           Must equal ``"evaluated"``, ``"symbolic"``, or ``None``.
@@ -837,8 +871,8 @@
     Given a boolean-valued input array, tensor, or Python sequence, this function
     reduces elements using the ``&`` (AND) operator.
 
-    By default, it reduces along index ``0``, which refers to the outermost axis.
-    Negative indices (e.g. ``-1``) count backwards from the innermost axis. The
+    Reductions along index ``0`` refer to the outermost axis and negative
+    indices (e.g. ``-1``) count backwards from the innermost axis. The
     special argument ``axis=None`` causes a simultaneous reduction over all axes.
     Note that the reduced form of an *empty* array is considered to be ``True``.
 
@@ -892,8 +926,10 @@
         value (ArrayBase | Iterable | bool): An input Dr.Jit array, tensor,
           iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
     Returns:
         object: The reduced array or tensor as specified above.
@@ -905,8 +941,8 @@
     Given a boolean-valued input array, tensor, or Python sequence, this function
     reduces elements using the ``|`` (OR) operator.
 
-    By default, it reduces along index ``0``, which refers to the outermost axis.
-    Negative indices (e.g. ``-1``) count backwards from the innermost axis. The
+    Reductions along index ``0`` refer to the outermost axis and negative
+    indices (e.g. ``-1``) count backwards from the innermost axis. The
     special argument ``axis=None`` causes a simultaneous reduction over all axes.
     Note that the reduced form of an *empty* array is considered to be ``False``.
 
@@ -960,8 +996,10 @@
         value (ArrayBase | Iterable | bool): An input Dr.Jit array, tensor,
           iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
     Returns:
         bool | drjit.ArrayBase: Result of the reduction operation
@@ -1024,8 +1062,10 @@
         value (ArrayBase | Iterable | bool): An input Dr.Jit array, tensor,
           iterable, or scalar Python type.
 
-        axes (int | tuple[int, ...] | None): The axis/axes along which
-          to reduce. The default value is ``0``.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
     Returns:
         bool | drjit.ArrayBase: Result of the reduction operation
@@ -6826,8 +6866,8 @@
     ``1`` and ``False`` elements as ``0``). It returns an unsigned 32-bit version
     of the input array.
 
-    By default, it reduces along index ``0``, which refers to the outermost axis.
-    Negative indices (e.g. ``-1``) count backwards from the innermost axis. The
+    Reductions along index ``0`` refer to the outermost axis and negative 
+    indices (e.g. ``-1``) count backwards from the innermost axis. The
     special argument ``axis=None`` causes a simultaneous reduction over all axes.
     Note that the reduced form of an *empty* array is considered to be zero.
 
@@ -6837,10 +6877,10 @@
     Args:
         value (bool | Sequence | drjit.ArrayBase): A Python or Dr.Jit mask type
 
-        axis (int | None): The axis along which to reduce. The default value of
-          ``0`` refers to the outermost axis. Negative values count backwards from
-          the innermost axis. A value of ``None`` causes a simultaneous reduction
-          along all axes.
+        axis (int | tuple[int, ...] | ... | None): The axis/axes along which
+          to reduce. The special argument ``axis=None`` causes a simultaneous 
+          reduction over all axes. The default ``axis=...`` applies a 
+          reduction over all axes for tensor types and index ``0`` otherwise.
 
     Returns:
         int | drjit.ArrayBase: Result of the reduction operation

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -96,11 +96,11 @@ def test04_sum(t):
     m = sys.modules[t.__module__]
     assert dr.allclose(dr.sum(6.0), 6)
 
-    a = dr.sum(m.Float([1, 2, 3]), mode='evaluated')
+    a = dr.sum(m.Float([1, 2, 3]), axis=0, mode='evaluated')
     assert dr.allclose(a, 6)
     assert type(a) is m.Float
 
-    a = dr.sum(m.Float([1, 2, 3]), mode='symbolic')
+    a = dr.sum(m.Float([1, 2, 3]), axis=0, mode='symbolic')
     assert dr.allclose(a, 6)
     assert type(a) is m.Float
 

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -96,11 +96,11 @@ def test04_sum(t):
     m = sys.modules[t.__module__]
     assert dr.allclose(dr.sum(6.0), 6)
 
-    a = dr.sum(m.Float([1, 2, 3]), axis=0, mode='evaluated')
+    a = dr.sum(m.Float([1, 2, 3]), mode='evaluated')
     assert dr.allclose(a, 6)
     assert type(a) is m.Float
 
-    a = dr.sum(m.Float([1, 2, 3]), axis=0, mode='symbolic')
+    a = dr.sum(m.Float([1, 2, 3]), mode='symbolic')
     assert dr.allclose(a, 6)
     assert type(a) is m.Float
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -200,7 +200,7 @@ def test06_reduce(t, drjit_verbose, capsys):
     assert msg.count('jit_any') == 1
     assert msg.count('jit_all') == 1
 
-    v_any = dr.any(v)
+    v_any = dr.any(v, axis=0)
     msg = capsys.readouterr().out
     assert msg.count('= or(') == 1
 


### PR DESCRIPTION
Changing default behaviour of reductions for tensor types.

To be consistent with past releases, we make `axis=None` for tensor types, and `axis=0` otherwise. A default value of `axis=...` is used to capture this behaviour.

Also move `mean` to cpp implementation