### PR TITLE
Properly compile ``rsqrt`` intrinsic on LLVM

### DIFF
--- a/include/drjit/texture.h
+++ b/include/drjit/texture.h
@@ -69,7 +69,8 @@ public:
             _packet = empty<Packet>(m_channels_storage);        \
             name = _packet.data();                              \
         } else {                                                \
-            name = (_Storage*)alloca(sizeof(_Storage) * size);  \
+            name = (_Storage*) alloca(sizeof(_Storage) * size); \
+            (void) _packet;                                     \
         }
 
     /// Default constructor: create an invalid texture object

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,5 @@
-# Test selection of Dr.Jit functionality using postponed evaluation of 
-# annotations. The following import has to be included first which is why we 
+# Test selection of Dr.Jit functionality using postponed evaluation of
+# annotations. The following import has to be included first which is why we
 # have a dedicated test file
 from __future__ import annotations
 
@@ -15,11 +15,11 @@ def test01_gather_pytree(t):
     i = dr.uint32_array_t(t)([1, 0])
 
     if dr.backend_v(t) == dr.JitBackend.CUDA:
-        @dataclass 
+        @dataclass
         class MyDataclass:
             a : dr.cuda.ad.Float
     else:
-        @dataclass 
+        @dataclass
         class MyDataclass:
             a : dr.llvm.ad.Float
 
@@ -36,11 +36,11 @@ def test02_scatter_pytree(t):
     y = dr.zeros(t, 4)
 
     if dr.backend_v(t) == dr.JitBackend.CUDA:
-        @dataclass 
+        @dataclass
         class MyDataclass:
             a : dr.cuda.ad.Float
     else:
-        @dataclass 
+        @dataclass
         class MyDataclass:
             a : dr.llvm.ad.Float
 

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -431,3 +431,17 @@ def test22_and_mask(t):
 
     arr &= m
     assert dr.all(arr == t(1, 2, 0, 0))
+
+@pytest.test_arrays('float32, shape=(*), is_diff')
+def test23_rsqrt(t):
+    x = t(0.001, 0.1, 1, 2, 3, 4, 100)
+    y = 1 / dr.sqrt(x)
+    z = dr.rsqrt(x)
+    assert dr.all((y-z) / y < 1e-7)
+
+    x = t(0, float('inf'))
+    y = 1 / dr.sqrt(x)
+    z = dr.rsqrt(x)
+
+    assert dr.isinf(y[0]) == dr.isinf(z[0])
+    assert y[1] == z[1]


### PR DESCRIPTION
Dr.Jit provides an approximate ``dr.rsqrt()`` operation that performs a reciprocal square root with a very small amount of rounding error (~1 ULP) when compared to the IEEE 754-compliant version. The main benefit is that this has significantly lower latency.

Previously, only the CUDA backend implemented this operation properly, while an IEEE 754-compliant fallback was used on the LLVM backend. This commit adds a proper implementation for AVX, AVX512, and ARM Neon.