### PR TITLE
Add `drjit::repeat` for C++ interface. Setting up tests for Python-cpp implementation consistency

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -401,6 +401,13 @@ struct DRJIT_TRIVIAL_ABI DiffArray
             return steal(jit_var_tile(m_index, count));
     }
 
+    DiffArray repeat_(size_t count) const {
+        if constexpr (IsFloat)
+            return steal(ad_var_repeat(m_index, count));
+        else
+            return steal(jit_var_repeat(m_index, count));
+    }
+
     DiffArray dot_(const DiffArray &a) const { return sum(*this * a); }
 
     auto count_() const {

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -168,6 +168,9 @@ extern DRJIT_EXTRA_EXPORT uint64_t ad_var_block_reduce(ReduceOp op,
 /// Tile the input array 'count' times
 extern DRJIT_EXTRA_EXPORT uint64_t ad_var_tile(uint64_t index, uint32_t count);
 
+/// Repeat values of an array into larger blocks
+extern DRJIT_EXTRA_EXPORT uint64_t ad_var_repeat(uint64_t index, uint32_t count);
+
 /// Perform a differentiable gather operation. See jit_var_gather for signature.
 extern DRJIT_EXTRA_EXPORT uint64_t ad_var_gather(uint64_t source,
                                                  uint32_t offset, uint32_t mask,

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -576,6 +576,10 @@ struct DRJIT_TRIVIAL_ABI JitArray
         return steal(jit_var_tile(m_index, (uint32_t) count));
     }
 
+    JitArray repeat_(size_t count) const {
+        return steal(jit_var_repeat(m_index, (uint32_t) count));
+    }
+
     JitArray copy() const { return steal(jit_var_copy(m_index)); }
 
     bool schedule_() const { return jit_var_schedule(m_index) != 0; }
@@ -705,6 +709,22 @@ template <typename T> T tile(const T &value, size_t count) {
         return result;
     } if constexpr (is_jit_v<T>) {
         return value.tile_(count);
+    } else {
+        return value;
+    }
+}
+
+template <typename T> T repeat(const T &value, size_t count) {
+    if constexpr (is_traversable_v<T>) {
+        T result;
+        traverse_2(
+            fields(result), fields(value),
+            [count](auto &x, const auto &y) {
+                x = repeat(y, count);
+            });
+        return result;
+    } if constexpr (is_jit_v<T>) {
+        return value.repeat_(count);
     } else {
         return value;
     }

--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -2119,7 +2119,7 @@ struct BlockReduceEdge : Special {
 
             case ReduceOp::Min:
             case ReduceOp::Max: {
-                    JitVar value_tile = dr::tile(m_value_out, m_block_size);
+                    JitVar value_tile = dr::repeat(m_value_out, m_block_size);
                     result = dr::block_sum(source_grad & (value_tile == m_value_in), m_block_size, m_symbolic);
                 }
                 break;
@@ -2142,18 +2142,18 @@ struct BlockReduceEdge : Special {
         JitVar result;
         switch (m_op) {
             case ReduceOp::Add:
-                result = dr::tile(target_grad, m_block_size);
+                result = dr::repeat(target_grad, m_block_size);
                 break;
 
             case ReduceOp::Mul:
-                result = dr::tile(target_grad * m_value_out, m_block_size) / m_value_in;
+                result = dr::repeat(target_grad * m_value_out, m_block_size) / m_value_in;
                 break;
 
             case ReduceOp::Min:
             case ReduceOp::Max:
                 result = dr::select(
-                    dr::tile(m_value_out, m_block_size) == m_value_in,
-                    dr::tile(target_grad, m_block_size), scalar(m_value_in.index(), 0.0));
+                    dr::repeat(m_value_out, m_block_size) == m_value_in,
+                    dr::repeat(target_grad, m_block_size), scalar(m_value_in.index(), 0.0));
                 break;
 
             default:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_drjit_test(call_ext call_ext.cpp)
 add_drjit_test(while_loop_ext while_loop_ext.cpp)
 add_drjit_test(if_stmt_ext if_stmt_ext.cpp)
 add_drjit_test(custom_type_ext custom_type_ext.cpp)
+add_drjit_test(py_cpp_consistency_ext py_cpp_consistency_ext.cpp)
 
 file(GLOB TEST_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.py")
 

--- a/tests/py_cpp_consistency_ext.cpp
+++ b/tests/py_cpp_consistency_ext.cpp
@@ -1,0 +1,36 @@
+#include <nanobind/nanobind.h>
+#include <drjit/python.h>
+#include <drjit/autodiff.h>
+#include <drjit/packet.h>
+
+namespace nb = nanobind;
+namespace dr = drjit;
+
+template <typename Float>
+Float tile(const Float &source, uint32_t count) {
+    return Float::steal(jit_var_tile(source.index(), count));
+}
+
+template <typename Float>
+Float repeat(const Float &source, uint32_t count) {
+    return Float::steal(jit_var_repeat(source.index(), count));
+}
+
+template <JitBackend Backend> void bind(nb::module_ &m) {
+    using Float = dr::DiffArray<Backend, float>;
+
+    m.def("tile", &tile<Float>);
+    m.def("repeat", &repeat<Float>);
+}
+
+NB_MODULE(py_cpp_consistency_ext, m) {
+#if defined(DRJIT_ENABLE_LLVM)
+    nb::module_ llvm = m.def_submodule("llvm");
+    bind<JitBackend::LLVM>(llvm);
+#endif
+
+#if defined(DRJIT_ENABLE_CUDA)
+    nb::module_ cuda = m.def_submodule("cuda");
+    bind<JitBackend::CUDA>(cuda);
+#endif
+}

--- a/tests/test_py_cpp_consistency_ext.py
+++ b/tests/test_py_cpp_consistency_ext.py
@@ -1,0 +1,30 @@
+"""
+There are instances where functions that have Python-specific arguments such
+as PyTrees use an independent code path relative to just the pure C++ interface.
+These tests provide basic coverage to check consistency between the two 
+implementations.
+"""
+
+import drjit as dr
+import pytest
+
+def get_pkg(t):
+    with dr.detail.scoped_rtld_deepbind():
+        m = pytest.importorskip("py_cpp_consistency_ext")
+    backend = dr.backend_v(t)
+    if backend == dr.JitBackend.LLVM:
+        return m.llvm
+    elif backend == dr.JitBackend.CUDA:
+        return m.cuda
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test01_tile(t):
+    pkg = get_pkg(t)
+    x = dr.arange(t, 10)
+    assert dr.all(pkg.tile(x, 3) == dr.tile(x, 3))
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test02_repeat(t):
+    pkg = get_pkg(t)
+    x = dr.arange(t, 10)
+    assert dr.all(pkg.repeat(x, 3) == dr.repeat(x, 3))


### PR DESCRIPTION
There are instances where functions that have Python object arguments such as PyTrees use an independent code path relative to just the pure C++ interface. Setting up the test module with initial tests for `tile` and `repeat`, and in the future more tests can be added.