### PR TITLE
Ability to flip the order of axes in Tensor -> nested array conversions

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -517,6 +517,27 @@ each other (e.g. to display a complete 3D vector on each line in the above
 example). In contrast, the string conversion of tensors matches that of other
 array programming libraries and does not transpose the input.
 
+As the example above showed, conversion between nested arrays and tensors
+always preserves the shape---for example
+
+.. code-block:: python
+
+   x = dr.zeros(Array3f, shape=(3, N))
+   y = TensorXf(x)
+
+produces a tensor ``y`` of shape ``(3, N)``. However, sometimes an application might
+actually need a tensor of shape ``(N, 3)``. Pass ``flip_axes=True`` to the
+constructor to reverse the order of the ``shape`` elements and directly perform
+this conversion. The same also works in the reverse direction.
+
+.. code-block:: python
+
+   # Convert to (N, 3) tensor
+   y = TensorXf(x, flip_axes=True)
+
+   # Convert (N, 3) tensor back to nested array form
+   y = Array3f(y, flip_axes=True)
+
 Tensors support all normal mathematical operations along with automatic
 differentiation. They share the broadcasting behavior known from other array
 programming frameworks.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -97,7 +97,7 @@ def test02_init_broadcast(t):
 # Test array initialization from a list of arguments (explicit, list, tuple, iterable)
 @pytest.test_arrays('-tensor')
 def test03_init_list(t):
-    with pytest.raises(TypeError, match='Constructor does not take keyword arguments.'):
+    with pytest.raises(TypeError, match='Unknown keyword argument'):
         t(hello='world')
 
     value = False if dr.is_mask_v(t) else 0

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -572,3 +572,22 @@ def test18_tensor_index_signed_vec(t):
     x = t([1, 2, 3], shape=(1, 3))
     A = dr.int32_array_t(dr.array_t(x))
     assert dr.all(x[:, A([-1, 0])] == t([3, 1]))
+
+@pytest.test_arrays('jit, float32, shape=(3, *)')
+def test19_roundtrip_flip(t):
+    mod = sys.modules[t.__module__]
+    TensorXf = getattr(mod, 'TensorXf')
+
+    x = t([1,2], [3,4], [5,6])
+    t1 = TensorXf(x)
+    t2 = TensorXf(x, flip_axes=True)
+    assert x.shape == (3, 2)
+    assert t1.shape == (3, 2)
+    assert t2.shape == (2, 3)
+    assert dr.all(t1.array == (1,2,3,4,5,6))
+    assert dr.all(t2.array == (1,3,5,2,4,6))
+
+    x1 = t(t1)
+    x2 = t(t2, flip_axes=True)
+    assert dr.all(x1 == x, axis=None)
+    assert dr.all(x2 == x, axis=None)


### PR DESCRIPTION
Dr.Jit can convert between nested arrays and tensors (e.g., ``Array3f(TensorXf(...))`` or ``TensorXf(Array3f(...))``), which requires raveling/unraveling the array contents.

This step preserves the shape -- for example
```
x = dr.zeros(Array3f, shape=(3, N))
y = TensorXf(x)
```
returns a tensor of type ``(3, N)``. However, sometimes what is actually needed is shape ``(N, 3)``.

This PR adds a ``flip_axes`` argument to the constructor that accomplishes this.

```
y = TensorXf(x, flip_axes=True)

y = Array3f(y, flip_axes=True)
```