### PR TITLE
`dr.replace_grad`: better handling of non-differentiable types and unknown types

### DIFF
--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -237,6 +237,11 @@ static void accum_grad(nb::handle target, nb::handle source) {
 
 static nb::object replace_grad(nb::handle h0, nb::handle h1) {
     struct ReplaceGrad : TransformPairCallback {
+
+        nb::object transform_unknown(nb::handle h1, nb::handle /*unused*/) const override {
+            return nb::borrow(h1);
+        }
+
         void operator()(nb::handle h1, nb::handle h2, nb::handle h3) override {
             const ArraySupplement &s = supp(h1.type());
 
@@ -266,6 +271,9 @@ static nb::object replace_grad(nb::handle h0, nb::handle h1) {
                          i3 = ((uint32_t) i1) | ((i2 >> 32) << 32);
 
                 s.init_index(i3, inst_ptr(h3));
+            } else {
+                uint32_t index = (uint32_t) s.index(inst_ptr(h1));
+                s.init_index(index, inst_ptr(h3));
             }
         }
     } rg;

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -1233,12 +1233,35 @@ def test090_replace_grad(t):
     z = t(1.0, 2.0 ,3.0)
     dr.enable_grad(a, z)
     b = dr.replace_grad(z, a)
-
     assert type(b) is type(a)
     assert dr.width(b) == dr.width(z) == 3
     assert dr.width(dr.grad(b) == 3)
     assert b.index_ad != 0
     assert b.index_ad != a.index_ad
+
+    UInt32 = dr.uint32_array_t(t)
+    a = {
+        "one": t(1, 2, 3),
+        "two": UInt32(0, 2, 4),
+        "three": True
+    }
+    y = {
+        "one": t(1, 2, 3),
+        "two": UInt32(0, 2, 4),
+        "three": False
+    }
+    dr.enable_grad(y)
+    b = dr.replace_grad(a, y)
+    assert type(b["one"]) is type(a["one"])
+    assert type(b["two"]) is type(a["two"])
+    assert b["one"].index_ad != 0
+    assert b["one"].index_ad != a["one"].index_ad
+    assert b["two"].index_ad == 0
+    assert b["two"].index_ad == y["two"].index_ad
+    assert dr.allclose(b["two"], y["two"])
+    assert dr.allclose(b["two"], [0, 2, 4])
+    assert b["three"] == True
+    assert y["three"] == False
 
 @pytest.test_arrays('is_diff,float32,shape=(*)')
 def test091_safe_functions(t):


### PR DESCRIPTION
This PR changes the semantics of `dr.replace_grad(a, b)`:
* For non-differentiable types, the function call returns `a` rather than the default initialization. For example, if `a = dr.auto.ad.UInt32(0, 1, 2)` then the function now returns `a` instead of `dr.auto.ad.UInt32()` (zero-width value).
* Non unknown types, it will also just return `a` rather than `None`.

This is helpful for Mitsuba records which are `DRJIT_STRUCT`s, where it would result in a ragged value as non-differentiable members of the struct had width 0. The workaround was to exhaustively call `replace_grad` for each differentiable member.

I don't have a strong opinion on how to handle non-Dr.Jit types, it seemed natural to return the unchanged primal value there too.