### PR TITLE
[doc] Various typo fixes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ conveying a medical connotation that is emphasized by the `Rod of Asclepius
 <https://en.wikipedia.org/wiki/Rod_of_Asclepius>`_. Differentiable rendering
 algorithms are growing beyond our control in terms of conceptual and
 implementation-level complexity. A doctor is a person, who can offer help in
-such a time of great need. *Dr.Jit* tries to fill this role to to improve the
+such a time of great need. *Dr.Jit* tries to fill this role to improve the
 well-being of differentiable rendering researchers.
 
 *Dr.Jit* is the successor of the `Enoki

--- a/docs/autodiff.rst
+++ b/docs/autodiff.rst
@@ -19,7 +19,7 @@ Consider a program that consumes certain inputs :math:`x_1`, :math:`x_2`, etc.,
 performs a computation, and then generates outputs :math:`y_1`, :math:`y_2`,
 etc. Systems for *automatic differentiation* (AD) automate the computation of
 derivatives :math:`\partial y_i/\partial x_i`, which is instrumental when the
-program should be be optimized to accomplish a certain task.
+program should be optimized to accomplish a certain task.
 
 AD does this by decomposing the program into a sequence of steps that are
 individually easy to differentiate. Given such a decomposition, it then applies
@@ -224,7 +224,7 @@ this as well.
 
 As a consequence, gradients are only stored in *leaf* variables, which refers
 to variables that aren't referenced by other computation (*forward mode*), or
-variables that were made made differentiable via :py:func:`drjit.enable_grad()`
+variables that were made differentiable via :py:func:`drjit.enable_grad()`
 (*reverse mode*).
 
 If you require derivatives of interior nodes, simply pass the ``flags=`` parameter
@@ -325,7 +325,7 @@ feature are noteworthy:
 Visualizations
 --------------
 
-It is possible to visualize the AD computation graph graph via
+It is possible to visualize the AD computation graph via
 :py:func:`dr.graphviz_ad() <graphviz_ad>` (this requires installing the
 ``graphviz`` `PyPI package <https://pypi.org/project/graphviz/>`__).
 Variables can be labeled to identify them more easily.

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -84,7 +84,7 @@ members:
 
 Static 1-4D arrays also support `swizzling
 <https://en.wikipedia.org/wiki/Swizzling_(computer_graphics)>`__, which
-arbitrarily reorders elements. For example, the following compact compact
+arbitrarily reorders elements. For example, the following compact
 notation updates and combines entries of a larger array.
 
 .. code-block:: python

--- a/docs/bench.rst
+++ b/docs/bench.rst
@@ -39,7 +39,7 @@ we could add a call to :py:func:`dr.sync_thread()`.
    dr.sync_thread(y)
    end = time.end()
 
-However,explicit synchronization is generally an *anti-pattern* and not
+However, explicit synchronization is generally an *anti-pattern* and not
 recommended. Measuring kernels timings on the CPU will also add considerable
 noise due to OS scheduling, etc.
 

--- a/docs/cflow.rst
+++ b/docs/cflow.rst
@@ -257,7 +257,7 @@ The advantage of symbolic mode is that it can keep variable state in fast
 CPU/GPU registers, which improves performance and reduces storage costs.
 
 The main *disadvantage* is that symbolic variables cannot be evaluated while
-tracing. Likewise, they cannot be passed to other frameworks like like PyTorch or
+tracing. Likewise, they cannot be passed to other frameworks like PyTorch or
 Tensorflow. Indeed, *any* attempt to reveal the content of symbolic variables
 is doomed to fail since it literally does not exist (yet). The upcoming section
 on :ref:`variable evaluation <eval>` clarifies what operations require
@@ -280,7 +280,7 @@ usually outweigh these disadvantages.
      :py:func:`dr.print() <drjit.print>` that prints in a delayed manner
      (i.e., asynchronously from the device) to avoid this problem.
 
-   - Symbolic mode tends to create much large kernels. Indeed, the idea is to
+   - Symbolic mode tends to create much larger kernels. Indeed, the idea is to
      preserve the entire program and generate one giant output kernel (a
      *megakernel*). Such large kernels can be costly to compile, though
      this cost is usually offset by *kernel caching* discussed in the next

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -314,7 +314,7 @@ Here is what's new:
   :py:attr:`drjit.ArrayBase.index_ad`) used to monotonically increase as
   variables were being created. Internally, multiple hash tables were needed to
   associate these ever-growing indices with locations in an internal variable
-  array, which which had a surprisingly large impact on tracing performance.
+  array, which had a surprisingly large impact on tracing performance.
   Dr.Jit removes this mapping both at the AD and JIT levels and eagerly reuses
   variable indices.
 

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -510,7 +510,7 @@ trees:
     }
 
 The type trait :cpp:var:`dr::is_traversable\<T\> <drjit::is_traversable_v>`
-checks if an instance of a particular type type can be traversed.
+checks if an instance of a particular type can be traversed.
 
 The helper functions :cpp:func:`drjit::traverse_1`
 :cpp:func:`drjit::traverse_2`, :cpp:func:`drjit::traverse_3`, respectively

--- a/docs/eval.rst
+++ b/docs/eval.rst
@@ -214,7 +214,7 @@ Kernel caching
 When Dr.Jit evaluates an expression, it must generate and compile a *kernel*,
 i.e., a self-contained parallel program that can run on the target device. This
 compilation step is not free---in fact, compilation can sometimes take *longer*
-than the actual runtime of a associated kernel.
+than the actual runtime of an associated kernel.
 
 To mitigate this cost, Dr.Jit implements a *kernel cache*. Roughly speaking,
 the idea is that we often end up repeating the same kind of computation with
@@ -341,7 +341,7 @@ this list.
       - device            : 4 KiB/4 KiB used (peak: 4 KiB).
 
 
-It shows that a three variables are registered with the system, of which one
+It shows that three variables are registered with the system, of which one
 (index 4, label ``y``) is evaluated and occupies 4 KiB of device memory on CUDA
 device 0.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -319,7 +319,7 @@ Matrices change the behavior of various operations:
 - True division (``arg0 / arg1``) with a matrix-valued denominator ``arg1``
   involves a matrix inverse.
 
-- Additionally, the following operations generalize by internally replace
+- Additionally, the following operations generalize by internally replacing
   ordinary multiplication and division operations with their matrix analogs:
 
   - :py:func:`drjit.fma`

--- a/docs/what.rst
+++ b/docs/what.rst
@@ -218,7 +218,7 @@ difference between the two can be quite subtle.
 
 However, the program and metaprogram could also be different. For example,
 let's modify the code so that it asks the user to enter a number on the
-keyboard that is then used to to raise the integrand to a custom power:
+keyboard that is then used to raise the integrand to a custom power:
 
 .. code-block:: python
    :emphasize-lines: 3
@@ -316,4 +316,3 @@ this documentation explain how Dr.Jit generalizes to bigger programs:
    debugging, printing, benchmarking, pitfalls
    how to clear the cache for benchmarking
    faq
-

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -2224,7 +2224,7 @@ def rand(dtype: Type[ArrayT],
 
        This function is still considered experimental, and the algorithm used
        to generate random variates may change in future versions of Dr.Jit.
-       Specify ``version=1`` to to ensure that your program remains unaffected
+       Specify ``version=1`` to ensure that your program remains unaffected
        by such future changes.
 
     .. note::

--- a/drjit/interop.py
+++ b/drjit/interop.py
@@ -636,7 +636,7 @@ def wrap(source: typing.Union[str, types.ModuleType],
 
          - **Limitation**: The passed/returned :ref:`PyTrees <pytrees>` can
            contain arbitrary arrays or tensors, but other types
-           (e.g., a custom Python object not understood by PyTorch) will will
+           (e.g., a custom Python object not understood by PyTorch) will
            raise errors when differentiating in *forward mode* (backward mode
            works fine).
 

--- a/drjit/opt.py
+++ b/drjit/opt.py
@@ -95,7 +95,7 @@ class Optimizer(Generic[Extra], MutableMapping[str, dr.ArrayBase]):
 
          Compared to PyTorch, an optimization loop therefore involves some
          boilerplate code (e.g., ``my_param = opt["my_param"]``) to fetch
-         parameter values and and use them to compute a differentiable
+         parameter values and use them to compute a differentiable
          objective.
 
        In general, it is recommended that you optimize Dr.Jit code using Dr.Jit
@@ -147,7 +147,7 @@ class Optimizer(Generic[Extra], MutableMapping[str, dr.ArrayBase]):
 
             mask_updates (bool):
                 Set this parameter to ``True`` to mask updates to zero-valued
-                gradient components. This can can be preferable in some types
+                gradient components. This can be preferable in some types
                 of differentiable Monte Carlo simulations, where only a subset
                 of the parameters is observed during a typical optimization
                 step.
@@ -1119,7 +1119,7 @@ class GradScaler:
                 to begin exploring larger scale factors.
 
             debug (bool):
-                Print a debug message whenever the scale changes. This this
+                Print a debug message whenever the scale changes. This
                 synchronizes with the device after each step, which will have a
                 negative effect on optimization performance.
         """

--- a/include/drjit/custom.h
+++ b/include/drjit/custom.h
@@ -31,7 +31,7 @@ NAMESPACE_BEGIN(detail)
  * reverse mode. In some cases, it may be useful or even necessary to tell
  * it how a particular operation should be differentiated.
  *
- * To do so, extend this class and and provide callback functions that will be
+ * To do so, extend this class and provide callback functions that will be
  * invoked when the AD backend traverses the associated node in the computation
  * graph. This class also provides a convenient way of stashing temporary
  * results during the original function evaluation that can be accessed later

--- a/include/drjit/math.h
+++ b/include/drjit/math.h
@@ -1552,7 +1552,7 @@ template <typename Value, bool Native> Value erf(const Value &x) {
     }
 }
 
-// Inverse real error function approximation based on on "Approximating the
+// Inverse real error function approximation based on "Approximating the
 // erfinv function" by Mark Giles
 template <typename Value> Value erfinv(const Value &x) {
     Value w = -log((Value(1.f) - x) * (Value(1.f) + x));

--- a/resources/remez.h
+++ b/resources/remez.h
@@ -508,7 +508,7 @@ template<typename Target, typename Source> Target memcpy_cast(const Source &sour
 /**
  * \brief Atomic floating point data type
  *
- * The class implements an an atomic floating point data type (which is not
+ * The class implements an atomic floating point data type (which is not
  * possible with the existing overloads provided by <tt>std::atomic</tt>). It
  * internally casts floating point values to an integer storage format and uses
  * atomic integer compare and exchange operations to perform changes.

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -5352,8 +5352,8 @@
 
        def dispatch(inst, target, *args, **kwargs):
            result = []
-           for in in inst:
-               result.append(target(inst, *args, **kwargs))
+           for inst_ in inst:
+               result.append(target(inst_, *args, **kwargs))
 
     However, the implementation accomplishes this more efficiently using only a
     single call per unique instance. Instead of a Python ``list``, it returns a

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -611,7 +611,7 @@
     Python's `PEP 465 <https://peps.python.org/pep-0465/>`__. There is no practical
     difference between using :py:func:`drjit.matul()` or ``@`` in Dr.Jit-based
     code. Multiplication of matrix types (e.g., :py:class:`drjit.scalar.Matrix2f`)
-    using the standard multiplication operator (``*``) is also based on on matrix
+    using the standard multiplication operator (``*``) is also based on matrix
     multiplication.
 
     This function takes two Dr.Jit arrays and picks one of the following 5 cases
@@ -651,7 +651,7 @@
 
        This operation only handles fixed-sizes arrays. A different approach is
        needed for multiplications involving potentially large dynamic
-       arrays/tensors. Other other tools like PyTorch, JAX, or Tensorflow will be
+       arrays/tensors. Other tools like PyTorch, JAX, or Tensorflow will be
        preferable in such situations (e.g., to train neural networks).
 
     Args:
@@ -3700,7 +3700,7 @@
     are connected by an edge and subsequently separately differentiated.
 
     In advanced applications that require multiple AD traversals of the same graph,
-    specify specify different combinations of the enumeration
+    specify different combinations of the enumeration
     :py:class:`drjit.ADFlag` via the ``flags`` parameter.
 
     Args:
@@ -4631,7 +4631,7 @@
 
     2. **Evaluated mode**: Dr.Jit *evaluates* the inputs  ``index``, ``args``,
        ``kwargs`` via :py:func:`drjit.eval`, groups them by ``index``, and invokes
-       each function with with the subset of inputs that reference it. Callables
+       each function with the subset of inputs that reference it. Callables
        that are not referenced by any element of ``index`` are ignored.
 
        In this mode, a :py:func:`drjit.switch` statement will cause Dr.Jit to
@@ -5039,7 +5039,7 @@
           :py:attr:`drjit.JitFlag.SymbolicLoops` and then either performs a
           symbolic or an evaluated loop.
 
-        compress (Optional[bool]): Set this this parameter to ``True`` or ``False``
+        compress (Optional[bool]): Set this parameter to ``True`` or ``False``
           to enable or disable *loop state compression* in evaluated loops (see the
           text above for a description of this feature). The function
           queries the value of :py:attr:`drjit.JitFlag.CompressLoops` when the
@@ -5635,7 +5635,7 @@
     more verbose debug level).
 
     Dr.Jit aggressively reuses the indices of expired variables by default, but
-    this can make debug output difficult to interpret. When when debugging Dr.Jit
+    this can make debug output difficult to interpret. When debugging Dr.Jit
     itself, it is often helpful to investigate the history of a particular
     variable. In such cases, set this flag to ``False`` to disable variable reuse
     both at the JIT and AD levels. This comes at a cost: the internal data
@@ -5873,7 +5873,7 @@
     On the LLVM backend, the operation replaces vector/scatter instructions
     with a combination of aligned packet loads/stores and a matrix transpose
     (implemented for 2, 4, and 8-D inputs, larger vectors perform several 8D
-    transposes). Speedups here are are rather dramatic (up to >20× for
+    transposes). Speedups here are rather dramatic (up to >20× for
     scatters, 1.5-2× for gathers have been measured).
 
     This optimization is expected to make an even bigger difference following
@@ -6615,7 +6615,7 @@
     :py:func:`drjit.compress()`, which can likewise be used to reduce a stream to a
     smaller subset of active items. The downside of :py:func:`drjit.compress()` is
     that it requires evaluating the variables to be reduced, which can be very
-    costly in terms of of memory traffic and storage footprint. Reducing through
+    costly in terms of memory traffic and storage footprint. Reducing through
     :py:func:`drjit.scatter_inc()` does not have this limitation: it can operate on
     symbolic arrays that greatly exceed the available device memory. One advantage
     of :py:func:`drjit.compress()` is that it essentially boils down to a
@@ -6839,7 +6839,7 @@
        **Technical details on symbolic printing**
 
        When Dr.Jit compiles and executes queued computation on the target device,
-       it includes additional code for symbolic print operations that that captures
+       it includes additional code for symbolic print operations that captures
        referenced arguments and copies them back to the host (CPU). The information
        is then printed following the end of that process.
 
@@ -6908,7 +6908,7 @@
           thread_id=[0, 0, 1, 1, 1], i=[0, 1, 0, 1, 2]
 
        The example above runs a symbolic loop twice in parallel: the first thread
-       runs for for 2 iterations, and the second runs for 3 iterations. The loop
+       runs for 2 iterations, and the second runs for 3 iterations. The loop
        prints the iteration counter ``i``, which then leads to the output ``[0, 1,
        0, 1, 2]`` where the first two entries are produced by the first thread, and
        the trailing three belong to the second thread. The ``thread_id`` output
@@ -6978,7 +6978,7 @@
     the number of items being processed in parallel.
 
     The function raises an exception when the input(s) is ragged, i.e., when it
-    contains arrays with incompatible sizes. It returns ``1`` if if the input is
+    contains arrays with incompatible sizes. It returns ``1`` if the input is
     scalar and/or does not contain any Dr.Jit arrays.
 
     Args:
@@ -7321,7 +7321,7 @@
 
     Compilation strategy for atomic scatter-reductions.
 
-    Elements of of this enumeration determine how Dr.Jit executes *atomic
+    Elements of this enumeration determine how Dr.Jit executes *atomic
     scatter-reductions*, which refers to indirect writes that update an existing
     element in an array, while avoiding problems arising due to concurrency.
 
@@ -7351,7 +7351,7 @@
 
     - use :py:attr:`drjit.ReduceMode.Expand` if the computation uses the LLVM
       backend and the ``target`` array storage size is smaller or equal
-      than than the value given by :py:func:`drjit.expand_threshold`. This
+      than the value given by :py:func:`drjit.expand_threshold`. This
       threshold can be changed using the :py:func:`drjit.set_expand_threshold`
       function.
 

--- a/src/python/reduce.cpp
+++ b/src/python/reduce.cpp
@@ -220,7 +220,7 @@ nb::object reduce(uint32_t op, nb::handle h, nb::handle axis_, nb::handle mode) 
         int ndim = (int)::ndim(h);
         if (ndim == 0) {
             int value;
-            // Accept 0-dim tensors and axis==0 (the default); return the the
+            // Accept 0-dim tensors and axis==0 (the default); return the
             // tensor without changes instead of failing with an error message.
             if (nb::try_cast(axis_, value) && value == 0)
                 return nb::borrow(h);
@@ -510,7 +510,7 @@ nb::object mean(nb::handle value, nb::handle axis, nb::handle mode) {
     }
 
     // mean = sum / (num_input/num_output)
-    return (out * prod(shape(out), nb::none())) / prod(shape(value), nb::none()); 
+    return (out * prod(shape(out), nb::none())) / prod(shape(value), nb::none());
 }
 
 nb::object dot(nb::handle h0, nb::handle h1) {

--- a/src/python/tracker.cpp
+++ b/src/python/tracker.cpp
@@ -375,7 +375,7 @@ bool VariableTracker::Impl::traverse(Context &ctx, nb::handle h) {
 
             if (!idx && new_variable && ctx.write) {
                 // This case arises when revisiting a state variables as part
-                // of an AD traversal. This state state will have been passed
+                // of an AD traversal. This state will have been passed
                 // through drjit.detail.reset(), which creates a structural copy
                 // with uninitialized Dr.Jit arrays.
 

--- a/tests/test_while_loop_ad.py
+++ b/tests/test_while_loop_ad.py
@@ -226,7 +226,7 @@ def test09_sum_loop_extra(t, mode):
 
         return y
 
-    # Construct an array so that the the m_inputs field in LoopOp looks like this:
+    # Construct an array so that the m_inputs field in LoopOp looks like this:
     # [{has_grad_in = false, ...}, {has_grad_in = true, ...}, {has_grad_in = false, ...}]
     l = [t(1), t(2)]
     dr.make_opaque(l[0])


### PR DESCRIPTION
I went through the v1.0.x docs linearly to update some of my code using drjit v0.4.x. In the process I found a few typos.

This PR only touches documentation.