### PR TITLE
Call domain isolation per (variant, domain)

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -768,7 +768,8 @@ struct DRJIT_TRIVIAL_ABI DiffArray
         if constexpr (!IsClass)
             return out;
         else
-            return (Value) jit_registry_ptr(Backend, CallSupport::Domain, out);
+            return (Value) jit_registry_ptr(
+                CallSupport::Variant, CallSupport::Domain, out);
     }
 
     bool schedule_() const { return jit_var_schedule((uint32_t) m_index); }
@@ -936,7 +937,7 @@ void backward_to(const T &value, uint32_t flags = (uint32_t) ADFlag::Default) {
 template <typename T>
 void forward_from(T &value, uint32_t flags = (uint32_t) ADFlag::Default) {
     detail::check_grad_enabled("forward_from", value);
-    
+
     if constexpr (is_complex_v<T>)
         set_grad(value, T(1.f, 1.f));
     else if constexpr (is_quaternion_v<T>)

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -334,11 +334,11 @@ typedef void (*ad_call_cleanup)(void*);
  * already been destroyed.
  */
 extern DRJIT_EXTRA_EXPORT bool
-ad_call(JitBackend backend, const char *domain, int symbolic, size_t callable_count,
-        const char *name, bool is_getter, uint32_t index, uint32_t mask,
-        const drjit::vector<uint64_t> &args, drjit::vector<uint64_t> &rv,
-        void *payload, ad_call_func callback, ad_call_cleanup cleanup,
-        bool ad);
+ad_call(JitBackend backend, const char *variant, const char *domain,
+        int symbolic, size_t callable_count, const char *name, bool is_getter,
+        uint32_t index, uint32_t mask, const drjit::vector<uint64_t> &args,
+        drjit::vector<uint64_t> &rv, void *payload, ad_call_func callback,
+        ad_call_cleanup cleanup, bool ad);
 
 // Callbacks used by \ref ad_loop() below. See the interface for details
 typedef void (*ad_loop_read)(void *payload, drjit::vector<uint64_t> &);

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -435,8 +435,8 @@ struct DRJIT_TRIVIAL_ABI JitArray
             uint32_t *temp = new uint32_t[size];
             jit_memcpy(Backend, temp, data(), size * sizeof(uint32_t));
             for (uint32_t i = 0; i < size; i++)
-                ((void **) ptr)[i] =
-                    jit_registry_ptr(Backend, CallSupport::Domain, temp[i]);
+                ((void **) ptr)[i] = jit_registry_ptr(
+                    CallSupport::Variant, CallSupport::Domain, temp[i]);
             delete[] temp;
         }
     }
@@ -555,8 +555,9 @@ struct DRJIT_TRIVIAL_ABI JitArray
             drjit_fail("Unsupported operand type");
         } else {
             uint32_t bucket_count = 0;
-            CallBucket *buckets = jit_var_call_reduce(
-                Backend, CallSupport::Domain, m_index, &bucket_count);
+            CallBucket *buckets   = jit_var_call_reduce(
+                Backend, CallSupport::Variant, CallSupport::Domain, m_index,
+                &bucket_count);
             return { buckets, bucket_count };
         }
     }
@@ -626,7 +627,8 @@ struct DRJIT_TRIVIAL_ABI JitArray
         if constexpr (!IsClass)
             return out;
         else
-            return (Value) jit_registry_ptr(Backend, CallSupport::Domain, out);
+            return (Value) jit_registry_ptr(CallSupport::Variant,
+                                            CallSupport::Domain, out);
     }
 
     template <typename T, enable_if_t<!std::is_void_v<T> && std::is_same_v<T, Value>> = 0>

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -952,8 +952,10 @@ nanobind::object bind_array(ArrayBinding &b, nanobind::handle scope = {},
         nb::object result = bind_func(nb::cast((void *) &b));
     #endif
 
-    if constexpr (std::is_pointer_v<value_t<T>>)
+    if constexpr (std::is_pointer_v<value_t<T>>) {
+        result.attr("Variant") = T::CallSupport::Variant;
         result.attr("Domain") = T::CallSupport::Domain;
+    }
 
     return result;
 }

--- a/tests/call_ext.cpp
+++ b/tests/call_ext.cpp
@@ -50,7 +50,7 @@ template <typename Float> struct Base : nb::intrusive_base {
 
     Base() {
         if constexpr (dr::is_jit_v<Float>)
-            jit_registry_put(dr::backend_v<Float>, "Base", this);
+            jit_registry_put("", "Base", this);
     }
 
     virtual ~Base() { jit_registry_remove(this); }


### PR DESCRIPTION
Replaces https://github.com/mitsuba-renderer/drjit/pull/307.
Second attempt at offering a mechanism to isolate symbolic calls, after discussion with @wjakob and @njroussel.

Requires https://github.com/mitsuba-renderer/drjit-core/pull/109 in `drjit-core`.