### PR TITLE
Coopvec hashgrid

### DIFF
--- a/drjit/nn.py
+++ b/drjit/nn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import drjit
 import sys
+from dataclasses import dataclass, field
 
 if sys.version_info < (3, 11):
     from typing_extensions import Tuple, Sequence, Union, Type, TypeAlias, Optional, Any
@@ -503,204 +504,343 @@ class SinEncode(Module):
         return CoopVec(r)
 
 
-class PyHashGrid3D:
+def cosine_ramp(x):
+    """ "Smoothed" ramp to help features blend-in without instabilities"""
+    return 0.5 * (1.0 - drjit.cos(drjit.pi * x))
+
+def div_round_up(num: int, divisor: int) -> int:
+    return (num + divisor - 1) // divisor
+
+
+def next_multiple(num: int, multiple: int) -> int:
+    return multiple * div_round_up(num, multiple)
+
+@dataclass
+class HashGridConfig:
+    dimension: int
+    num_levels: int
+    num_features: int
+    hashmap_size: int
+    base_res: int
+    per_level_scale: float
+    log2_per_level_scale: float
+    align_corners: bool
+    torchngp_compat: bool
+    smooth_weight_gradients: bool
+    smooth_weight_lambda: float
+    grid_offsets: list
+    level_offsets: list
+    cell_sizes: list
+
     def __init__(
         self,
-        array_type,
-        hashmap_size: int,
-        num_levels: int,
-        base_res: int,
-        per_level_scale: float,
-        num_features: int = 2,
+        dimension: int = -1,
+        num_levels: int = -1,
+        num_features: int = -1,
+        hashmap_size: int = 2**19,
+        base_res: int = 16,
+        per_level_scale: float = 2,
+        log2_per_level_scale: float = 1,
         align_corners: bool = False,
         torchngp_compat: bool = False,
-        grid_lod: GridLod = None,
         smooth_weight_gradients: bool = False,
         smooth_weight_lambda: float = 1.0,
-    ):
-        """Python-based implementation of the INGP hashgrid.
-
-        :parameter smooth_weight_gradients: whether to smooth the gradients of the weights
-            by using a straight-through estimator.
-        :parameter smooth_weight_lambda: the value of lambda used for the straight-through estimator.
-        """
-        # Note: we don't want to lose precision during e.g. interpolation
-        # weight computations, so we will still use f32 in many computation
-        # even when the `array_type` is `mi.Float16`.
-        self.StorageFloat = array_type
-        self.Float = dr.float32_array_t(array_type) if dr.is_half_v(array_type) else array_type
-        self.VectorDf = {
-            (mi.Float16, 2): mi.Vector2f,  # Still f32
-            (mi.Float32, 2): mi.Vector2f,
-            (mi.Float64, 2): mi.Vector2d,
-            (mi.Float16, 3): mi.Vector3f,  # Still f32
-            (mi.Float32, 3): mi.Vector3f,
-            (mi.Float64, 3): mi.Vector3d,
-        }[(array_type, self.dimensionality())]
-        self.VectorDu = dr.uint32_array_t(self.VectorDf)
-
-        self._hashmap_size = hashmap_size
-        self._num_levels = num_levels
-        self._base_res = base_res
-        self._per_level_scale = per_level_scale
-        self.log2_per_level_scale = dr.log2(self._per_level_scale)
-        self._num_features = num_features
-        self._align_corners = align_corners
-
-        # TODO: add support for Torch NGP indexing compatibility
-        self._torchngp_compat = torchngp_compat
-        if self._torchngp_compat:
-            raise NotImplementedError("Not supported yet: `torchngp_compat = True` in the Python-based hashgrid.")
-
-        self.grid_lod = grid_lod
-
-        assert (self._hashmap_size % 8) == 0
-
-        self.level_offsets = [None] * (self._num_levels + 1)
-        self.cell_sizes = [0.0] * self._num_levels
-        max_params = dr.largest(dr.scalar.UInt32) // 2
-        dimensionality = self.dimensionality()
-        offset = 0
-        for level_i in range(self._num_levels):
-            res = self._grid_resolution(self._grid_scale(level_i))
-            stride = dr.power(float(res), dimensionality)
-            params_in_level = int(max_params) if (stride > max_params) else (res**dimensionality)
-            params_in_level = next_multiple(params_in_level, 8)
-            params_in_level = min(params_in_level, self._hashmap_size)
-
-            self.level_offsets[level_i] = offset
-            self.cell_sizes[level_i] = 1.0 / (self._base_res * self._per_level_scale**level_i)
-            offset += params_in_level
-
-        self.level_offsets[-1] = offset
-
-        self.current_step = 0
+        grid_offsets: list = [],
+        level_offsets: list = [],
+        cell_sizes: list = [],
+    ) -> None:
+        self.dimension = dimension
+        self.num_levels = num_levels
+        self.num_features = num_features
+        self.hashmap_size = hashmap_size
+        self.base_res = base_res
+        self.per_level_scale = per_level_scale
+        self.log2_per_level_scale = log2_per_level_scale
+        self.align_corners = align_corners
+        self.torchngp_compat = torchngp_compat
         self.smooth_weight_gradients = smooth_weight_gradients
         self.smooth_weight_lambda = smooth_weight_lambda
+        self.grid_offsets = grid_offsets
+        self.level_offsets = level_offsets
+        self.cell_sizes = cell_sizes
 
-        params_size = self.level_offsets[-1] * self._num_features
-        self.data = dr.zeros(array_type, params_size)
 
-    @annotate("PyHashGrid3D.__call__")
+class HashGridEncoding(Module):
+    DRJIT_STRUCT = {
+        "data": drjit.ArrayBase,
+        "dtype": type,
+        "_config": HashGridConfig,
+    }
+
+    def __init__(
+        self,
+        dimension: int = -1,
+        num_levels: int = -1,
+        num_features: int = -1,
+        *,
+        hashmap_size: int = 2**19,
+        base_res: int = 16,
+        per_level_scale: float = 2,
+        align_corners: bool = False,
+        torchngp_compat: bool = False,
+        smooth_weight_gradients: bool = False,
+        smooth_weight_lambda: float = 1.0,
+    ) -> None:
+        self._config = HashGridConfig(
+            dimension=dimension,
+            hashmap_size=hashmap_size,
+            num_levels=num_levels,
+            base_res=base_res,
+            per_level_scale=per_level_scale,
+            num_features=num_features,
+            align_corners=align_corners,
+            torchngp_compat=torchngp_compat,
+            log2_per_level_scale=drjit.log2(per_level_scale),
+            smooth_weight_gradients=smooth_weight_gradients,
+            smooth_weight_lambda=smooth_weight_lambda,
+        )
+
     def __call__(
-        self, p: mi.Array3f | mi.Array3h | list[mi.Float32] | list[mi.Float16], active: dr.ArrayBase
-    ) -> list[mi.Float32] | list[mi.Float16]:
-        # TODO: check if faster as a drjit loop (although then a custom backward is mandatory)
-        assert len(p) == 3
+        self, p: drjit.ArrayBase | list[drjit.ArrayBase] | CoopVec, active=True
+    ) -> CoopVec:
+        dtype = self.dtype
+        mod = sys.modules[dtype.__module__]
+        StorageFloat = dtype
+        UInt32 = drjit.uint32_array_t(dtype)
+        ArrayXu = mod.ArrayXu
+        StorageFloatXf = mod.ArrayXf16 if drjit.is_half_v(dtype) else mod.ArrayXf
 
-        p = self.VectorDf(*p)
-        invalid = active & dr.any((p < 0) | (p >= 1))
+        if isinstance(p, CoopVec):
+            p = list(p)
+
+        if isinstance(p, list):
+            PositionFloat = drjit.leaf_t(p[0])
+        else:
+            PositionFloat = drjit.leaf_t(p)
+
+        PositionFloatXf = mod.ArrayXf16 if drjit.is_half_v(PositionFloat) else mod.ArrayXf
+
+        if isinstance(p, list) or isinstance(p, CoopVec):
+            p = PositionFloatXf(p)
+
+        indexing_primes = [1, UInt32(2654435761), UInt32(805459861)]
+
+        invalid = active & drjit.any((p < 0) | (p >= 1))
 
         result = []
-        grid = self.data
 
-        for level_i in range(self._num_levels):
-            if not self.grid_lod.is_level_used(level_i, self.current_step):
-                # Unused level, output some zeros
-                zeros = dr.full(self.StorageFloat, 0, dr.width(p))
-                for _ in range(self._num_features):
-                    result.append(zeros)
-                continue
-
+        for level_i in range(self.num_levels):
             scale = self._grid_scale(level_i)
             res = self._grid_resolution(scale)
-            level_offset = self.level_offsets[level_i]
-            this_level_size = self.level_offsets[level_i + 1] - level_offset
-            num_features_fourth = self._num_features - (self._num_features % 4)
-            num_features_even = self._num_features - (self._num_features % 2)
+            level_offset = self._config.level_offsets[level_i]
+            this_level_size = self._config.level_offsets[level_i + 1] - level_offset
+            num_features_fourth = self.num_features - (self.num_features % 4)
+            num_features_even = self.num_features - (self.num_features % 2)
 
-            omega_l = self.grid_lod.interpolation_weight(level_i, self.current_step)
+            p_offset: float = 0.0 if self.align_corners else 0.5
+            pos = drjit.fma(p, scale, p_offset)
 
-            def indexing_function(x, y, z):
-                index = x  # Warning: not a copy
-                stride = res
-                if stride <= this_level_size:
-                    index = index + stride * y
-                    stride *= res
-                if stride <= this_level_size:
-                    index = index + stride * z
-                    stride *= res
-
-                if this_level_size < stride:
-                    index = x ^ (y * mi.UInt32(2654435761)) ^ (z * mi.UInt32(805459861))
-
-                sub_grid_index = level_offset + (index % mi.UInt32(this_level_size))
-                return self._num_features * sub_grid_index
-
-            # Unrolls and use packed gathers
-            def acc_features(weight: self.StorageFloat, index: mi.UInt32):
-                if self.smooth_weight_gradients:
-                    weight_smooth = cosine_ramp(weight)
-                    weight = weight + self.smooth_weight_lambda * (weight_smooth - dr.detach(weight_smooth))
-                for k in range(0, num_features_fourth, 4):
-                    v = dr.gather4(self.StorageFloat, grid, index + k, active)
-                    values[k] = dr.fma(v[0], weight, values[k])
-                    values[k + 1] = dr.fma(v[1], weight, values[k + 1])
-                    values[k + 2] = dr.fma(v[2], weight, values[k + 2])
-                    values[k + 3] = dr.fma(v[3], weight, values[k + 3])
-                for k in range(num_features_fourth, num_features_even, 2):
-                    v = dr.gather2(self.StorageFloat, grid, index + k, active)
-                    values[k] = dr.fma(v[0], weight, values[k])
-                    values[k + 1] = dr.fma(v[1], weight, values[k + 1])
-                for k in range(num_features_even, self._num_features):
-                    v = dr.gather(self.StorageFloat, grid, index + k, active)
-                    values[k] = dr.fma(v, weight, values[k])
-
-            # --- Trilinear interpolation at this level
-            # Note: f32 precision, even when StorageFloat is f16
-            p_offset: float = 0.0 if self._align_corners else 0.5
-            pos = dr.fma(p, scale, p_offset)
-            pos0 = dr.floor2int(self.VectorDu, pos)
-            pos1 = pos0 + 1
+            pos0 = ArrayXu(drjit.floor(pos))
 
             w1 = pos - pos0
-            w0 = self.Float(1.0) - w1
+            w0 = 1.0 - w1
 
-            values = [self.StorageFloat(0.0)] * self._num_features
+            # We define a gather function to be able to handle MatrixViews
+            if isinstance(self.data, MatrixView):
+                assert self.data.shape[1] == 1
+                assert self.data.stride == 1
+                def gather(type, source, index, mask, **kwargs):
+                    return drjit.gather(type, source.buffer, self.data.offset + index, mask, **kwargs)
+            else:
+                def gather(type, source, index, mask, **kwargs):
+                    return drjit.gather(type, source, index, mask, **kwargs)
 
-            weight = self.StorageFloat(w0.x * w0.y * w0.z)
-            index = indexing_function(pos0.x, pos0.y, pos0.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w0.x * w0.y * w1.z)
-            index = indexing_function(pos0.x, pos0.y, pos1.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w0.x * w1.y * w0.z)
-            index = indexing_function(pos0.x, pos1.y, pos0.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w0.x * w1.y * w1.z)
-            index = indexing_function(pos0.x, pos1.y, pos1.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w1.x * w0.y * w0.z)
-            index = indexing_function(pos1.x, pos0.y, pos0.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w1.x * w0.y * w1.z)
-            index = indexing_function(pos1.x, pos0.y, pos1.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w1.x * w1.y * w0.z)
-            index = indexing_function(pos1.x, pos1.y, pos0.z)
-            acc_features(weight, index)
-            weight = self.StorageFloat(w1.x * w1.y * w1.z)
-            index = indexing_function(pos1.x, pos1.y, pos1.z)
-            acc_features(weight, index)
+            def indexing_function(pos_grid: ArrayXu):
+                """
+                This function is used to index the underlying data array of the
+                hash grid given a grid position.
+                """
+                stride = 1
+                index = UInt32(0)
+                for d in range(self.dimension):
+                    index += pos_grid[d] * stride
+                    stride *= res
+
+                    if stride > this_level_size:
+                        break
+
+                if this_level_size < stride:
+                    index = UInt32(0)
+                    for d in range(0, self.dimension):
+                        index ^= pos_grid[d] * indexing_primes[d]
+
+                sub_grid_index = level_offset + (index % UInt32(this_level_size))
+                return self.num_features * sub_grid_index
+
+            def acc_features(weight: StorageFloat, index: UInt32):
+                """
+                Accumulates the ``self.num_features`` features at the given index.
+                It tries to use packet gather operations if possible, to improve
+                the performance of the backward pass, as atomic packet scatters
+                perform better than their non packeted counterparts.
+                """
+                if self.smooth_weight_gradients:
+                    weight_smooth = cosine_ramp(weight)
+                    weight = weight + self.smooth_weight_lambda * (weight_smooth - drjit.detach(weight_smooth))
+
+                for k in range(0, num_features_fourth, 4):
+                    v = gather(
+                        StorageFloatXf,
+                        self.data,
+                        (index + k) // 4,
+                        active,
+                        shape=(4, drjit.width(index)),
+                    )
+                    values[k + 0] = drjit.fma(v[0], weight, values[k + 0])
+                    values[k + 1] = drjit.fma(v[1], weight, values[k + 1])
+                    values[k + 2] = drjit.fma(v[2], weight, values[k + 2])
+                    values[k + 3] = drjit.fma(v[3], weight, values[k + 3])
+                for k in range(num_features_fourth, num_features_even, 2):
+                    v = gather(
+                        StorageFloatXf,
+                        self.data,
+                        (index + k) // 2,
+                        active,
+                        shape=(2, drjit.width(index)),
+                    )
+                    values[k + 0] = drjit.fma(v[0], weight, values[k + 0])
+                    values[k + 1] = drjit.fma(v[1], weight, values[k + 1])
+                for k in range(num_features_even, self.num_features):
+                    v = gather(StorageFloat, self.data, index + k, active)
+                    values[k] = drjit.fma(v, weight, values[k])
+
+            values = [StorageFloat(0.0)] * self.num_features
+
+            def acc(offset: ArrayXu):
+                """
+                Given one of the ``2**self.dimensionality()`` vertices, this function
+                calculates the grid position and interpolation weight and accumulates
+                the features into the ``values`` field.
+                """
+                pos_grid = pos0 + ArrayXu(offset)
+                weight = drjit.select(ArrayXu(offset) == 0, w0, w1)
+                weight = drjit.prod(weight, axis = 0)
+
+                index = indexing_function(pos_grid)
+                acc_features(weight, index)
+
+            for offset in self._config.grid_offsets:
+                acc(ArrayXu(offset))
 
             for v in values:
                 # Since we're not really validating the inputs, let's at least
                 # consistently output NaNs for out-of-range inputs.
                 # Without this `select`, NaNs would often show up only in the
                 # backward pass, which is really difficult to debug.
-                v = omega_l * dr.select(invalid, dr.nan, v & active)
+                v = drjit.select(invalid, drjit.nan, v & active)
 
-                # TODO: reset optimizer state (e.g. Adam) when the level gets enabled?
-                if not self.grid_lod.is_level_optimized(level_i, self.current_step):
-                    v = dr.detach(v)
                 result.append(v)
 
-        return result
+        return CoopVec(*result)
 
-    # --------------------
+    def _alloc_internal(self, dtype: Type[drjit.ArrayBase]):
+        mod = sys.modules[dtype.__module__]
+        self.dtype = drjit.leaf_t(dtype)
 
-    def step(self, step_i: int, optimizer, rng):
-        self.current_step = step_i
+        assert (self.hashmap_size % 8) == 0, (
+            f"Invalid hashmap size {self.hashmap_size}, must be a multiple of 8."
+        )
+
+        self._config.level_offsets = [None] * (self.num_levels + 1)
+        self._config.cell_sizes = [0.0] * self.num_levels
+        max_params = drjit.scalar.UInt32(0xffffffff) // 2
+        offset = 0
+
+        for level_i in range(self.num_levels):
+            res = self._grid_resolution(self._grid_scale(level_i))
+            stride = drjit.power(float(res), self.dimension)
+
+            params_in_level = int(max_params) if (stride > max_params) else (res**self.dimension)
+            params_in_level = next_multiple(params_in_level, 8)
+            params_in_level = min(params_in_level, self.hashmap_size)
+
+            self._config.level_offsets[level_i] = offset
+            self._config.cell_sizes[level_i] = 1.0 / (self.base_res * self.per_level_scale**level_i)
+            offset += params_in_level
+
+        self._config.level_offsets[-1] = offset
+
+        params_size = self._config.level_offsets[-1] * self.num_features
+        self.data = drjit.zeros(dtype, params_size)
+
+        # Stores the pattern of offsets used to index the 2** n corners of a voxel
+        self._config.grid_offsets = [
+            [(i >> j) & 1 for j in range(self.dimension)]
+            for i in range(2**self.dimension)
+        ]
+
+    def _alloc(self, dtype: Type[drjit.ArrayBase], size: int = -1, /) -> Tuple[Module, int]:
+
+        dimension = self.dimension
+        if dimension < 0:
+            dimension = size
+
+        num_levels = self.num_levels
+        num_features = self.num_features
+
+        if dimension < 0 or num_levels < 0 or num_features < 0:
+            raise RuntimeError(
+                "The network contains layers with an unspecified "
+                "size. You must specify the input size to drjit.nn.Module.alloc()."
+            )
+
+        result = HashGridEncoding(
+            dimension,
+            hashmap_size=self.hashmap_size,
+            num_levels=self.num_levels,
+            base_res=self.base_res,
+            per_level_scale=self.per_level_scale,
+            num_features=self.num_features,
+            align_corners=self.align_corners,
+            torchngp_compat=self.torchngp_compat,
+            smooth_weight_gradients=self.smooth_weight_gradients,
+            smooth_weight_lambda=self.smooth_weight_lambda,
+        )
+        result._alloc_internal(dtype)
+
+        return result, result.out_features
+
+    def _grid_scale(self, level) -> float:
+        """
+        The -1 means that `base_resolution` refers to the number of grid _vertices_ rather
+        than the number of cells. This is slightly different from the notation in the paper,
+        but results in nice, power-of-2-scaled parameter grids that fit better into cache lines.
+        """
+        return drjit.exp2(level * self._config.log2_per_level_scale) * self.base_res - 1.0
+
+    def _grid_resolution(self, scale) -> int:
+        return (
+            int(drjit.ceil(scale))
+            + (0 if self.align_corners else 1)
+            + (1 if self.torchngp_compat else 0)
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"HashGrid(\n"
+            f"    dtype={self.dtype},\n"
+            f"    dimension={self.dimension},\n"
+            f"    hashmap_size={self.hashmap_size},\n"
+            f"    num_levels={self.num_levels},\n"
+            f"    num_features={self.num_features},\n"
+            f"    base_res={self.base_res},\n"
+            f"    per_level_scale={self.per_level_scale},\n"
+            f"    align_corners={self.align_corners},\n"
+            f"    torchngp_compat={self.torchngp_compat},\n"
+            f"    smooth_weight_gradients={self.smooth_weight_gradients},\n"
+            f"    smooth_weight_lambda={self.smooth_weight_lambda}\n"
+            ")"
+        )
 
     # --------------------
 
@@ -711,46 +851,68 @@ class PyHashGrid3D:
         return 0.0
 
     def n_dims_encoded(self, n_dims_in: int) -> int:
-        return self._num_features * self._num_levels
+        return self.num_features * self.num_levels
 
     def n_params(self) -> int:
-        return dr.width(self.data)
+        return drjit.width(self.data)
 
-    def params(self) -> mi.Float16 | mi.Float32:
-        return self.data
-
-    def set_params(self, values: dr.ArrayBase, copy=False) -> None:
+    def set_params(self, values: drjit.ArrayBase, copy=False) -> None:
         """
         Should pass `values` as a DrJit array (float32 only for now).
         """
-        assert dr.width(values) == dr.width(self.data)
-        assert type(values) == type(self.data)
+        assert drjit.width(values) == drjit.width(self.data)
+        assert type(values) is type(self.data)
         if copy:
             self.data = type(self.data)(values)
         else:
             assert isinstance(values, type(self.data))
             self.data = values
 
+    @property
+    def dimension(self) -> int:
+        return self._config.dimension
+
+    @property
     def hashmap_size(self) -> int:
-        return self._hashmap_size
+        return self._config.hashmap_size
 
+    @property
     def num_levels(self) -> int:
-        return self._num_levels
+        return self._config.num_levels
 
+    @property
     def base_res(self) -> int:
-        return self._base_res
+        return self._config.base_res
 
+    @property
     def per_level_scale(self) -> float:
-        return self._per_level_scale
+        return self._config.per_level_scale
 
+    @property
     def num_features(self) -> int:
-        return self._num_features
+        return self._config.num_features
 
+    @property
     def align_corners(self) -> bool:
-        return self._align_corners
+        return self._config.align_corners
 
+    @property
     def torchngp_compat(self) -> int:
-        return self._torchngp_compat
+        return self._config.torchngp_compat
+
+    @property
+    def smooth_weight_gradients(self) -> bool:
+        return self._config.smooth_weight_gradients
+
+    @property
+    def smooth_weight_lambda(self) -> float:
+        return self._config.smooth_weight_lambda
+
+    @property
+    def out_features(self) -> int:
+        return self._config.num_features *  self.num_levels
+
+    # --------------------
 
     def level_offset(self, level_i: int) -> int:
         """
@@ -761,17 +923,5 @@ class PyHashGrid3D:
         Each level contains `num_features()` times the difference between the next
         offset entries.
         """
-        return self.level_offsets[level_i]
+        return self._level_offsets[level_i]
 
-    # --------------------
-
-    def _grid_scale(self, level) -> float:
-        """
-        The -1 means that `base_resolution` refers to the number of grid _vertices_ rather
-        than the number of cells. This is slightly different from the notation in the paper,
-        but results in nice, power-of-2-scaled parameter grids that fit better into cache lines.
-        """
-        return dr.exp2(level * self.log2_per_level_scale) * self._base_res - 1.0
-
-    def _grid_resolution(self, scale):
-        return int(dr.ceil(scale)) + (0 if self._align_corners else 1)

--- a/drjit/nn.py
+++ b/drjit/nn.py
@@ -503,3 +503,275 @@ class SinEncode(Module):
         return CoopVec(r)
 
 
+class PyHashGrid3D:
+    def __init__(
+        self,
+        array_type,
+        hashmap_size: int,
+        num_levels: int,
+        base_res: int,
+        per_level_scale: float,
+        num_features: int = 2,
+        align_corners: bool = False,
+        torchngp_compat: bool = False,
+        grid_lod: GridLod = None,
+        smooth_weight_gradients: bool = False,
+        smooth_weight_lambda: float = 1.0,
+    ):
+        """Python-based implementation of the INGP hashgrid.
+
+        :parameter smooth_weight_gradients: whether to smooth the gradients of the weights
+            by using a straight-through estimator.
+        :parameter smooth_weight_lambda: the value of lambda used for the straight-through estimator.
+        """
+        # Note: we don't want to lose precision during e.g. interpolation
+        # weight computations, so we will still use f32 in many computation
+        # even when the `array_type` is `mi.Float16`.
+        self.StorageFloat = array_type
+        self.Float = dr.float32_array_t(array_type) if dr.is_half_v(array_type) else array_type
+        self.VectorDf = {
+            (mi.Float16, 2): mi.Vector2f,  # Still f32
+            (mi.Float32, 2): mi.Vector2f,
+            (mi.Float64, 2): mi.Vector2d,
+            (mi.Float16, 3): mi.Vector3f,  # Still f32
+            (mi.Float32, 3): mi.Vector3f,
+            (mi.Float64, 3): mi.Vector3d,
+        }[(array_type, self.dimensionality())]
+        self.VectorDu = dr.uint32_array_t(self.VectorDf)
+
+        self._hashmap_size = hashmap_size
+        self._num_levels = num_levels
+        self._base_res = base_res
+        self._per_level_scale = per_level_scale
+        self.log2_per_level_scale = dr.log2(self._per_level_scale)
+        self._num_features = num_features
+        self._align_corners = align_corners
+
+        # TODO: add support for Torch NGP indexing compatibility
+        self._torchngp_compat = torchngp_compat
+        if self._torchngp_compat:
+            raise NotImplementedError("Not supported yet: `torchngp_compat = True` in the Python-based hashgrid.")
+
+        self.grid_lod = grid_lod
+
+        assert (self._hashmap_size % 8) == 0
+
+        self.level_offsets = [None] * (self._num_levels + 1)
+        self.cell_sizes = [0.0] * self._num_levels
+        max_params = dr.largest(dr.scalar.UInt32) // 2
+        dimensionality = self.dimensionality()
+        offset = 0
+        for level_i in range(self._num_levels):
+            res = self._grid_resolution(self._grid_scale(level_i))
+            stride = dr.power(float(res), dimensionality)
+            params_in_level = int(max_params) if (stride > max_params) else (res**dimensionality)
+            params_in_level = next_multiple(params_in_level, 8)
+            params_in_level = min(params_in_level, self._hashmap_size)
+
+            self.level_offsets[level_i] = offset
+            self.cell_sizes[level_i] = 1.0 / (self._base_res * self._per_level_scale**level_i)
+            offset += params_in_level
+
+        self.level_offsets[-1] = offset
+
+        self.current_step = 0
+        self.smooth_weight_gradients = smooth_weight_gradients
+        self.smooth_weight_lambda = smooth_weight_lambda
+
+        params_size = self.level_offsets[-1] * self._num_features
+        self.data = dr.zeros(array_type, params_size)
+
+    @annotate("PyHashGrid3D.__call__")
+    def __call__(
+        self, p: mi.Array3f | mi.Array3h | list[mi.Float32] | list[mi.Float16], active: dr.ArrayBase
+    ) -> list[mi.Float32] | list[mi.Float16]:
+        # TODO: check if faster as a drjit loop (although then a custom backward is mandatory)
+        assert len(p) == 3
+
+        p = self.VectorDf(*p)
+        invalid = active & dr.any((p < 0) | (p >= 1))
+
+        result = []
+        grid = self.data
+
+        for level_i in range(self._num_levels):
+            if not self.grid_lod.is_level_used(level_i, self.current_step):
+                # Unused level, output some zeros
+                zeros = dr.full(self.StorageFloat, 0, dr.width(p))
+                for _ in range(self._num_features):
+                    result.append(zeros)
+                continue
+
+            scale = self._grid_scale(level_i)
+            res = self._grid_resolution(scale)
+            level_offset = self.level_offsets[level_i]
+            this_level_size = self.level_offsets[level_i + 1] - level_offset
+            num_features_fourth = self._num_features - (self._num_features % 4)
+            num_features_even = self._num_features - (self._num_features % 2)
+
+            omega_l = self.grid_lod.interpolation_weight(level_i, self.current_step)
+
+            def indexing_function(x, y, z):
+                index = x  # Warning: not a copy
+                stride = res
+                if stride <= this_level_size:
+                    index = index + stride * y
+                    stride *= res
+                if stride <= this_level_size:
+                    index = index + stride * z
+                    stride *= res
+
+                if this_level_size < stride:
+                    index = x ^ (y * mi.UInt32(2654435761)) ^ (z * mi.UInt32(805459861))
+
+                sub_grid_index = level_offset + (index % mi.UInt32(this_level_size))
+                return self._num_features * sub_grid_index
+
+            # Unrolls and use packed gathers
+            def acc_features(weight: self.StorageFloat, index: mi.UInt32):
+                if self.smooth_weight_gradients:
+                    weight_smooth = cosine_ramp(weight)
+                    weight = weight + self.smooth_weight_lambda * (weight_smooth - dr.detach(weight_smooth))
+                for k in range(0, num_features_fourth, 4):
+                    v = dr.gather4(self.StorageFloat, grid, index + k, active)
+                    values[k] = dr.fma(v[0], weight, values[k])
+                    values[k + 1] = dr.fma(v[1], weight, values[k + 1])
+                    values[k + 2] = dr.fma(v[2], weight, values[k + 2])
+                    values[k + 3] = dr.fma(v[3], weight, values[k + 3])
+                for k in range(num_features_fourth, num_features_even, 2):
+                    v = dr.gather2(self.StorageFloat, grid, index + k, active)
+                    values[k] = dr.fma(v[0], weight, values[k])
+                    values[k + 1] = dr.fma(v[1], weight, values[k + 1])
+                for k in range(num_features_even, self._num_features):
+                    v = dr.gather(self.StorageFloat, grid, index + k, active)
+                    values[k] = dr.fma(v, weight, values[k])
+
+            # --- Trilinear interpolation at this level
+            # Note: f32 precision, even when StorageFloat is f16
+            p_offset: float = 0.0 if self._align_corners else 0.5
+            pos = dr.fma(p, scale, p_offset)
+            pos0 = dr.floor2int(self.VectorDu, pos)
+            pos1 = pos0 + 1
+
+            w1 = pos - pos0
+            w0 = self.Float(1.0) - w1
+
+            values = [self.StorageFloat(0.0)] * self._num_features
+
+            weight = self.StorageFloat(w0.x * w0.y * w0.z)
+            index = indexing_function(pos0.x, pos0.y, pos0.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w0.x * w0.y * w1.z)
+            index = indexing_function(pos0.x, pos0.y, pos1.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w0.x * w1.y * w0.z)
+            index = indexing_function(pos0.x, pos1.y, pos0.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w0.x * w1.y * w1.z)
+            index = indexing_function(pos0.x, pos1.y, pos1.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w1.x * w0.y * w0.z)
+            index = indexing_function(pos1.x, pos0.y, pos0.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w1.x * w0.y * w1.z)
+            index = indexing_function(pos1.x, pos0.y, pos1.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w1.x * w1.y * w0.z)
+            index = indexing_function(pos1.x, pos1.y, pos0.z)
+            acc_features(weight, index)
+            weight = self.StorageFloat(w1.x * w1.y * w1.z)
+            index = indexing_function(pos1.x, pos1.y, pos1.z)
+            acc_features(weight, index)
+
+            for v in values:
+                # Since we're not really validating the inputs, let's at least
+                # consistently output NaNs for out-of-range inputs.
+                # Without this `select`, NaNs would often show up only in the
+                # backward pass, which is really difficult to debug.
+                v = omega_l * dr.select(invalid, dr.nan, v & active)
+
+                # TODO: reset optimizer state (e.g. Adam) when the level gets enabled?
+                if not self.grid_lod.is_level_optimized(level_i, self.current_step):
+                    v = dr.detach(v)
+                result.append(v)
+
+        return result
+
+    # --------------------
+
+    def step(self, step_i: int, optimizer, rng):
+        self.current_step = step_i
+
+    # --------------------
+
+    def dimensionality(self) -> int:
+        return 3
+
+    def default_padding_value(self) -> float:
+        return 0.0
+
+    def n_dims_encoded(self, n_dims_in: int) -> int:
+        return self._num_features * self._num_levels
+
+    def n_params(self) -> int:
+        return dr.width(self.data)
+
+    def params(self) -> mi.Float16 | mi.Float32:
+        return self.data
+
+    def set_params(self, values: dr.ArrayBase, copy=False) -> None:
+        """
+        Should pass `values` as a DrJit array (float32 only for now).
+        """
+        assert dr.width(values) == dr.width(self.data)
+        assert type(values) == type(self.data)
+        if copy:
+            self.data = type(self.data)(values)
+        else:
+            assert isinstance(values, type(self.data))
+            self.data = values
+
+    def hashmap_size(self) -> int:
+        return self._hashmap_size
+
+    def num_levels(self) -> int:
+        return self._num_levels
+
+    def base_res(self) -> int:
+        return self._base_res
+
+    def per_level_scale(self) -> float:
+        return self._per_level_scale
+
+    def num_features(self) -> int:
+        return self._num_features
+
+    def align_corners(self) -> bool:
+        return self._align_corners
+
+    def torchngp_compat(self) -> int:
+        return self._torchngp_compat
+
+    def level_offset(self, level_i: int) -> int:
+        """
+        Helpful to build e.g. debug visualizations by splitting params per level
+        Must be called with an index up to and including `num_levels()`.
+
+        Warning: the level offset returned does *not* account for the feature count.
+        Each level contains `num_features()` times the difference between the next
+        offset entries.
+        """
+        return self.level_offsets[level_i]
+
+    # --------------------
+
+    def _grid_scale(self, level) -> float:
+        """
+        The -1 means that `base_resolution` refers to the number of grid _vertices_ rather
+        than the number of cells. This is slightly different from the notation in the paper,
+        but results in nice, power-of-2-scaled parameter grids that fit better into cache lines.
+        """
+        return dr.exp2(level * self.log2_per_level_scale) * self._base_res - 1.0
+
+    def _grid_resolution(self, scale):
+        return int(dr.ceil(scale)) + (0 if self._align_corners else 1)

--- a/tests/test_coop_vec.py
+++ b/tests/test_coop_vec.py
@@ -638,3 +638,199 @@ def test22_optimize_in_loop_bwd_v2(t, mode):
     b = TensorXf16(b_view)
     assert dr.all(A == TensorXf16([[3, 3], [0, 0]]))
     assert dr.all(b == TensorXf16([[6], [0]]))
+
+
+@pytest.test_arrays("jit,shape=(*),cuda,float16,diff")
+def test23_hash_grid_encoding(t):
+    skip_if_coopvec_not_supported(t)
+
+    dr.set_flag(dr.JitFlag.KernelHistory, True)
+    import tinycudann as tcnn
+    import torch
+
+    m = sys.modules[t.__module__]
+    Float16 = t
+    Float32 = m.Float32
+
+    config = {
+        "hashmap_size": 2**19,
+        "num_levels": 16,
+        "base_res": 16,
+        "per_level_scale": 1.5,
+        "num_features": 2,
+    }
+
+    hg = nn.HashGridEncoding(
+        3,
+        **config,
+        align_corners=False,
+        torchngp_compat=False,
+    )
+    hg = hg.alloc(Float16)
+
+    config = {
+        "otype": "Grid",
+        "type": "Hash",
+        "n_levels": 16,
+        "n_features_per_level": 2,
+        "log2_hashmap_size": 19,
+        "base_resolution": 16,
+        "per_level_scale": 1.5,
+        "interpolation": "Linear",
+    }
+
+    hg_ref = tcnn.Encoding(3, config, )
+    # print(f"{next(hg_ref.named_parameters())=}")
+    data = hg_ref.params.data
+
+    hg.set_params(Float16(data.to(dtype = torch.float16)))
+
+    sampler = m.PCG32(2**18)
+
+    x = [sampler.next_float32(), sampler.next_float32(), sampler.next_float32()]
+    x_torch = torch.stack([xx.torch() for xx in x], dim = 1)
+
+    dr.kernel_history_clear()
+
+    res = m.ArrayXf16(hg(x)).torch().permute(1, 0)
+
+    kernels = dr.kernel_history()
+    execution_time = 0
+    for kernel in kernels:
+        execution_time += kernel["execution_time"]
+    print(f"Dr.Jit: {execution_time=}ms")
+
+    start = torch.cuda.Event(enable_timing = True)
+    end = torch.cuda.Event(enable_timing = True)
+
+    start.record()
+    ref = hg_ref(x_torch)
+    end.record()
+
+    torch.cuda.synchronize()
+    print(f"PyTorch: execution_time={start.elapsed_time(end)}ms")
+
+    assert torch.allclose(res, ref, atol=0.00001)
+
+
+@pytest.test_arrays("jit,shape=(*),cuda,float16,diff")
+def test24_hash_grid_net(t):
+    skip_if_coopvec_not_supported(t)
+
+    import tinycudann as tcnn
+    import torch
+
+    m = sys.modules[t.__module__]
+    Float16 = t
+    Float32 = m.Float32
+
+    net = nn.Sequential(
+        nn.HashGridEncoding(-1, 16, 2),
+        nn.Cast(Float16),
+        nn.Linear(-1, -1, bias = False),
+        nn.Linear(-1, -1, bias=False),
+        nn.LeakyReLU(),
+        nn.Linear(-1, -1, bias=False),
+        nn.LeakyReLU(),
+        nn.Linear(-1, -1, bias=False),
+        nn.LeakyReLU(),
+        nn.Linear(-1, 3, bias=False),
+    )
+
+    net = net.alloc(m.TensorXf16, 3)
+
+    weights, net = nn.pack(net, layout = "training")
+
+    sampler = m.PCG32(2**18)
+
+    x = nn.CoopVec([sampler.next_float32(), sampler.next_float32(), sampler.next_float32()])
+    print(f"{net}")
+
+    y = net(x)
+
+# @pytest.test_arrays("jit,shape=(*),cuda,float16,diff")
+# def test25_hash_grid_img(t):
+#     skip_if_coopvec_not_supported(t)
+#
+#     from tqdm.auto import tqdm
+#     import imageio.v3 as iio
+#     import drjit as dr
+#     import drjit.nn as nn
+#     from drjit.opt import Adam, GradScaler
+#     from drjit.auto.ad import Texture2f, TensorXf, TensorXf16, Float16, Float32, Array2f, Array3f
+#
+#     # Load a test image and construct a texture object
+#     ref = TensorXf(iio.imread("https://rgl.s3.eu-central-1.amazonaws.com/media/uploads/wjakob/2024/06/wave-128.png") / 256)
+#     tex = Texture2f(ref)
+#
+#      # Ensure consistent results when re-running the following
+#     dr.seed(0)
+#
+#     # Establish the network structure
+#     net = nn.Sequential(
+#         nn.HashGridEncoding(-1, 16, 2),
+#         # nn.TriEncode(16, 0.2),
+#         nn.Cast(Float16),
+#         nn.Linear(-1, -1, bias=False),
+#         nn.LeakyReLU(),
+#         nn.Linear(-1, -1, bias=False),
+#         nn.LeakyReLU(),
+#         nn.Linear(-1, -1, bias=False),
+#         nn.LeakyReLU(),
+#         nn.Linear(-1, 3, bias=False),
+#         nn.Exp()
+#     )
+#
+#     # Instantiate the network for a specific backend + input size
+#     net = net.alloc(TensorXf16, 2)
+#
+#     # Convert to training-optimal layout
+#     weights, net = nn.pack(net, layout='training')
+#     print(net)
+#
+#     # Optimize a single-precision copy of the parameters
+#     opt = Adam(lr=1e-3, params={'weights': Float32(weights)})
+#
+#     # This is an adaptive mixed-precision (AMP) optimization, where a half
+#     # precision computation runs within a larger single-precision program.
+#     # Gradient scaling is required to make this numerically well-behaved.
+#     scaler = GradScaler()
+#
+#     res = 256
+#
+#     for i in tqdm(range(4000)):
+#         with dr.profile_range("iteration"):
+#             # Update network state from optimizer
+#             weights[:] = Float16(opt['weights'])
+#
+#             # Generate jittered positions on [0, 1]^2
+#             t = dr.arange(Float32, res)
+#             p = (Array2f(dr.meshgrid(t, t)) + dr.rand(Array2f, (2, res * res))) / res
+#
+#             # Evaluate neural net + L2 loss
+#             with dr.profile_range("fwd"):
+#                 img = Array3f(net(nn.CoopVec(p)))
+#             with dr.profile_range("loss"):
+#                 loss = dr.squared_norm(tex.eval(p) - img)
+#
+#             # Mixed-precision training: take suitably scaled steps
+#             with dr.profile_range("bwd"):
+#                 dr.backward(scaler.scale(loss))
+#             with dr.profile_range("step"):
+#                 scaler.step(opt)
+#
+#     # Done optimizing, now let's plot the result
+#     t = dr.linspace(Float32, 0, 1, res)
+#     p = Array2f(dr.meshgrid(t, t))
+#     img = Array3f(net(nn.CoopVec(p)))
+#
+#     # Convert 'img' with shape 3 x (N*N) into a N x N x 3 tensor
+#     img = dr.reshape(TensorXf(img, flip_axes=True), (res, res, 3))
+#
+#     # import matplotlib.pyplot as plt
+#     # fig, ax = plt.subplots(1, 2, figsize=(10,5))
+#     # ax[0].imshow(ref)
+#     # ax[1].imshow(dr.clip(img, 0, 1))
+#     # fig.tight_layout()
+#     # plt.show()
+#


### PR DESCRIPTION
This PR implements a HashGrid encoding layer for the upcoming neural network interface. It works with the `nn.Sequential` module and can take `CoopVec`, `ArrayXf` or `list`s of `Float` values in both 16 and 32 bit. The output will be either a `CoopVec` of 16 or 32 bit floats depending on the storage type.

The tests still have to be refined, and some of the fields will probably have to be renamed.

The implementation has originally been developed by @merlinND. I have ported it to the upstream branch and extended it to `n` dimensions.