### PR TITLE
Support higher axis numbers for dr.any and dr.all reductions

### DIFF
--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -460,3 +460,22 @@ def test13_test_prefix_reduction(t, reverse, exclusive):
     test_red((9, 5, 7), 1)
     test_red((9, 5, 7), 2)
     test_red((9, 5, 7), -1)
+
+@pytest.test_arrays('tensor, bool')
+def test14_any_all_multidimensional_tensors(t):
+    v_all = t([[True, False, True],
+               [True, True, True],
+               [True, False, True],
+               [True, True, True]
+               ])
+    assert list(dr.all(v_all, axis=0)) == [True, False, True]
+    assert list(dr.all(v_all, axis=1)) == [False, True, False, True]
+
+    v_any = t([[False, False, False],
+               [False, True, False],
+               [False, True, False],
+               [False, True, False]
+               ])
+
+    assert list(dr.any(v_any, axis=0)) == [False, True, False]
+    assert list(dr.any(v_any, axis=1)) == [False, True, True, True]


### PR DESCRIPTION
Hello,

I have been experimenting with the latest drjit version and noticed that `dr.all()` and `dr.any()` operations seem to not be supported for Tensors when they are evaluated with `axis` argument greater than `0`.

Reproducer below raises `RuntimeError: drjit.all(<drjit.cuda.TensorXb>): tensor type is not compatible with the requested reduction.

```py
import drjit as dr
from drjit.cuda import TensorXb

v = TensorXb([[True, False, True],
              [True, True, True],
              [True, False, True],
              [True, True, True]
             ])
dr.all(v, axis=1)
```

Similar exception is raised when calling `dr.any()`.

This PR aims to enable `dr.all()` and `dr.any()` operations for Tensors with `axis` parameter greater than `0`.




