### PR TITLE
Add Python bindings for the jit_scope functions

### DIFF
--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -321,7 +321,11 @@ void export_detail(nb::module_ &) {
 
      .def("can_scatter_reduce", &can_scatter_reduce, doc_detail_can_scatter_reduce)
 
-     .def("cuda_compute_capability", &jit_cuda_compute_capability);
+     .def("cuda_compute_capability", &jit_cuda_compute_capability)
+
+     .def("new_scope", &jit_new_scope, "backend"_a, doc_detail_new_scope)
+     .def("scope", &jit_scope, "backend"_a, doc_detail_scope)
+     .def("set_scope", &jit_set_scope, "backend"_a, "scope"_a, doc_detail_set_scope);
 
     trace_func_handle = d.attr("trace_func");
 }

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -5380,6 +5380,33 @@
    Check if the underlying backend supports a desired flavor of
    scatter-reduction for the given array type.
 
+.. topic:: detail_new_scope
+
+   Set a new scope identifier to separate basic blocks.
+
+   Several steps of Dr.Jit's compilation rely on the definition of
+   a "basic block", which marks the boundary for certain optimizations
+   and re-orderings to take place (e.g., common subexpression elimination).
+
+   When executing Dr.Jit computation on different threads, the user
+   has to ensure that basic blocks are separated between threads.
+   Before a thread T2 references Dr.Jit arrays created by another thread T1,
+   it must create a new scope to guarantee that dependencies between them
+   are correctly tracked and ordered during the compilation process. Dr.Jit
+   checks for violations of this condition and will raise an exception when
+   attempting to evaluate incorrectly ordered expressions.
+
+   This function sets a unique, new scope identifier (a simple 32 bit integer)
+   to separate any of the following computation from the previous basic block.
+
+.. topic:: detail_scope
+
+    Queries the scope identifier (see :py:func:`drjit.detail.new_scope())
+
+.. topic:: detail_set_scope
+
+    Manually sets a scope identifier (see :py:func:`drjit.detail.new_scope())
+
 .. topic:: JitFlag
 
     Flags that control how Dr.Jit compiles and optimizes programs.

--- a/tests/test_detail.py
+++ b/tests/test_detail.py
@@ -1,0 +1,11 @@
+import drjit as dr
+
+
+def test01_jit_scope():
+    backend = dr.JitBackend.LLVM
+    scope = dr.detail.scope(backend)
+    dr.detail.new_scope(backend)
+    assert dr.detail.scope(backend) > scope
+
+    dr.detail.set_scope(backend, scope)
+    assert dr.detail.scope(backend) == scope


### PR DESCRIPTION
This adds the missing Python bindings for the Jit scope calls. The motivation for this it to allow users to explicitly separate different Python threads and their CSE.

I added some documentation and a simple test. What remains an open TODO for the future would be to more rigorously document Dr.Jit's thread safety behavior somewhere in the documentation.
