### PR TITLE
Backport fix `dr.backward_from` and `dr.forward_from` on special types

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -908,7 +908,13 @@ void backward_from(T &value, uint32_t flags = (uint32_t) ADFlag::Default) {
     if constexpr (depth_v<T> > 1)
         value = value + T(0);
 
-    set_grad(value, 1.f);
+    if constexpr (is_complex_v<T>)
+        set_grad(value, T(1.f, 1.f));
+    else if constexpr (is_quaternion_v<T>)
+        set_grad(value, T(1.f, 1.f, 1.f, 1.f));
+    else
+        set_grad(value, full<T>(1.f));
+
     enqueue(ADMode::Backward, value);
     traverse<T>(ADMode::Backward, flags);
 }
@@ -923,7 +929,14 @@ void backward_to(const T &value, uint32_t flags = (uint32_t) ADFlag::Default) {
 template <typename T>
 void forward_from(T &value, uint32_t flags = (uint32_t) ADFlag::Default) {
     detail::check_grad_enabled("forward_from", value);
-    set_grad(value, 1.f);
+    
+    if constexpr (is_complex_v<T>)
+        set_grad(value, T(1.f, 1.f));
+    else if constexpr (is_quaternion_v<T>)
+        set_grad(value, T(1.f, 1.f, 1.f, 1.f));
+    else
+        set_grad(value, full<T>(1.f));
+
     enqueue(ADMode::Forward, value);
     traverse(ADMode::Forward, flags);
 }

--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -297,8 +297,12 @@ static bool check_grad_enabled(const char *name, nb::handle h, uint32_t flags) {
 
 static void forward_from(nb::handle_t<dr::ArrayBase> h, uint32_t flags) {
     if (check_grad_enabled("drjit.forward_from", h, flags)) {
+        // Full for quaternion and complex types won't fill all components
+        // so make sure we use corresponding array type
+        nb::handle tp = h.type();
+        nb::handle at = is_drjit_type(tp) ? supp(tp).array : tp.ptr();
         ::clear_grad(h);
-        ::accum_grad(h, h.type()(1.0));
+        ::accum_grad(h, full("ones", at, nb::int_(1), 1));
         enqueue_impl(dr::ADMode::Forward, h);
         nb::gil_scoped_release r;
         ad_traverse(dr::ADMode::Forward, flags);
@@ -307,8 +311,12 @@ static void forward_from(nb::handle_t<dr::ArrayBase> h, uint32_t flags) {
 
 static void backward_from(nb::handle_t<dr::ArrayBase> h, uint32_t flags) {
     if (check_grad_enabled("drjit.backward_from", h, flags)) {
+        // Full for quaternion and complex types won't fill all components
+        // so make sure we use corresponding array type
+        nb::handle tp = h.type();
+        nb::handle at = is_drjit_type(tp) ? supp(tp).array : tp.ptr();
         ::clear_grad(h);
-        ::accum_grad(h, h.type()(1.0));
+        ::accum_grad(h, full("ones", at, nb::int_(1), 1));
         enqueue_impl(dr::ADMode::Backward, h);
         nb::gil_scoped_release r;
         ad_traverse(dr::ADMode::Backward, flags);

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -2067,3 +2067,40 @@ def test131_prefix_sum_tensor(t, axis):
         assert dr.all(x.grad == t([[3, 2, 1], [3, 2, 1], [3, 2, 1]]))
     else:
         assert dr.all(x.grad == t([[3, 3, 3], [2, 2, 2], [1, 1, 1]]))
+
+@pytest.test_arrays('is_diff,quat')
+def test132_forward_from_quaternion(t):
+    # Propagating from a Quaternion, propagates from all its components
+    a = t(1.0)
+    dr.enable_grad(a.y) # Gradients on `j` component
+    b = 2 * a
+    dr.forward_from(a)
+    y = dr.grad(b)
+    assert dr.allclose(y, t(0, 2, 0, 0))
+
+@pytest.test_arrays('is_diff,quat')
+def test133_backward_from_quaternion(t):
+    # Propagating from a Quaternion, propagates from all its components
+    a = t(1.0)
+    dr.enable_grad(a.y) # Gradients on `j` component
+    b = 2 * a
+    dr.backward_from(b)
+    assert dr.allclose(dr.grad(a), t(0, 2, 0, 0))
+
+@pytest.test_arrays('is_diff,complex')
+def test134_forward_from_complex(t):
+    # Propagating from a Quaternion, propagates from all its components
+    a = t(1.0)
+    dr.enable_grad(a.imag) # Gradients on imaginary component
+    b = 2 * a
+    dr.forward_from(a)
+    assert dr.allclose(dr.grad(b), t(0, 2))
+
+@pytest.test_arrays('is_diff,complex')
+def test135_backward_from_complex(t):
+    # Propagating from a Quaternion, propagates from all its components
+    a = t(1.0)
+    dr.enable_grad(a.imag) # Gradients on imaginary component
+    b = 2 * a
+    dr.backward_from(b)
+    assert dr.allclose(dr.grad(a), t(0, 2))


### PR DESCRIPTION
This was fixed in prior Dr.Jit release (PR #172). Need to ensure gradients are correctly initialized for all components