### PR TITLE
fix mask type select

### DIFF
--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -264,8 +264,9 @@ DRJIT_INLINE auto select(const M &m, const T &t, const F &f) {
             });
         return result;
     } else {
-        using E = replace_scalar_t<array_t<typename detail::deepest<T, F, M>::type>,
-                                   typename detail::expr<scalar_t<T>, scalar_t<F>>::type>;
+        using E_ = replace_scalar_t<array_t<typename detail::deepest<T, F, M>::type>,
+                                    typename detail::expr<scalar_t<T>, scalar_t<F>>::type>;
+        using E = std::conditional_t<is_mask_v<T>, mask_t<E_>, E_>;
         using EM = mask_t<E>;
 
         if constexpr (!is_array_v<E>) {

--- a/include/drjit/array_static.h
+++ b/include/drjit/array_static.h
@@ -147,7 +147,7 @@ struct StaticArrayBase : ArrayBaseT<Value_, IsMask_, Derived_> {
     void store_(void *mem) const {
         static_assert(!is_dynamic_v<value_t<T>>,
                       "store(): nested dynamic array not "
-                      "supported! Did you mean to use drjit::gather?");
+                      "supported! Did you mean to use drjit::scatter?");
 
         if constexpr (drjit::detail::is_scalar_v<Value>) {
             memcpy(mem, derived().data(), sizeof(Value) * Derived::Size);


### PR DESCRIPTION
`select` doesn't quite work when source types are masks:

```cpp
	drjit::Packet<float, 16> a, b;
	auto m = drjit::select(a > 0, a < b, a > b); // Return type is deduced back to Packet instead of PacketMask
```

And for some compilers this is a straight-up compile error:

```
no matching conversion for static_cast from 'const drjit::PacketMask<float, 16>' to 'ref_cast_t<drjit::PacketMask<float, 16>, E>' (aka 'drji
t::Packet<float, 16>')
```