### PR TITLE
CustomOp: avoid an unnecessary variable copy

### DIFF
--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -436,7 +436,8 @@ public:
                     uint32_t jit_index = (uint32_t) index;
                     uint32_t ad_index = (uint32_t) (index >> 32);
                     op.add_index((JitBackend) s.backend, ad_index, input);
-                    uint32_t new_idx = jit_var_copy(jit_index);
+                    VarInfo info = jit_set_backend(jit_index);
+                    uint32_t new_idx = jit_var_undefined(info.backend, info.type, info.size);
                     s.init_index(((uint64_t) ad_index) << 32 | new_idx, inst_ptr(h2));
                     jit_var_dec_ref(new_idx);
                 }


### PR DESCRIPTION
A prior commit (4d71e9c6e2021e994e03203c3646eabd20fd7b8e) changed CustomOp so that it preserves a copy of variables to remember their size. This has been identified as a source of inefficiency in a downstream application. The change in this PR switches the copy to an empty (jit_var_undefined) array of the right size/type, which does not cause an actual allocation/copy to take place.