### PR TITLE
Fix #337 Broadcasting of tensors in dr.select

### DIFF
--- a/src/python/apply.cpp
+++ b/src/python/apply.cpp
@@ -366,14 +366,18 @@ void tensor_broadcast(nb::object &tensor, nb::object &array,
     for (size_t i = 0; i < ndim; ++i)
         dst_size *= shape_dst[i];
 
-    if (src_size == 1) {
-        if (dst_size != 1)
-            array = array + full("zeros", array.type(), nb::int_(0), dst_size);
-        return;
-    }
-
     nb::handle tp = tensor.type();
     const ArraySupplement &s = supp(tp);
+
+    if (src_size == 1) {
+        if (dst_size != 1) {
+            if (s.type == (uint16_t) VarType::Bool)
+                array = array | full("zeros", array.type(), nb::bool_(0), dst_size);
+            else
+                array = array + full("zeros", array.type(), nb::int_(0), dst_size);
+        }
+        return;
+    }
 
     nb::type_object_t<ArrayBase> index_type =
         nb::borrow<nb::type_object_t<ArrayBase>>(s.tensor_index);

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -327,6 +327,13 @@ def test09_broadcast(t):
     x = dr.full(t, 2, shape=(4,5)) * dr.full(t, 3, shape=(3,4,5))
     assert dr.all(x == dr.full(t, 6, shape=(3,4,5)), axis=None)
 
+    # Implicit broadcast with select
+    x = dr.full(t, 2, shape=(1,1))
+    y = dr.full(t, 2, shape=(2,1))
+    z = dr.select(x==2, 2, y)
+    assert dr.all(z == y)
+    assert z.shape == (2,1)
+
     with pytest.raises(RuntimeError, match=r'operands have incompatible shapes: \(2,\) and \(3,\).'):
         dr.zeros(t, 2) + dr.zeros(t, 3)
 


### PR DESCRIPTION
`select` requires promotion of arguments to consistent types including the mask, so we need to handle tensor broadcasting in this case