### PR TITLE
Minor fixes to `dr.count()`

### DIFF
--- a/src/python/reduce.cpp
+++ b/src/python/reduce.cpp
@@ -309,6 +309,12 @@ nb::object reduce(uint32_t op, nb::handle h, nb::handle axis_, nb::handle mode) 
                 // Directly process the underlying 1D array
                 nb::object value = nb::steal(s.tensor_array(h.ptr()));
                 value = reduce(op, value, axis, mode);
+                if (op == (uint32_t) ReduceOpExt::Count) {
+                    ArrayMeta m = s;
+                    m.type = (uint16_t) VarType::UInt32;
+                    tp = meta_get_type(m);
+                }
+
                 return tp(value, nb::tuple());
             } else {
                 if (op >= (uint32_t) ReduceOp::Count) {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -632,3 +632,11 @@ def test28_width(t):
     assert dr.width([t(1, 2), t(1)]) == 2
     with pytest.raises(RuntimeError, match='ragged'):
         dr.width([t(1, 2), t(2, 3, 3)])
+
+
+@pytest.test_arrays('uint32, jit, shape=(*)')
+def test29_bool_casts(t):
+    Mask = dr.mask_t(t)
+
+    assert dr.all(Mask(t([0, 1, 0, 3])) == [False, True, False, True])
+    assert dr.all(t(Mask([False, True, False, True])) == [0, 1, 0, 1])

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -358,6 +358,7 @@ def test10_sum_avg_mixed_size(t):
 @pytest.test_arrays('shape=(*), bool')
 def test11_count(t):
     i = dr.uint32_array_t(t)
+    m = sys.modules[t.__module__]
 
     assert dr.count(t(True, False)) == i(1)
     assert dr.count(t(True, False, True, True, False, False, False)) == i(3)
@@ -365,6 +366,8 @@ def test11_count(t):
     assert dr.count(False) == 0
     assert dr.count(True) == 1
     assert dr.count((True, False)) == 1
+    assert dr.count(m.TensorXb([True, False, True])) == 2
+    assert dr.count(m.Array3b([True, False, True])) == 2
 
 
 @pytest.mark.parametrize('op', [dr.ReduceOp.Add, dr.ReduceOp.Max, dr.ReduceOp.Min])


### PR DESCRIPTION
This PR fixes #396. In that issue a few different failure cases of `dr.count() were reported`. They were due to missing casts to/from `Bool` types and some missing logic in the main reduction helper function (it would return a boolean rather than an integer if the input type was not a 1D array)..

Test cases were added to check the validity of the new casts and regression tests were added for the configurations brought up in #396.