### PR TITLE
Added ``JitFlag.ForbidSynchronization`` to catch synchronization issues

### DIFF
--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -5925,6 +5925,17 @@
 
     This flag has a severe performance impact and is *disabled* by default.
 
+.. topic:: JitFlag_ForbidSynchronization
+
+    Treat any kind of synchronization as an error and raise an exception when
+    it is encountered.
+
+    Operations like :py:func:`drjit.sync_thread()` are costly because they
+    prevent the system from overlapping CPU/GPU work. Enable this flag to find
+    places in a larger codebase that are responsible for this.
+
+    This flag is *disabled* by default.
+
 .. topic:: JitFlag_ScatterReduceLocal
 
     Reduce locally before performing atomic scatter-reductions.

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -101,6 +101,7 @@ NB_MODULE(_drjit_ext, m_) {
         .value("PrintIR", JitFlag::PrintIR, doc_JitFlag_PrintIR)
         .value("KernelHistory", JitFlag::KernelHistory, doc_JitFlag_KernelHistory)
         .value("LaunchBlocking", JitFlag::LaunchBlocking, doc_JitFlag_LaunchBlocking)
+        .value("ForbidSynchronization", JitFlag::ForbidSynchronization, doc_JitFlag_ForbidSynchronization)
         .value("ScatterReduceLocal", JitFlag::ScatterReduceLocal, doc_JitFlag_ScatterReduceLocal)
         .value("SymbolicConditionals", JitFlag::SymbolicConditionals, doc_JitFlag_SymbolicConditionals)
         .value("SymbolicScope", JitFlag::SymbolicScope, doc_JitFlag_SymbolicScope)


### PR DESCRIPTION
There can sometimes be lingering issues in a codebase (e.g., forgotten leftovers from a prior debugging session) that trigger costly CPU<->GPU.

The new ``JitFlag.ForbidSynchronization`` flag will raise an exception in ``jitc_sync_thread()`` to immediately identify such problems.