### PR TITLE
API to convolve arrays/tensors with continuous convolution kernels

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -116,6 +116,7 @@ Rearranging array contents
 .. autofunction:: tile
 .. autofunction:: repeat
 .. autofunction:: resample
+.. autofunction:: convolve
 
 Random number generation
 ------------------------

--- a/include/drjit/resample.h
+++ b/include/drjit/resample.h
@@ -34,7 +34,7 @@ public:
      * Create a Resampler that uses a predefined reconstruction filter to
      * resample a signal from resolution ``source_res`` to ``target_res``.
      *
-     * The following options are available:
+     * The following ``filter`` presets are available:
      *
      * - ``"box"``: use nearest-neighbor interpolation/averaging. This is
      *   very efficient but generally produces sub-par output that is either
@@ -44,16 +44,29 @@ public:
      *    reconstruct each output sample when upsampling. Tends to produce
      *    relatively blurry results.
      *
-     * - ``"cubic"``: use cubic filter kernel that uses 4 neighbors to
+     * - ``"hamming"``: uses the same number of input samples as ``"linear"``
+     *    but better preserves sharpness when downscaling. Do not use for
+     *    upscaling.
+     *
+     * - ``"cubic"``: use cubic filter kernel that queries 4 neighbors to
      *   reconstruct each output sample when upsampling. Produces high-quality
      *   results.
      *
-     * - ``"lanczos"``: use a windowed Lanczos filter that uses 6 neighbors to
-     *   reconstruct each output sample when upsampling. This is the best filter
-     *   for smooth signals, but also the costliest. The Lanczos filter is
-     *   susceptible to ringing when the input array contains discontinuities.
+     * - ``"lanczos"``: use a windowed Lanczos filter that queries 6 neighbors
+     *   to reconstruct each output sample when upsampling. This is the best
+     *   filter for smooth signals, but also the costliest. The Lanczos filter
+     *   is susceptible to ringing when the input array contains discontinuities.
+     *
+     * - ``"gaussian"``: use a Gaussian filter that queries 4 neighbors to
+     *    reconstruct each output sample when upsampling. The Gaussian has a
+     *    standard deviation of 0.5 and is truncated after 4 standard
+     *    deviations. This filter is mainly useful when intending to blur a signal.
+     *
+     * The optional ``radius_scale`` parameter can be used to scale the
+     * filter kernel radius.
      */
-    Resampler(uint32_t source_res, uint32_t target_res, const char *filter);
+    Resampler(uint32_t source_res, uint32_t target_res, const char *filter,
+              double radius_scale = 1.0);
 
     /**
      * \brief Construct a Resampler using a custom filter kernel.

--- a/src/python/resample.cpp
+++ b/src/python/resample.cpp
@@ -10,6 +10,7 @@
 
 #include <drjit/resample.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/optional.h>
 #include "common.h"
 
 void export_resample(nb::module_ &) {
@@ -18,19 +19,19 @@ void export_resample(nb::module_ &) {
 
     auto resampler = nb::class_<Resampler>(detail, "Resampler")
         .def("__init__", [](Resampler *self, uint32_t source_res, uint32_t target_res,
-                            const char *filter, nb::handle filter_radius) {
-                 if (!filter_radius.is_none())
+                            const char *filter, std::optional<double> filter_radius, bool convolve) {
+                 if (filter_radius.has_value() && !convolve)
                      nb::raise("drjit.Resampler(): 'filter_radius' must be None when using a filter preset.");
-                 new (self) Resampler(source_res, target_res, filter);
-             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a = nb::none())
+                 new (self) Resampler(source_res, target_res, filter, filter_radius.has_value() ? filter_radius.value() : 1.0);
+             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a = nb::none(), "convolve"_a = false)
         .def("__init__", [](Resampler *self, uint32_t source_res, uint32_t target_res,
-                            nb::typed<nb::callable, float, float> filter, double filter_radius) {
+                            nb::typed<nb::callable, float, float> filter, double filter_radius, bool) {
                  Resampler::Filter filter_cb = [](double v, const void *ptr) -> double {
                      return nb::cast<double>(nb::handle((PyObject *) ptr)(v));
                  };
                  new (self) Resampler(source_res, target_res, filter_cb,
                                       filter.ptr(), filter_radius);
-             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a)
+             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a, "convolve"_a = false)
 #if defined(DRJIT_ENABLE_CUDA)
          .def("resample_fwd",
               (dr::CUDAArray<dr::half>(Resampler::*)(const dr::CUDAArray<dr::half> &, uint32_t) const) &Resampler::resample_fwd,

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -102,3 +102,14 @@ def test06_manual_filter(t):
     )
 
     assert dr.allclose(r1, r2)
+
+# Test filtering a signal without changing its resolution
+@pytest.test_arrays('float, -jit, shape=(*)')
+def test07_convolve(t):
+    x = t(1, 2, 10, 100)
+    y = dr.convolve(x, 'linear', 1)
+    assert dr.allclose(x, y)
+
+    y = dr.convolve(x, 'linear', 2)
+    z = t((1+2*.5)/1.5, (1*.5+2+10*.5)/2, (2*.5+10+100*.5)/2, (100+10*.5)/1.5)
+    assert dr.allclose(y, z)


### PR DESCRIPTION
This PR adds new function ``drjit.convolve()`` that repurposes the ``drjit.resample()`` infrastructure to convolve one or more axes of a Dr.Jit array or tensor with a 1D filter. The user can choose one of multiple presets or specify a custom function.