### PR TITLE
Better handling of unknown objects in ``dr.select()``

### DIFF
--- a/src/python/apply.cpp
+++ b/src/python/apply.cpp
@@ -928,6 +928,10 @@ nb::handle TransformPairCallback::transform_type(nb::handle tp) const {
 
 uint64_t TransformCallback::operator()(uint64_t index) { return index; }
 
+nb::object TransformPairCallback::transform_unknown(nb::handle, nb::handle) const {
+    return nb::none();
+}
+
 /// Transform a pair of input pytrees 'h1' and 'h2' into an output pytree, potentially of a different type
 nb::object transform_pair(const char *op, TransformPairCallback &tc,
                           nb::handle h1, nb::handle h2) {
@@ -1047,7 +1051,7 @@ nb::object transform_pair(const char *op, TransformPairCallback &tc,
                 }
                 return tp1(**result);
             } else {
-                return nb::none();
+                return tc.transform_unknown(h1, h2);
             }
         }
     } catch (nb::python_error &e) {

--- a/src/python/apply.h
+++ b/src/python/apply.h
@@ -90,6 +90,10 @@ struct TransformCallback {
 struct TransformPairCallback {
     virtual nb::handle transform_type(nb::handle tp) const;
     virtual void operator()(nb::handle h1, nb::handle h2, nb::handle h3) = 0;
+
+    // How should unknown (non-array) types be transformed? Should directly
+    // return the output object Identity by default.
+    virtual nb::object transform_unknown(nb::handle h1, nb::handle h2) const;
 };
 
 /// Invoke the given callback on leaf elements of the pytree 'h'

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -901,7 +901,7 @@ nb::object select(nb::handle h0, nb::handle h1, nb::handle h2) {
 
         nb::object transform_unknown(nb::handle h1, nb::handle h2) const override {
             if (!h1.is(h2))
-                nb::raise("encountered incompatible objects with an unknown type (not a Dr.Jit array, not a PyTree).");
+                nb::raise("select() encountered incompatible objects with an unknown type (not a Dr.Jit array, not a PyTree).");
             return nb::borrow(h1);
         }
 

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -258,6 +258,13 @@ def test06_select():
         with pytest.raises(RuntimeError) as e:
             result = dr.select(l.Array4b(True, False, True, True), a, 0)
 
+        assert dr.select(True, None, None) is None
+        assert dr.select(l.Array1b(True), None, None) is None
+        class Dummy(int):
+            pass
+        with pytest.raises(RuntimeError, match=r"encountered incompatible objects with an unknown type \(not a Dr.Jit array, not a PyTree\)."):
+            dr.select(l.Array2b(True, False), Dummy(1), Dummy(2))
+
 @pytest.test_arrays('type=float32,shape=(*)')
 def test07_power(t):
     assert dr.allclose(t(2)**0, t(1))


### PR DESCRIPTION
The ``dr.select()`` operation is able to traverse PyTrees. Whenever encountering unknown object type, it returns ``None`` in its place.

This commit changes the operation so that it preserves the object if both the true/false branch are consistent. Otherwise, it raises an exception.