### PR TITLE
Refine the semantics of ``dr.forward_from()`` / ``dr.backward_from()``

### DIFF
--- a/docs/autodiff.rst
+++ b/docs/autodiff.rst
@@ -404,10 +404,9 @@ example graph below.
 
 See :py:func:`dr.forward_to() <forward_to>`, :py:func:`dr.backward_to()
 <backward_to>`, :py:func:`dr.forward_from() <forward_from>`,
-:py:func:`dr.backward_from() <backward_from>` for details. Note that the
-``_from`` variants set the gradient of the input variable. There is an even
+:py:func:`dr.backward_from() <backward_from>` for details. There is an even
 lower-level interface (:py:func:`dr.enqueue() <enqueue>` and
-:py:func:`dr.traverse() <traverse>`) that can be used to avoid this.
+:py:func:`dr.traverse() <traverse>`) that can be useful in advanced use cases.
 
 PyTrees
 -------

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -119,6 +119,9 @@ extern DRJIT_EXTRA_EXPORT uint32_t ad_grad(uint64_t index, bool null_ok = false)
 /// Check if gradient tracking is enabled for the given variable
 extern DRJIT_EXTRA_EXPORT int ad_grad_enabled(uint64_t index);
 
+/// Check if a gradient has been assigned to a variable
+extern DRJIT_EXTRA_EXPORT int ad_has_grad(uint64_t index);
+
 /// Check if gradient tracking is disabled (can't create new AD variables)
 extern DRJIT_EXTRA_EXPORT int ad_grad_suspended();
 

--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -1795,6 +1795,23 @@ int ad_grad_enabled(Index index) {
     return ad_index != 0;
 }
 
+/// Check if a gradient has been assigned to a variable
+int ad_has_grad(Index index) {
+    ADIndex ad_index = ::ad_index(index);
+    if (!ad_index)
+        return 0;
+
+    const std::vector<Scope> &scopes = local_state.scopes;
+    if (!scopes.empty())
+        scopes.back().maybe_disable(ad_index);
+    if (!ad_index)
+        return 0;
+
+    std::lock_guard<Lock> guard(state.lock);
+    const Variable *v = state[ad_index];
+    return v->grad.valid();
+}
+
 int ad_grad_suspended() {
     const std::vector<Scope> &scopes = local_state.scopes;
     if (scopes.empty())

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -2104,3 +2104,21 @@ def test135_backward_from_complex(t):
     b = 2 * a
     dr.backward_from(b)
     assert dr.allclose(dr.grad(a), t(0, 2))
+
+@pytest.test_arrays('is_diff,float,shape=(*)')
+def test136_backward_from_existing_gradient(t):
+    a = t(1.0)
+    dr.enable_grad(a)
+    b = 2 * a
+    b.grad = 1000
+    dr.backward_from(b)
+    assert dr.allclose(a.grad, 2000)
+
+@pytest.test_arrays('is_diff,float,shape=(*)')
+def test137_forward_from_existing_gradient(t):
+    a = t(1.0)
+    dr.enable_grad(a)
+    b = 2 * a
+    a.grad = 1000
+    dr.forward_from(a)
+    assert dr.allclose(b.grad, 2000)

--- a/tests/test_call_ext.py
+++ b/tests/test_call_ext.py
@@ -295,9 +295,9 @@ def test07_backward_diff_implicit(t, symbolic, optimize, use_mask, opaque):
     dr.set_grad(xo, [1,2,3,4,5])
     dr.backward_from(xo)
 
-    assert dr.all(dr.grad(x) == t([0, 0, 0, 24, 32]))
-    assert dr.all(dr.grad(av) == t([4]))
-    assert dr.all(dr.grad(bv) == t([100]))
+    assert dr.all(dr.grad(x) == t([0, 0, 0, 96, 160]))
+    assert dr.all(dr.grad(av) == t([6]))
+    assert dr.all(dr.grad(bv) == t([464]))
 
 
 @pytest.mark.parametrize("use_mask", [True, False])


### PR DESCRIPTION
Prior to this commit, the following operations were simply aliases of each other:

- ``dr.backward_from(x)`` and ``dr.backward(x)``, and
- ``dr.forward_from(x)`` and ``dr.forward(x)``.

They assign an initial gradient to the variable ``x`` and then propagate it. For example, the backwards version expands to:

```
x.grad = 1
dr.enqueue(dr.ADMode.Backward, x)
dr.traverse(dr.ADMode.Backward)
```

However, this behavior is inconvenient when one wants to propagate a specific derivative other than ``1``. It also makes the following functions non-symmetric with respect to each other:

- ``dr.backward_to()`` vs ``dr.backward_from()``
- ``dr.forward_to()`` vs ``dr.forward_from()``

In particular, the ``*_to()`` variants transport existing derivatives *without* the initial assignment.

This PR changes ``dr.backward_from(x)`` and ``dr.forward_from(x)`` so that the operation ``x.grad = 1`` only takes place when there was no prior assignment to ``x.grad``.

This change has the potential to impact user code. However, that hypothetical situation (calling ``dr.backward_from(x)`` following a gradient assignment to ``x``) was deemed unlikely, hence the decision to have the better API.