### PR TITLE
Shader Execution Reordering

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -148,6 +148,7 @@ Miscellaneous operations
 .. autofunction:: copy
 .. autofunction:: linear_to_srgb
 .. autofunction:: srgb_to_linear
+.. autofunction:: reorder_threads
 
 Just-in-time compilation
 ------------------------

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -84,6 +84,7 @@ nanobind_add_module(
   local.h       local.cpp
   resample.h    resample.cpp
   coop_vec.h    coop_vec.cpp
+  reorder.h     reorder.cpp
 
   # Backends
   scalar.h      scalar.cpp
@@ -140,6 +141,10 @@ endif()
 
 if (DRJIT_ENABLE_CUDA)
   target_compile_definitions(drjit-python PRIVATE -DDRJIT_ENABLE_CUDA)
+endif()
+
+if (DRJIT_ENABLE_OPTIX)
+    target_compile_definitions(drjit-python PRIVATE -DDRJIT_ENABLE_OPTIX)
 endif()
 
 # Disable leak warnings by default in PyPI release builds

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -41,6 +41,7 @@
 #include "local.h"
 #include "resample.h"
 #include "coop_vec.h"
+#include "reorder.h"
 
 static int active_backend = -1;
 
@@ -107,6 +108,7 @@ NB_MODULE(_drjit_ext, m_) {
         .value("ScatterReduceLocal", JitFlag::ScatterReduceLocal, doc_JitFlag_ScatterReduceLocal)
         .value("SymbolicConditionals", JitFlag::SymbolicConditionals, doc_JitFlag_SymbolicConditionals)
         .value("SymbolicScope", JitFlag::SymbolicScope, doc_JitFlag_SymbolicScope)
+        .value("ShaderExecutionReordering", JitFlag::ShaderExecutionReordering, doc_JitFlag_ShaderExecutionReordering)
         .value("Default", JitFlag::Default, doc_JitFlag_Default)
 
         // Deprecated aliases
@@ -252,6 +254,7 @@ NB_MODULE(_drjit_ext, m_) {
     export_tracker(detail);
     export_local(m);
     export_resample(m);
+    export_reorder(m);
 
     export_scalar(scalar);
 

--- a/src/python/reorder.cpp
+++ b/src/python/reorder.cpp
@@ -1,0 +1,60 @@
+/*
+    reorder.cpp -- Bindings for drjit.reorder_threads()
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include "reorder.h"
+#include "detail.h"
+#include <drjit/autodiff.h>
+#include <drjit-core/optix.h>
+
+nb::object reorder_threads(nb::handle_t<dr::ArrayBase> key, int num_bits,
+                           nb::handle value) {
+    const ArraySupplement &s_key = supp(key.type());
+    if (s_key.ndim != 1 || s_key.type != (uint8_t) VarType::UInt32 ||
+        s_key.backend == (uint8_t) JitBackend::None)
+        nb::raise("drjit.reorder_threads(): 'key' must be a JIT-compiled 32 "
+                  "bit unsigned integer array (e.g., 'drjit.cuda.UInt32' or "
+                  "'drjit.llvm.ad.UInt32')");
+
+    dr::vector<uint64_t> value_indices;
+    ::collect_indices(value, value_indices);
+    if (value_indices.size() == 0)
+        nb::raise("drjit.reorder_threads(): 'value' must be a valid PyTree "
+                  "containing at least one JIT-compiled type");
+
+#if defined(DRJIT_ENABLE_OPTIX)
+    uint32_t n_values = (uint32_t) value_indices.size();
+
+    // Extract JIT indices
+    dr::vector<uint32_t> jit_indices(n_values);
+    for (size_t i = 0; i < n_values; ++i)
+        jit_indices[i] = (uint32_t) value_indices[i];
+
+    // Create updated values with reordering
+    dr::detail::index32_vector out_indices(n_values);
+    jit_optix_reorder(s_key.index(inst_ptr(key)), num_bits, n_values,
+                      jit_indices.data(), out_indices.data());
+
+    // Re-combine with AD indices
+    dr::vector<uint64_t> new_value_indices(n_values);
+    for (size_t i = 0; i < n_values; ++i) {
+        uint32_t ad_index = value_indices[i] >> 32;
+        new_value_indices[i] = (((uint64_t) ad_index) << 32 | ((uint64_t) out_indices[i]));
+    }
+
+    return ::update_indices(value, new_value_indices);
+#endif
+
+    return nb::borrow(value);
+}
+
+void export_reorder(nb::module_ &m) {
+    m.def("reorder_threads", &reorder_threads, "key"_a, "num_bits"_a, "value"_a,
+          doc_reorder_threads);
+}

--- a/src/python/reorder.h
+++ b/src/python/reorder.h
@@ -1,0 +1,16 @@
+/*
+    reorder.h -- Bindings for drjit.reorder_threads()
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#pragma once
+
+#include "common.h"
+
+extern nb::object reorder_threads(nb::handle_t<dr::ArrayBase>, int, nb::handle);
+extern void export_reorder(nb::module_ &);

--- a/tests/test_reorder.py
+++ b/tests/test_reorder.py
@@ -1,0 +1,55 @@
+import drjit as dr
+import pytest
+
+# Just an existence test
+@pytest.test_arrays('float32, jit, shape=(*)')
+def test01_reorder_switch(t):
+    UInt32 = dr.uint32_array_t(t)
+    N = 4
+
+    idx = dr.arange(UInt32, N) % 2
+    arg = dr.arange(t, N)
+    dr.make_opaque(arg)
+
+    def cheap_func(arg):
+        return arg
+
+    def expensive_func(arg):
+        return arg * 2
+
+    result = dr.switch(idx, [cheap_func, expensive_func], arg)
+    dr.allclose(result, [0, 2, 2, 6])
+
+
+# Test that reorder is valid inside loops
+@pytest.test_arrays('float32, jit, shape=(*)')
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@dr.syntax(recursive=True)
+def test01_reorder_loop(t, mode):
+    UInt32 = dr.uint32_array_t(t)
+    N = 4
+
+    idx = dr.arange(UInt32, N)
+    arg = dr.arange(t, N)
+    dr.make_opaque(arg)
+
+    def f(arg):
+        i = UInt32(0)
+        while dr.hint(i < 32, mode=mode):
+            j = UInt32(0)
+
+            # Arbitrary aritmetic
+            while dr.hint(j < 10, mode=mode):
+                arg = arg + j
+                j += 1
+
+            i = dr.reorder_threads(idx % 32, 2, i)
+            i += 1
+
+            # Early exit one thread per iteraion
+            i = dr.select(idx % 32 < i, 100, i)
+
+        return arg
+
+    result = f(arg)
+    dr.allclose(result, [45, 91, 137, 183])


### PR DESCRIPTION
This PR adds `dr.reorder_threads()`: an explicit way for users to trigger the SER functionality of their GPU without it being tied to a ray-intersection.

Related: https://github.com/mitsuba-renderer/drjit-core/pull/145

The function takes a `key` argument that acts as the sorting key for the reordering as well as a `value` argument. The latter solely serves a a way for us to tie the operation into the JIT graph.

Because the shuffling happens under the hood, there really isn't a way to test this properly other than a smoke test. I've added some basic ones in a new `test_reorder.py file.