### PR TITLE
Failing edge cases for Loops

### DIFF
--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -2128,7 +2128,7 @@ def test138_loop_state(t):
 
     Float = dr.float32_array_t(t)
 
-    @dr.syntax(print_code=True)
+    @dr.syntax
     def loop(t, x: Float, y: Float, n: int = 10) -> Float:
         UInt32 = dr.uint32_array_t(t)
 

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -2124,7 +2124,7 @@ def test137_forward_from_existing_gradient(t):
     assert dr.allclose(b.grad, 2000)
 
 @pytest.test_arrays("is_diff,float,shape=(*)")
-def test138_loop_state(t):
+def test138_loop_state_backprop(t):
 
     Float = dr.float32_array_t(t)
 


### PR DESCRIPTION
This PR adds test cases where accidentally adding a variable to a loop state, causes the test to fail. This might be problematic, as `dr.syntax` aggressively adds variables to the loop state.