### PR TITLE
Added a new `VarType::BaseFloat` for Python type promotion

### DIFF
--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -3398,7 +3398,7 @@ Index ad_var_block_reduce(ReduceOp op, Index index, uint32_t block_size, int sym
 
 static const char *type_name_short[(int) VarType::Count] {
     "void ", "msk", "i8",  "u8",  "i16", "u16", "i32",
-    "u32", "i64", "u64", "ptr", "f16", "f32", "f64"
+    "u32", "i64", "u64", "ptr", "???", "f16", "f32", "f64"
 };
 
 

--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -24,17 +24,17 @@ bool meta_check(ArrayMeta m) noexcept {
 
 static const char *type_name_lowercase[] = {
     "void", "bool", "int8", "uint8", "int16", "uint16", "int32", "uint32",
-    "int64", "uint64", "pointer", "float162", "float32", "float64"
+    "int64", "uint64", "pointer", "base_float", "float16", "float32", "float64"
 };
 
 static const char *type_name[] = {
     "Void", "Bool", "Int8", "UInt8", "Int16", "UInt16", "Int", "UInt",
-    "Int64", "UInt64", "Pointer", "Float16", "Float", "Float64"
+    "Int64", "UInt64", "Pointer", "BaseFloat", "Float16", "Float", "Float64"
 };
 
 static const char *type_suffix[] = {
     "?", "b", "i8", "u8", "i16", "u16", "i", "u",
-    "i64", "u64", "p", "f16", "f", "f64"
+    "i64", "u64", "p", "", "f16", "f", "f64"
 };
 
 /// Convert a metadata record into a string representation (for debugging)
@@ -175,7 +175,7 @@ ArrayMeta meta_get(nb::handle h) noexcept {
         }
         m.type = (uint8_t) vt;
     } else if (tp.is(&PyFloat_Type)) {
-        m.type = (uint8_t) VarType::Float32;
+        m.type = (uint8_t) VarType::BaseFloat;
     } else if (tp.is(&PyTuple_Type) || tp.is(&PyList_Type)) {
         Py_ssize_t len = PySequence_Size(h.ptr());
 
@@ -299,7 +299,7 @@ ArrayMeta meta_get_general(nb::handle h) noexcept {
     else if (h.is(&PyLong_Type))
         m.type = (uint8_t) VarType::Int32;
     else if (h.is(&PyFloat_Type))
-        m.type = (uint8_t) VarType::Float32;
+        m.type = (uint8_t) VarType::BaseFloat;
     else
         m.is_valid = false;
 
@@ -349,6 +349,9 @@ void promote(nb::object *o, size_t n, bool select) {
 
     if (!meta_check(m))
         nb::raise("Incompatible arguments.");
+
+    if ((VarType) m.type == VarType::BaseFloat)
+        m.type = (uint32_t) VarType::Float32;
 
     for (size_t i = 0; i < n; ++i) {
         // if this is a compatible Dr.Jit array

--- a/src/python/traits.cpp
+++ b/src/python/traits.cpp
@@ -72,6 +72,9 @@ nb::object expr_t(nb::handle h0, nb::handle h1) {
               m1 = meta_get_general(h1),
               m  = meta_promote(m0, m1);
 
+    if ((VarType) m.type == VarType::BaseFloat)
+        m.type = (uint32_t) VarType::Float32;
+
     if (!meta_check(m))
         nb::raise_type_error(
             "drjit.expr_t(): incompatible types \"%s\" and \"%s\"",

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -114,3 +114,13 @@ def test4_binop_promote_ad():
     assert type(x) is dr.llvm.ad.Complex2f
     x = dr.zeros(dr.llvm.ad.Float) + dr.zeros(dr.llvm.Complex2f)
     assert type(x) is dr.llvm.ad.Complex2f
+
+
+@pytest.test_arrays('float16, shape=(*)')
+def test5_half_precision_promotion(t):
+    x = t(1.0)
+    y = x + 1
+    z = x + 1.0
+    assert dr.type_v(x) == dr.VarType.Float16
+    assert dr.type_v(y) == dr.VarType.Float16
+    assert dr.type_v(z) == dr.VarType.Float16


### PR DESCRIPTION
This commit adds a dummy member `VarType::BaseFloat` to the `VarType` enumeration. This type cannot be used for actual computation.

It is a placeholder to be used in situations where we haven't quite decided what floating point precision to assign to a floating point variable (E.g. a Python scalar float).

This allows us to compute things like `Float16(1.0) + 2.0` without the `2.0` being interpreted as `Float32`, causing an unwanted cast to a higher precision.