### PR TITLE
Fix incorrect tracking of side-effects per vectorized call target

### DIFF
--- a/src/extra/call.cpp
+++ b/src/extra/call.cpp
@@ -300,8 +300,9 @@ static void ad_call_symbolic(JitBackend backend, const char *domain,
         size_t callable_count_final = 0;
         {
             scoped_set_mask mask_guard(backend, jit_var_call_mask(backend));
+            checkpoints[0] = guard_2.checkpoint_and_rewind();
+
             for (size_t i = 0; i < callable_count; ++i) {
-                checkpoints[i] = guard_2.checkpoint_and_rewind();
                 rv2.clear();
 
                 void *ptr;
@@ -338,10 +339,9 @@ static void ad_call_symbolic(JitBackend backend, const char *domain,
                     rv_ad[j] |= (index2 >> 32) != 0;
                     rv3.push_back_borrow((uint32_t) index2);
                 }
-                callable_count_final++;
-            }
 
-            checkpoints[callable_count_final] = guard_2.checkpoint_and_rewind();
+                checkpoints[++callable_count_final] = guard_2.checkpoint_and_rewind();
+            }
         }
 
         vector<uint32_t> rv4;


### PR DESCRIPTION
This PR fixes an issue in vectorized calls where the set of side-effects produced by a specific function where attributed to another function. More specifically, this would only happen if the vectorized call was being performed on a domain for which the registry was partially filled (some indices have been freed).

The PR includes a regression test.