### PR TITLE
Improve the behavior of control flow operations (``dr.if_stmt(), drjit.while_loop()``) in AD-suspended scopes

### DIFF
--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -119,6 +119,12 @@ extern DRJIT_EXTRA_EXPORT uint32_t ad_grad(uint64_t index, bool null_ok = false)
 /// Check if gradient tracking is enabled for the given variable
 extern DRJIT_EXTRA_EXPORT int ad_grad_enabled(uint64_t index);
 
+/// Check if gradient tracking is disabled (can't create new AD variables)
+extern DRJIT_EXTRA_EXPORT int ad_grad_suspended();
+
+/// Temporarily enforce gradient tracking without creating a new scope
+extern DRJIT_EXTRA_EXPORT int ad_set_force_grad(int status);
+
 /// Accumulate into the gradient associated with a given variable
 extern DRJIT_EXTRA_EXPORT void ad_accum_grad(uint64_t index, uint32_t value);
 

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -71,8 +71,8 @@ struct DRJIT_TRIVIAL_ABI JitArray
 
     ~JitArray() noexcept { jit_var_dec_ref(m_index); }
 
-    JitArray(const JitArray &a) : m_index(a.m_index) {
-        jit_var_inc_ref(m_index);
+    JitArray(const JitArray &a) {
+        m_index = jit_var_inc_ref(a.m_index);
     }
 
     JitArray(JitArray &&a) noexcept : m_index(a.m_index) {
@@ -122,9 +122,9 @@ struct DRJIT_TRIVIAL_ABI JitArray
     }
 
     JitArray &operator=(const JitArray &a) {
-        jit_var_inc_ref(a.m_index);
+        uint32_t index = jit_var_inc_ref(a.m_index);
         jit_var_dec_ref(m_index);
-        m_index = a.m_index;
+        m_index = index;
         return *this;
     }
 
@@ -677,8 +677,7 @@ struct DRJIT_TRIVIAL_ABI JitArray
 
     static DRJIT_INLINE JitArray borrow(Index index) {
         JitArray result;
-        jit_var_inc_ref(index);
-        result.m_index = index;
+        result.m_index = jit_var_inc_ref(index);
         return result;
     }
 
@@ -733,8 +732,7 @@ struct index32_vector : drjit::vector<uint32_t> {
 
     void push_back_steal(uint32_t index) { push_back(index); }
     void push_back_borrow(uint32_t index) {
-        jit_var_inc_ref(index);
-        push_back(index);
+        push_back(jit_var_inc_ref(index));
     }
 };
 

--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -695,11 +695,11 @@ static void ad_free(ADIndex index, Variable *v) {
     state.unused_variables.push(index);
 }
 
-Index ad_var_inc_ref_impl(Index index) JIT_NOEXCEPT {
+Index ad_var_copy_ref_impl(Index index) JIT_NOEXCEPT {
     JitIndex jit_index = ::jit_index(index);
     ADIndex ad_index = ::ad_index(index);
 
-    jit_var_inc_ref(jit_index);
+    jit_index = jit_var_inc_ref(jit_index);
 
     if (unlikely(ad_index)) {
         const std::vector<Scope> &scopes = local_state.scopes;
@@ -713,6 +713,20 @@ Index ad_var_inc_ref_impl(Index index) JIT_NOEXCEPT {
     }
 
     return combine(ad_index, jit_index);
+}
+
+Index ad_var_inc_ref_impl(Index index) JIT_NOEXCEPT {
+    JitIndex jit_index = ::jit_index(index);
+    ADIndex ad_index = ::ad_index(index);
+
+    jit_var_inc_ref(jit_index);
+
+    if (unlikely(ad_index)) {
+        std::lock_guard<std::mutex> guard(state.mutex);
+        ad_var_inc_ref_int(ad_index, state[ad_index]);
+    }
+
+    return index;
 }
 
 

--- a/src/extra/call.cpp
+++ b/src/extra/call.cpp
@@ -90,7 +90,7 @@ static void ad_call_getter(JitBackend backend, const char *domain,
             "ad_call_getter(\"%s%s%s\", index=r%u, mask=r%u)", domain_or_empty,
             separator, name, index, mask.index());
 
-    scoped_isolation_boundary guard;
+    scoped_isolation_guard guard;
     {
         scoped_record rec(backend, name, true);
 
@@ -279,7 +279,7 @@ static void ad_call_symbolic(JitBackend backend, const char *domain,
         /* Postponed operations captured by the isolation scope should only
          * be executed once we've exited the symbolic scope. We therefore
          * need to declare the AD isolation guard before the recording guard. */
-        scoped_isolation_boundary guard_1(1);
+        scoped_isolation_guard guard_1(1);
 
         scoped_record guard_2(backend, name, true);
         // Recording may fail due to recursion depth
@@ -631,7 +631,7 @@ public:
 
     /// Implements f(arg..., grad(rv)...) -> grad(arg) ...
     void backward() override {
-        scoped_isolation_boundary isolation_guard;
+        scoped_isolation_guard isolation_guard;
         std::string name = m_name + " [ad, bwd]";
 
         index64_vector args, rv;

--- a/src/extra/common.h
+++ b/src/extra/common.h
@@ -38,12 +38,12 @@ private:
 };
 
 /// RAII AD Isolation helper
-struct scoped_isolation_boundary {
-    scoped_isolation_boundary(int symbolic = -1) : symbolic(symbolic) {
+struct scoped_isolation_guard {
+    scoped_isolation_guard(int symbolic = -1) : symbolic(symbolic) {
         ad_scope_enter(drjit::ADScope::Isolate, 0, nullptr, symbolic);
     }
 
-    ~scoped_isolation_boundary() {
+    ~scoped_isolation_guard() {
         ad_scope_leave(success);
     }
 
@@ -57,6 +57,13 @@ struct scoped_isolation_boundary {
     int symbolic = -1;
     bool success = false;
 };
+
+struct scoped_force_grad_guard {
+    scoped_force_grad_guard() { value = ad_set_force_grad(1); }
+    ~scoped_force_grad_guard() { ad_set_force_grad(value); }
+    bool value;
+};
+
 
 /// RAII helper to temporarily push a mask onto the Dr.Jit mask stack
 struct scoped_push_mask {

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -45,7 +45,7 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
         /* Postponed operations captured by the isolation scope should only
          * be executed once we've exited the symbolic scope. We therefore
          * need to declare the AD isolation guard before the recording guard. */
-        scoped_isolation_boundary isolation_guard(1);
+        scoped_isolation_guard isolation_guard(1);
         scoped_record record_guard(backend);
 
         // Rewrite the loop state variables
@@ -980,7 +980,7 @@ bool ad_loop(JitBackend backend, int symbolic, int compress,
                       "drjit.while_loop() for general information on symbolic and "
                       "evaluated loops, as well as their limitations.");
 
-        scoped_isolation_boundary guard;
+        scoped_isolation_guard guard;
         ad_loop_evaluated(backend, name, payload, read_cb, write_cb,
                           cond_cb, body_cb, compress);
         guard.disarm();

--- a/tests/test_if_stmt.py
+++ b/tests/test_if_stmt.py
@@ -592,8 +592,7 @@ def test18_if_stmt_preserve_unused_ad(t, mode):
         x = t(0, 1)
         y = t(1, 3)
         dr.enable_grad(x, y)
-        print(x.index)
-        print(y.index)
+        y_id = y.index_ad
 
         with dr.suspend_grad():
             def true_fn(x, y):
@@ -613,3 +612,4 @@ def test18_if_stmt_preserve_unused_ad(t, mode):
 
         assert not dr.grad_enabled(x)
         assert dr.grad_enabled(y)
+        assert y.index_ad == y_id


### PR DESCRIPTION
Dr.Jit control flow operations (``dr.if_stmt(), drjit.while_loop()``) currently disable gradient tracking of all variable state when the operation takes place within an AD-disabled scope.

This can be surprising when a ``@dr.syntax`` transformation silently passes local variables to such an operation, which then become non-differentiable. @dvicini reported this in issue https://github.com/mitsuba-renderer/drjit/issues/253.

This commit carves out an exception: when variables aren't actually modified by the control flow operation, they can retain their AD identity.

The PR has 3 parts:

- the first commit changes the semantics of ``ad_var_inc_ref`` so that it only does reference counting. The old behavior (drop ref if variable is currently non-differentiable) is moved to a new function ``ad_var_copy_ref()`` (see the description of this commit for details). This already fixes 80% of the problems.
- Parts 2 and 3 fix ``dr.if_stmt()`` and ``dr.while_loop()``, respectively.

The PR depends on a Dr.Jit-Core PR: https://github.com/mitsuba-renderer/drjit-core/pull/104