### PR TITLE
Add support for gather/scatter of dataclass

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,55 @@
+# Test selection of Dr.Jit functionality using postponed evaluation of 
+# annotations. The following import has to be included first which is why we 
+# have a dedicated test file
+from __future__ import annotations
+
+import drjit as dr
+import pytest
+from dataclasses import dataclass
+from typing import ClassVar
+
+@pytest.test_arrays('float32,shape=(*),is_diff')
+def test01_gather_pytree(t):
+    x = t([1, 2, 3, 4])
+    y = t([5, 6, 7, 8])
+    i = dr.uint32_array_t(t)([1, 0])
+
+    if dr.backend_v(t) == dr.JitBackend.CUDA:
+        @dataclass 
+        class MyDataclass:
+            a : dr.cuda.ad.Float
+    else:
+        @dataclass 
+        class MyDataclass:
+            a : dr.llvm.ad.Float
+
+    s = MyDataclass(x)
+
+    r = dr.gather(MyDataclass, s, i)
+    assert type(r) is MyDataclass
+    assert dr.all(r.a == t([2, 1]))
+
+
+@pytest.test_arrays('float32,shape=(*), is_diff')
+def test02_scatter_pytree(t):
+    x = dr.zeros(t, 4)
+    y = dr.zeros(t, 4)
+
+    if dr.backend_v(t) == dr.JitBackend.CUDA:
+        @dataclass 
+        class MyDataclass:
+            a : dr.cuda.ad.Float
+    else:
+        @dataclass 
+        class MyDataclass:
+            a : dr.llvm.ad.Float
+
+    s = MyDataclass(x)
+    s.a = dr.zeros(t, 4)
+    dr.scatter(
+        s,
+        MyDataclass(t(1, 2)),
+        (1, 0),
+        (True, False)
+    )
+    assert dr.all(s.a == [0, 1, 0, 0])

--- a/tests/test_memop.py
+++ b/tests/test_memop.py
@@ -1,6 +1,7 @@
 import drjit as dr
 import pytest
 import sys
+from dataclasses import dataclass
 
 @pytest.test_arrays('-bool,shape=(*)')
 def test01_gather_simple(t):
@@ -144,9 +145,18 @@ def test07_gather_pytree(t):
         def __init__(self, a: t = t()):
             self.a = a
 
-    x = MyStruct(x)
-    r = dr.gather(MyStruct, x, i)
+    s = MyStruct(x)
+    r = dr.gather(MyStruct, s, i)
     assert type(r) is MyStruct
+    assert dr.all(r.a == t([2, 1]))
+
+    @dataclass 
+    class MyDataclass:
+        a : t
+
+    s = MyDataclass(x)
+    r = dr.gather(MyDataclass, s, i)
+    assert type(r) is MyDataclass
     assert dr.all(r.a == t([2, 1]))
 
 
@@ -169,15 +179,29 @@ def test08_scatter_pytree(t):
         def __init__(self, a: t):
             self.a = a
 
-    x = MyStruct(x)
-    x.a = dr.zeros(t, 4)
+    s = MyStruct(x)
+    s.a = dr.zeros(t, 4)
     dr.scatter(
-        x,
+        s,
         MyStruct(t(1, 2)),
         (1, 0),
         (True, False)
     )
-    assert dr.all(x.a == [0, 1, 0, 0])
+    assert dr.all(s.a == [0, 1, 0, 0])
+
+    @dataclass 
+    class MyDataclass:
+        a : t
+
+    s = MyDataclass(x)
+    s.a = dr.zeros(t, 4)
+    dr.scatter(
+        s,
+        MyDataclass(t(1, 2)),
+        (1, 0),
+        (True, False)
+    )
+    assert dr.all(s.a == [0, 1, 0, 0])
 
 
 def test09_ravel_scalar():


### PR DESCRIPTION
Motivated by #303 , add support for `gather` and `scatter` when using `dataclass` types 