### PR TITLE
Differentiable prefix reduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,6 @@ option(DRJIT_ENABLE_AUTODIFF  "Build Dr.Jit automatic differentation library?" O
 option(DRJIT_ENABLE_PYTHON    "Build Python extension library?" ON)
 option(DRJIT_ENABLE_TESTS     "Build Dr.Jit test suite? (Warning, this takes *very* long to compile)" OFF)
 
-if (NOT MSVC)
-  option(DRJIT_SANITIZE_UBSAN   "Enable the address sanitizer (GCC, Clang)" OFF)
-  option(DRJIT_SANITIZE_ASAN    "Enable the undefined behavior sanitizer (GCC, Clang)" OFF)
-  option(DRJIT_SANITIZE_INTENSE "Add costly internal instrumentation to catch undefined behavior." OFF)
-endif()
-
 # ----------------------------------------------------------
 #  Check if submodules have been checked out, or fail early
 # ----------------------------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -150,7 +150,7 @@ Here is what's new:
   which combines the benefits of both steps. This is particularly useful when
   computing the reverse-mode derivative of packet reads.
 
-- **Reductions operations**: reductions previously existed as *regular* (e.g.,
+- **Reductions**: reduction operations previously existed as *regular* (e.g.,
   :py:func:`drjit.all`) and *nested* (e.g. ``drjit.all_nested``) variants. Both
   are now subsumed by an optional ``axis`` argument similar to how this works
   in other array programming frameworks like NumPy. Reductions can now also
@@ -158,7 +158,7 @@ Here is what's new:
 
   The reduction functions (:py:func:`drjit.all` :py:func:`drjit.any`,
   :py:func:`drjit.sum`, :py:func:`drjit.prod`, :py:func:`drjit.min`,
-  :py:func:`drjit.max`) have different default axis values depending on the 
+  :py:func:`drjit.max`) have different default axis values depending on the
   input type. For tensors, ``axis=None`` by default and the reduction is
   performed along the entire underlying array recursively, analogous to the
   previous nested reduction. For all other types, the reduction is performed
@@ -166,6 +166,16 @@ Here is what's new:
 
   Aliases for the ``_nested`` function variants still exist to help porting but
   are deprecated and will be removed in a future release.
+
+- **Prefix reductions**: the functions :py:func:`drjit.cumsum`,
+  :py:func:`drjit.prefix_sum` compute inclusive or exclusive prefix sums along
+  arbitrary axes of a tensor or array. They wrap for the more general
+  :py:func:`drjit.prefix_reduce` that also supports other arithmetic operations
+  (e.g. minimum/maximum/product/and/or reductions), reverse reductions, etc.
+
+- **Block reductions**: the new functions :py:func:`drjit.block_reduce` and
+  :py:func:`drjit.block_prefix_reduce` compute reductions within contiguous
+  blocks of an array.
 
 - **Local memory**: kernels can now allocate temporary thread-local memory and
   perform arbitrary indexed reads and writes. This is useful to implement a

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -50,25 +50,23 @@ Control flow
 .. autofunction:: switch
 .. autofunction:: dispatch
 
-.. _horizontal-reductions-ref:
-
-Horizontal operations
----------------------
-
-These operations are *horizontal* in the sense that [..]
+Scatter/gather operations
+-------------------------
 
 .. autofunction:: gather
 .. autofunction:: scatter
-
-.. autoenum:: ReduceOp
-.. autoenum:: ReduceMode
 
 .. autofunction:: scatter_reduce
 .. autofunction:: scatter_add
 .. autofunction:: scatter_add_kahan
 .. autofunction:: scatter_inc
-.. autofunction:: block_reduce
-.. autofunction:: block_sum
+.. autofunction:: slice
+
+Reductions
+----------
+
+.. autoenum:: ReduceOp
+.. autoenum:: ReduceMode
 
 .. autofunction:: reduce
 .. autofunction:: sum
@@ -86,15 +84,30 @@ These operations are *horizontal* in the sense that [..]
 .. autofunction:: abs_dot
 .. autofunction:: squared_norm
 .. autofunction:: norm
+
+Prefix reductions
+-----------------
+
+.. autofunction:: prefix_reduce
 .. autofunction:: prefix_sum
 .. autofunction:: cumsum
-.. autofunction:: reverse
 
+Block reductions
+----------------
+
+.. autofunction:: block_reduce
+.. autofunction:: block_sum
+.. autofunction:: block_prefix_reduce
+.. autofunction:: block_prefix_sum
+
+Rearranging array contents
+--------------------------
+
+.. autofunction:: reverse
 .. autofunction:: compress
 .. autofunction:: ravel
 .. autofunction:: unravel
 .. autofunction:: reshape
-.. autofunction:: slice
 .. autofunction:: tile
 .. autofunction:: repeat
 

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1404,20 +1404,6 @@ def mulsign(arg0, arg1, /):
     return select(arg1 >= 0, arg0, -arg0)
 
 
-def cumsum(arg, /):
-    '''
-    Compute an cumulative sum (aka. inclusive prefix sum) of the input array.
-
-    This function wraps :py:func:`drjit.prefix_sum` and is implemented as
-
-    .. code-block:: python
-
-       def cumsum(arg, /):
-           return prefix_sum(arg, exclusive=False)
-    '''
-    return prefix_sum(arg, exclusive=False)
-
-
 def hypot(a, b, /):
     '''
     Computes :math:`\\sqrt{a^2+b^2}` while avoiding overflow and underflow.
@@ -2037,6 +2023,7 @@ def assert_equal(
         tb_skip=tb_skip+1,
         **kwargs,
     )
+
 
 newaxis = None
 

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -381,18 +381,18 @@ struct DRJIT_TRIVIAL_ABI DiffArray
 
     #undef DRJIT_HORIZONTAL_OP
 
-    DiffArray prefix_sum_(bool exclusive) const {
-        if constexpr (IsFloat)
-            return steal(ad_var_prefix_sum(m_index, exclusive));
-        else
-            return steal(jit_var_prefix_sum(m_index, exclusive));
-    }
-
     DiffArray block_reduce_(ReduceOp op, size_t block_size, int symbolic) const {
         if constexpr (IsFloat)
             return steal(ad_var_block_reduce(op, m_index, (uint32_t) block_size, symbolic));
         else
             return steal(jit_var_block_reduce(op, m_index, (uint32_t) block_size, symbolic));
+    }
+
+    DiffArray block_prefix_reduce_(ReduceOp op, uint32_t block_size, bool exclusive, bool reverse) const {
+        if constexpr (IsFloat)
+            return steal(ad_var_block_prefix_reduce(op, m_index, block_size, exclusive, reverse));
+        else
+            return steal(jit_var_block_prefix_reduce(op, m_index, block_size, exclusive, reverse));
     }
 
     DiffArray tile_(size_t count) const {

--- a/include/drjit/call.h
+++ b/include/drjit/call.h
@@ -85,17 +85,17 @@ private:                                                                       \
                                         vectorize_rv_t<Self, Ret>>;            \
         using CallStateT = detail::CallState<Ret2, Args...>;                   \
                                                                                \
-        ad_call_func callback = [](void *state_p, void *self,                  \
+        ad_call_func callback = [](void *state_p, void *self_,                 \
                                    const vector<uint64_t> &args_i,             \
                                    vector<uint64_t> &rv_i) {                   \
             CallStateT *state = (CallStateT *) state_p;                        \
             state->update_args(args_i);                                        \
             if constexpr (std::is_same_v<Ret, void>) {                         \
-                if (detail::is_valid_call_ptr<Class_, Base_>(self))            \
-                    ((Class_ *) self)->Name(drjit::get<Is>(state->args)...);   \
+                if (detail::is_valid_call_ptr<Class_, Base_>(self_))           \
+                    ((Class_ *) self_)->Name(drjit::get<Is>(state->args)...);  \
             } else {                                                           \
-                if (detail::is_valid_call_ptr<Class_, Base_>(self))            \
-                    state->rv = ((Class_ *) self)                              \
+                if (detail::is_valid_call_ptr<Class_, Base_>(self_))           \
+                    state->rv = ((Class_ *) self_)                             \
                                     ->Name(drjit::get<Is>(state->args)...);    \
                 else                                                           \
                     state->rv = zeros<Ret2>();                                 \
@@ -114,12 +114,12 @@ public:                                                                        \
             vectorize_rv_t<Self, decltype(std::declval<Class_ &>().Name())>;   \
         using CallStateT = detail::CallState<Ret, Mask_>;                      \
                                                                                \
-        ad_call_func callback = [](void *state_p, void *self,                  \
+        ad_call_func callback = [](void *state_p, void *self_,                 \
                                    const vector<uint64_t> &,                   \
                                    vector<uint64_t> &rv_i) {                   \
             CallStateT *state = (CallStateT *) state_p;                        \
-            if (detail::is_valid_call_ptr<Class_, Base_>(self))                \
-                state->rv = ((Class_ *) self)->Name();                         \
+            if (detail::is_valid_call_ptr<Class_, Base_>(self_))               \
+                state->rv = ((Class_ *) self_)->Name();                        \
             else                                                               \
                 state->rv = zeros<Ret>();                                      \
             state->collect_rv(rv_i);                                           \

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -144,9 +144,12 @@ extern DRJIT_EXTRA_EXPORT uint64_t ad_var_reduce(JitBackend, VarType,
 /// Dot product reduction
 extern DRJIT_EXTRA_EXPORT uint64_t ad_var_reduce_dot(uint64_t i0, uint64_t i1);
 
-/// Compute an exclusive or inclusive prefix sum
-extern DRJIT_EXTRA_EXPORT uint64_t ad_var_prefix_sum(uint64_t index,
-                                                     int exclusive);
+/// Compute an exclusive or inclusive prefix reduction
+extern DRJIT_EXTRA_EXPORT uint64_t ad_var_block_prefix_reduce(ReduceOp op,
+                                                              uint64_t index,
+                                                              uint32_t block_size,
+                                                              int exclusive,
+                                                              int reverse);
 
 /// Compute the sum of adjacent blocks of size 'block_size'
 extern DRJIT_EXTRA_EXPORT uint64_t ad_var_block_reduce(ReduceOp op,

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -64,7 +64,7 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
         // This is necessary to catch cases where a variable is added to the
         // loop state twice.
         read_cb(payload, indices1);
-        for (uint32_t i : indices1)
+        for (uint64_t i : indices1)
             indices2.push_back((uint32_t) i);
         jit_var_loop_update_inner_in(loop.index(), indices2.data());
         indices1.release();
@@ -494,7 +494,7 @@ public:
                 input.is_diff = true;
                 input.has_grad_in = add_index(m_backend, ad_index, true);
                 if (input.has_grad_in)
-                    input.grad_in_index = m_input_indices.size() - 1;
+                    input.grad_in_index = (uint32_t) m_input_indices.size() - 1;
                 input.grad_in_offset = (uint32_t) m_diff_count++;
             }
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -122,6 +122,8 @@ target_compile_definitions(drjit-python PRIVATE -DDRJIT_PYTHON_BUILD)
 
 if (MSVC)
   target_compile_options(drjit-python PRIVATE /wd4714) # function marked as __forceinline not inlined
+else()
+  target_compile_options(drjit-python PRIVATE -Wno-redundant-move)
 endif()
 
 target_link_libraries(drjit-python PRIVATE drjit drjit-core drjit-extra)

--- a/src/python/apply.cpp
+++ b/src/python/apply.cpp
@@ -94,7 +94,6 @@ static const char *op_names[] = {
     "prod",
     "min",
     "max",
-    "prefix_sum",
 
     // Miscellaneous
     "__richcmp__",
@@ -1007,7 +1006,7 @@ nb::object transform_pair(const char *op, TransformPairCallback &tc,
             for (size_t i = 0; i < len1; ++i)
                 result.append(transform_pair(op, tc, l1[i], l2[i]));
 
-            return result;
+            return std::move(result);
         } else if (tp1.is(&PyDict_Type)) {
             nb::dict d1 = nb::borrow<nb::dict>(h1),
                      d2 = nb::borrow<nb::dict>(h2);
@@ -1022,7 +1021,7 @@ nb::object transform_pair(const char *op, TransformPairCallback &tc,
             for (nb::handle k : k1)
                 result[k] = transform_pair(op, tc, d1[k], d2[k]);
 
-            return result;
+            return std::move(result);
         } else {
             if (nb::dict ds = get_drjit_struct(tp1); ds.is_valid()) {
                 nb::object result = tp1();

--- a/src/python/eval.cpp
+++ b/src/python/eval.cpp
@@ -22,14 +22,14 @@ bool schedule(nb::handle h) {
         void operator()(nb::handle h) override {
             const ArraySupplement &s = supp(h.type());
             if (s.index)
-                result |= jit_var_schedule((uint32_t) s.index(inst_ptr(h))) != 0;
+                result |= (bool) jit_var_schedule((uint32_t) s.index(inst_ptr(h))) != 0;
         }
 
         void traverse_unknown(nb::handle h) override {
             if (h.type().is(local_type)) {
                 Local & local = nb::cast<Local&>(h);
                 for (uint32_t index : local.arrays())
-                    result |= jit_var_schedule(index);
+                    result |= (bool) jit_var_schedule(index);
             }
         }
     };

--- a/src/python/inspect.cpp
+++ b/src/python/inspect.cpp
@@ -22,7 +22,7 @@ static nb::object graphviz(bool ad, bool as_string) {
         string = nb::str(jit_var_graphviz());
 
     if (as_string)
-        return string;
+        return std::move(string);
 
     try {
         return nb::module_::import_("graphviz").attr("Source")(string);
@@ -44,7 +44,7 @@ static nb::object whos(bool ad, bool as_string) {
         string = nb::str(jit_var_whos());
 
     if (as_string) {
-        return string;
+        return std::move(string);
     } else {
         nb::print(string);
         return nb::none();

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -52,14 +52,14 @@ nb::object gather(nb::type_object dtype, nb::object source,
             if (!dtype.is(&PyList_Type))
                 return dtype(result);
             else
-                return result;
+                return std::move(result);
         } else if (source_tp.is(&PyDict_Type)) {
             nb::dict result;
             for (auto [k, v] : nb::borrow<nb::dict>(source))
                 result[k] = gather(nb::borrow<nb::type_object>(v.type()),
                                    nb::borrow(v), index, active, mode);
 
-            return result;
+            return std::move(result);
         } else {
             nb::object dstruct = nb::getattr(dtype, "DRJIT_STRUCT", nb::handle());
             if (dstruct.is_valid() && dstruct.type().is(&PyDict_Type)) {
@@ -982,7 +982,7 @@ static nb::object reshape(nb::type_object dtype, nb::handle value,
                 for (nb::handle item : nb::borrow<nb::list>(value))
                     tmp.append(reshape(nb::borrow<nb::type_object>(item.type()),
                                        item, target_shape, order, shrink));
-                return tmp;
+                return std::move(tmp);
             } else if (tp.is(&PyTuple_Type)) {
                 nb::list tmp;
                 for (nb::handle item : nb::borrow<nb::tuple>(value))
@@ -994,7 +994,7 @@ static nb::object reshape(nb::type_object dtype, nb::handle value,
                 for (auto [k, v] : nb::borrow<nb::dict>(value))
                     tmp[k] = reshape(nb::borrow<nb::type_object>(v.type()), v,
                                      target_shape, order, shrink);
-                return tmp;
+                return std::move(tmp);
             } else {
                 nb::object dstruct = nb::getattr(tp, "DRJIT_STRUCT", nb::handle());
                 if (dstruct.is_valid() && dstruct.type().is(&PyDict_Type)) {

--- a/src/python/print.cpp
+++ b/src/python/print.cpp
@@ -658,7 +658,7 @@ static nb::object format_impl(const char *name, const std::string &fmt,
             file.attr("write")(str);
             return nb::none();
         } else {
-            return str;
+            return std::move(str);
         }
     } catch (nb::python_error &e) {
         nb::raise_from(e, PyExc_RuntimeError,

--- a/src/python/tracker.cpp
+++ b/src/python/tracker.cpp
@@ -9,6 +9,10 @@
     BSD-style license that can be found in the LICENSE.txt file.
 */
 
+#if defined (_MSC_VER)
+#  pragma warning (disable: 4324) // structure was padded due to alignment specifier
+#endif
+
 #include "tracker.h"
 #include "base.h"
 #include "shape.h"

--- a/tests/if_stmt_ext.cpp
+++ b/tests/if_stmt_ext.cpp
@@ -45,7 +45,7 @@ bool packet_cond() {
 
     x = dr::if_stmt(
         dr::make_tuple(x),
-        x < 10,
+        x < 10.f,
         [](Float x_) { return -x_; },
         [](Float x_) { return  x_; }
     );

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -1273,7 +1273,7 @@ def test092_prefix_sum_fwd(t):
 
     x = t([1,2,3,4])
     dr.enable_grad(x)
-    y = dr.prefix_sum(x, False)
+    y = dr.cumsum(x)
     assert dr.allclose(y, [1, 3, 6, 10])
     dr.set_grad(x, [1.1, 1.2, 1.3, 1.4])
     dr.forward_to(y)
@@ -1281,7 +1281,7 @@ def test092_prefix_sum_fwd(t):
 
     x = t([1,2,3,4])
     dr.enable_grad(x)
-    y = dr.prefix_sum(x, False)
+    y = dr.cumsum(x)
     dr.forward_from(x)
     assert dr.allclose(dr.grad(y), [1, 2, 3, 4])
 
@@ -1298,7 +1298,7 @@ def test093_prefix_sum_bwd(t):
 
     x = t([1, 2, 3, 4])
     dr.enable_grad(x)
-    y = dr.prefix_sum(x, False)
+    y = dr.cumsum(x)
     dr.set_grad(y, 1)
     dr.backward_to(x)
     assert dr.allclose(dr.grad(x), [4, 3, 2, 1])
@@ -2052,3 +2052,18 @@ def test130_packet_scatter_fwd_target_disabled(t, enabled):
         xg = dr.forward_to(x)
 
         assert dr.all(xg == [10, 30, 50, 70, 20, 40, 60, 80])
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.test_arrays('is_diff,tensor,float32')
+def test131_prefix_sum_tensor(t, axis):
+    x = dr.ones(t, (3, 3))
+    dr.make_opaque(x)
+    dr.enable_grad(x)
+    y = dr.cumsum(x, axis=axis)
+    dr.backward_from(y)
+
+    if axis == 1:
+        assert dr.all(x.grad == t([[3, 2, 1], [3, 2, 1], [3, 2, 1]]))
+    else:
+        assert dr.all(x.grad == t([[3, 3, 3], [2, 2, 2], [1, 1, 1]]))


### PR DESCRIPTION
This commit adds the general differentiable prefix reduction operation ``drjit.prefix_reduce()``, which supports arbitrary scalar types, both regular arrays and tensors, and various reduction operations. It is implemented in terms of a blocked prefix reduction for 1D arrays (``drjit.blocked_prefix_reduce()``), which admits arbitrary (non-power-of-two) block sizes. The reductions are efficiently done using shared memory on the CUDA backend.

Most of the changes are in a related Dr.Jit-Core PR https://github.com/mitsuba-renderer/drjit-core/pull/103.

The following two previously existing functions now simply call the general case.

- ``drjit.prefix_sum``
- ``drjit.cumsum``

Somewhat unrelated: the commit removes sanitization-related options from Dr.Jit, since were recently moved to Dr.Jit-Core.