### PR TITLE
Hold GIL when traversing python objects

### DIFF
--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -1102,6 +1102,8 @@ inline void traverse_py_cb_ro(const TraversableBase *base, void *payload,
                               void (*fn)(void *, uint64_t, const char *variant,
                                          const char *domain)) {
     namespace nb    = nanobind;
+    nb::gil_scoped_acquire guard;
+
     nb::handle self = base->self_py();
     if (!self)
         return;
@@ -1127,8 +1129,9 @@ inline void traverse_py_cb_ro(const TraversableBase *base, void *payload,
 inline void traverse_py_cb_rw(TraversableBase *base, void *payload,
                               uint64_t (*fn)(void *, uint64_t, const char *,
                                              const char *)) {
-
     namespace nb    = nanobind;
+    nb::gil_scoped_acquire guard;
+
     nb::handle self = base->self_py();
     if (!self)
         return;

--- a/include/drjit/traversable_base.h
+++ b/include/drjit/traversable_base.h
@@ -219,17 +219,13 @@ public:                                                                        \
     void traverse_1_cb_ro(void *payload,                                       \
                           drjit::detail::traverse_callback_ro fn)              \
         const override {                                                       \
-        DRJIT_MARK_USED(payload);                                              \
-        DRJIT_MARK_USED(fn);                                                   \
-        if constexpr (!std ::is_same_v<Base, drjit ::TraversableBase>)         \
+        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
             Base::traverse_1_cb_ro(payload, fn);                               \
         drjit::traverse_py_cb_ro(this, payload, fn);                           \
     }                                                                          \
     void traverse_1_cb_rw(void *payload,                                       \
                           drjit::detail::traverse_callback_rw fn) override {   \
-        DRJIT_MARK_USED(payload);                                              \
-        DRJIT_MARK_USED(fn);                                                   \
-        if constexpr (!std ::is_same_v<Base, drjit ::TraversableBase>)         \
+        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
             Base::traverse_1_cb_rw(payload, fn);                               \
         drjit::traverse_py_cb_rw(this, payload, fn);                           \
     }


### PR DESCRIPTION
The traversal helpers `traverse_py_cb_ro` and `traverse_py_cb_rw` might be called from C++ without holding the GIL. This will typically lead to segfaults. An example of this is the traversal of a custom Mitsuba plugin in a loop's state.

This PR ensures that the GIL is held during those operations.