### PR TITLE
Make ``dr.all()``, ``dr.any()``, and ``dr.none()`` asynchronous

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -364,6 +364,8 @@ struct DRJIT_TRIVIAL_ABI DiffArray
 
     bool all_() const { return jit_var_all((uint32_t) m_index); }
     bool any_() const { return jit_var_any((uint32_t) m_index); }
+    auto all_async_() const { return MaskType::steal(jit_var_all_async(Backend, (uint32_t) m_index)); }
+    auto any_async_() const { return MaskType::steal(jit_var_any_async(Backend, (uint32_t) m_index)); }
 
     #define DRJIT_HORIZONTAL_OP(name, op)                                      \
         DiffArray name##_() const {                                            \

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -323,6 +323,8 @@ struct DRJIT_TRIVIAL_ABI JitArray
 
     bool all_() const { return jit_var_all(m_index); }
     bool any_() const { return jit_var_any(m_index); }
+    auto all_async_() const { return MaskType::steal(jit_var_all_async(Backend, m_index)); }
+    auto any_async_() const { return MaskType::steal(jit_var_any_async(Backend, m_index)); }
 
     #define DRJIT_HORIZONTAL_OP(name, op)                                  \
         JitArray name##_() const {                                         \

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -713,8 +713,8 @@ void bind_tensor(ArrayBinding &b) {
 
 template <typename T> void bind_mask_reductions(ArrayBinding &b) {
     if constexpr (is_jit_v<T>) {
-        b[ArrayOp::All] = (void *) +[](const T *a, T *b) { new (b) T(a->all_()); };
-        b[ArrayOp::Any] = (void *) +[](const T *a, T *b) { new (b) T(a->any_()); };
+        b[ArrayOp::All] = (void *) +[](const T *a, T *b) { new (b) T(a->all_async_()); };
+        b[ArrayOp::Any] = (void *) +[](const T *a, T *b) { new (b) T(a->any_async_()); };
         b[ArrayOp::Count] = (void *) +[](const T *a, uint32_array_t<T> *b) {
             new (b) uint32_array_t<T>(a->count_());
         };


### PR DESCRIPTION
Previously, the Python version of these functions copied a Boolean scalar to the CPU and then constructed a literal array. The new implementation leaves the value on the device and does not block.