### PR TITLE
Add a missing #include <string>

### DIFF
--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -54,6 +54,7 @@
 #include <nanobind/intrusive/counter.inl>
 #include <queue>
 #include <mutex>
+#include <string>
 
 namespace dr = drjit;
 


### PR DESCRIPTION
`#include <string>` is necessary to allow compiling with
LLVM 20 + libc++.