### PR TITLE
Add ``dr.mul_wide()`` wide integer multiplication operation

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -285,6 +285,8 @@ Standard mathematical functions
 .. autofunction:: copysign
 .. autofunction:: mulsign
 .. autofunction:: step
+.. autofunction:: mul_hi
+.. autofunction:: mul_wide
 
 Operations for vectors and matrices
 -----------------------------------

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -193,8 +193,8 @@ DRJIT_ROUTE_UNARY_FALLBACK(rsqrt, rsqrt, detail::rsqrt_(a))
 
 DRJIT_ROUTE_BINARY_FALLBACK(maximum, maximum, detail::maximum_((E) a1, (E) a2))
 DRJIT_ROUTE_BINARY_FALLBACK(minimum, minimum, detail::minimum_((E) a1, (E) a2))
-
-DRJIT_ROUTE_BINARY_FALLBACK(mulhi, mulhi, detail::mulhi_((E) a1, (E) a2))
+DRJIT_ROUTE_BINARY_FALLBACK(mul_hi, mul_hi,     detail::mul_hi_((E) a1, (E) a2))
+DRJIT_ROUTE_BINARY_FALLBACK(mul_wide, mul_wide, detail::mul_wide_((E) a1, (E) a2))
 DRJIT_ROUTE_UNARY_FALLBACK(lzcnt, lzcnt, detail::lzcnt_(a))
 DRJIT_ROUTE_UNARY_FALLBACK(tzcnt, tzcnt, detail::tzcnt_(a))
 DRJIT_ROUTE_UNARY_FALLBACK(popcnt, popcnt, detail::popcnt_(a))

--- a/include/drjit/array_utils.h
+++ b/include/drjit/array_utils.h
@@ -282,7 +282,7 @@ template <typename T> DRJIT_INLINE T brev_(T value_) {
 }
 
 template <typename T>
-DRJIT_INLINE T mulhi_(T x, T y) {
+DRJIT_INLINE T mul_hi_(T x, T y) {
     if constexpr (sizeof(T) == 4) {
         using Wide = std::conditional_t<std::is_signed_v<T>, int64_t, uint64_t>;
         return T(((Wide) x * (Wide) y) >> 32);
@@ -304,7 +304,7 @@ DRJIT_INLINE T mulhi_(T x, T y) {
         if constexpr (std::is_signed_v<T>) {
             int32_t x1 = (int32_t) (x >> 32);
             int32_t y1 = (int32_t) (y >> 32);
-            uint32_t x0y0_hi = mulhi_(x0, y0);
+            uint32_t x0y0_hi = mul_hi_(x0, y0);
             int64_t t = x1 * (int64_t) y0 + x0y0_hi;
             int64_t w1 = x0 * (int64_t) y1 + (t & mask);
 
@@ -312,7 +312,7 @@ DRJIT_INLINE T mulhi_(T x, T y) {
         } else {
             uint32_t x1 = (uint32_t) (x >> 32);
             uint32_t y1 = (uint32_t) (y >> 32);
-            uint32_t x0y0_hi = mulhi_(x0, y0);
+            uint32_t x0y0_hi = mul_hi_(x0, y0);
 
             uint64_t x0y1 = x0 * (uint64_t) y1;
             uint64_t x1y0 = x1 * (uint64_t) y0;
@@ -325,6 +325,13 @@ DRJIT_INLINE T mulhi_(T x, T y) {
         }
 #endif
     }
+}
+
+template <typename T>
+DRJIT_INLINE auto mul_wide_(T x, T y) {
+    static_assert(sizeof(T) == 4);
+    using Wide = std::conditional_t<std::is_signed_v<T>, int64_t, uint64_t>;
+    return (Wide) x * (Wide) y;
 }
 
 NAMESPACE_END(detail)

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -206,9 +206,15 @@ struct DRJIT_TRIVIAL_ABI DiffArray
             return steal(jit_var_mul(m_index, a.m_index));
     }
 
-    DiffArray mulhi_(const DiffArray &a) const {
-        return steal(jit_var_mulhi((uint32_t) m_index,
-                                   (uint32_t) a.m_index));
+    DiffArray mul_hi_(const DiffArray &a) const {
+        return steal(jit_var_mul_hi((uint32_t) m_index,
+                                    (uint32_t) a.m_index));
+    }
+
+    auto mul_wide_(const DiffArray &v) const {
+        static_assert(sizeof(Value_) == 4);
+        using Result = DiffArray<Backend, std::conditional_t<std::is_signed_v<Value_>, int64_t, uint64_t>>;
+        return Result::steal(jit_var_mul_wide((uint32_t) m_index, (uint32_t) v.m_index));
     }
 
     DiffArray div_(const DiffArray &a) const {

--- a/include/drjit/idiv.h
+++ b/include/drjit/idiv.h
@@ -162,7 +162,7 @@ template <typename T> struct divisor<T, enable_if_t<std::is_unsigned_v<T>>> {
         }
 
         // ubsan must be locally turned off for this line (overflows)
-        Value q = mulhi(multiplier, value);
+        Value q = mul_hi(multiplier, value);
         Value t = sr<1>(value - q) + q;
         return t >> shift;
     }
@@ -204,7 +204,7 @@ struct divisor<T, enable_if_t<std::is_signed_v<T>>> {
             return value;
 
         // ubsan must be locally turned off for this line (overflows)
-        Value q = mulhi(multiplier, value) + value;
+        Value q = mul_hi(multiplier, value) + value;
         Value q_sign = sr<sizeof(T) * 8 - 1>(q);
         q = q + (q_sign & ((T(1) << shift) - (multiplier == 0 ? 1 : 0)));
         Value sign = div < 0 ? -1 : 0;

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -154,8 +154,14 @@ struct DRJIT_TRIVIAL_ABI JitArray
         return steal(jit_var_mul(m_index, v.m_index));
     }
 
-    JitArray mulhi_(const JitArray &v) const {
-        return steal(jit_var_mulhi(m_index, v.m_index));
+    JitArray mul_hi_(const JitArray &v) const {
+        return steal(jit_var_mul_hi(m_index, v.m_index));
+    }
+
+    auto mul_wide_(const JitArray &v) const {
+        static_assert(sizeof(Value_) == 4);
+        using Result = JitArray<Backend, std::conditional_t<std::is_signed_v<Value_>, int64_t, uint64_t>>;
+        return Result::steal(jit_var_mul_wide(m_index, v.m_index));
     }
 
     JitArray div_(const JitArray &v) const {

--- a/include/drjit/packet_avx2.h
+++ b/include/drjit/packet_avx2.h
@@ -323,7 +323,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(32)
             _mm256_setr_epi32(I0, I1, I2, I3, I4, I5, I6, I7));
     }
 
-    DRJIT_INLINE Derived mulhi_(Ref b) const {
+    DRJIT_INLINE Derived mul_hi_(Ref b) const {
         Derived even, odd;
 
         if constexpr (std::is_signed_v<Value>) {
@@ -552,7 +552,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(32)
         #endif
     }
 
-    DRJIT_INLINE Derived mulhi_(Ref b) const {
+    DRJIT_INLINE Derived mul_hi_(Ref b) const {
         if constexpr (std::is_unsigned_v<Value>) {
             const __m256i low_bits = _mm256_set1_epi64x(0xffffffffu);
             __m256i al = m, bl = b.m;

--- a/include/drjit/packet_avx512.h
+++ b/include/drjit/packet_avx512.h
@@ -741,7 +741,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(64)
         return _mm512_permutexvar_epi32(idx, m);
     }
 
-    DRJIT_INLINE Derived mulhi_(Ref a) const {
+    DRJIT_INLINE Derived mul_hi_(Ref a) const {
         auto blend = mask_t<Derived>::from_k(0b0101010101010101);
         Derived even, odd;
 
@@ -991,7 +991,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(64)
         return _mm512_permutexvar_epi64(idx, m);
     }
 
-    DRJIT_INLINE Derived mulhi_(Ref b) const {
+    DRJIT_INLINE Derived mul_hi_(Ref b) const {
         if (std::is_unsigned_v<Value>) {
             const __m512i low_bits = _mm512_set1_epi64(0xffffffffu);
             __m512i al = m, bl = b.m;

--- a/include/drjit/packet_neon.h
+++ b/include/drjit/packet_neon.h
@@ -732,7 +732,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(16)
     }
 
 #if defined(DRJIT_ARM_64)
-    DRJIT_INLINE Derived mulhi_(Ref a) const {
+    DRJIT_INLINE Derived mul_hi_(Ref a) const {
     uint32x4_t ll, hh;
         if constexpr (std::is_signed_v<Value>) {
             int64x2_t l = vmull_s32(vreinterpret_s32_u32(vget_low_u32(m)),

--- a/include/drjit/packet_recursive.h
+++ b/include/drjit/packet_recursive.h
@@ -88,7 +88,7 @@ struct StaticArrayImpl<Value_, Size_, IsMask_, Derived_,
     DRJIT_INLINE Derived div_(Ref a) const { return Derived(a1 / a.a1, a2 / a.a2); }
     DRJIT_INLINE Derived mod_(Ref a) const { return Derived(a1 % a.a1, a2 % a.a2); }
 
-    DRJIT_INLINE Derived mulhi_(Ref a) const { return Derived(mulhi(a1, a.a1), mulhi(a2, a.a2)); }
+    DRJIT_INLINE Derived mul_hi_(Ref a) const { return Derived(mul_hi(a1, a.a1), mul_hi(a2, a.a2)); }
 
     DRJIT_INLINE auto lt_ (Ref a) const { return mask_t<Derived>(a1 <  a.a1, a2 <  a.a2); }
     DRJIT_INLINE auto gt_ (Ref a) const { return mask_t<Derived>(a1 >  a.a1, a2 >  a.a2); }

--- a/include/drjit/packet_sse42.h
+++ b/include/drjit/packet_sse42.h
@@ -736,7 +736,7 @@ template <typename Value_, bool IsMask_, typename Derived_> struct alignas(16)
         return _mm_shuffle_epi32(m, _MM_SHUFFLE(I3, I2, I1, I0));
     }
 
-    DRJIT_INLINE Derived mulhi_(Ref a) const {
+    DRJIT_INLINE Derived mul_hi_(Ref a) const {
         Derived even, odd;
 
         if constexpr (std::is_signed_v<Value>) {

--- a/include/drjit/tensor.h
+++ b/include/drjit/tensor.h
@@ -210,10 +210,10 @@ struct Tensor
         return Tensor(t0.m_array * t1.m_array, std::move(shape));
     }
 
-    Tensor mulhi_(const Tensor &b) const {
+    Tensor mul_hi_(const Tensor &b) const {
         Tensor t0 = *this, t1 = b;
-        Shape shape = detail::tensor_broadcast("mulhi_", t0, t1);
-        return Tensor(mulhi(t0.m_array, t1.m_array), std::move(shape));
+        Shape shape = detail::tensor_broadcast("mul_hi_", t0, t1);
+        return Tensor(mul_hi(t0.m_array, t1.m_array), std::move(shape));
     }
 
     Tensor div_(const Tensor &b) const {

--- a/src/python/apply.h
+++ b/src/python/apply.h
@@ -24,8 +24,11 @@ enum ApplyMode {
     /// Rich comparison, a binary operation mapping T, T -> mask_t<T>
     RichCompare,
 
-    ///  Select, a ternary operation mapping mask_t<T>, T, T -> T
-    Select
+    /// Select, a ternary operation mapping mask_t<T>, T, T -> T
+    Select,
+
+    /// mul_wide(), which maps [u]int32 x [u]int32 to [u]int64
+    MulWide
 };
 
 /**

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -1218,6 +1218,24 @@ void export_base(nb::module_ &m) {
     DR_MATH_UNOP_UINT32(tzcnt, ArrayOp::Tzcnt);
     DR_MATH_UNOP_UINT32(brev, ArrayOp::Brev);
 
+    m.def("mul_hi", [](nb::handle h0, nb::handle h1) {
+        if (NB_UNLIKELY(!is_drjit_array(h0) && !is_drjit_array(h1)))
+            return nb::steal(NB_NEXT_OVERLOAD);
+        return nb::steal(apply<Normal>(
+            ArrayOp::MulHi, "mul_hi", std::make_index_sequence<2>(), h0.ptr(), h1.ptr()));
+    }, doc_mul_hi);
+    m.def("mul_hi", [](int32_t a, int32_t b) { return dr::mul_hi(a, b); });
+    m.def("mul_hi", [](uint32_t a, uint32_t b) { return dr::mul_hi(a, b); });
+
+    m.def("mul_wide", [](nb::handle h0, nb::handle h1) {
+        if (NB_UNLIKELY(!is_drjit_array(h0) && !is_drjit_array(h1)))
+            return nb::steal(NB_NEXT_OVERLOAD);
+        return nb::steal(apply<MulWide>(
+            ArrayOp::MulWide, "mul_wide", std::make_index_sequence<2>(), h0.ptr(), h1.ptr()));
+    }, doc_mul_wide);
+    m.def("mul_wide", [](int32_t a, int32_t b) { return dr::mul_wide(a, b); });
+    m.def("mul_wide", [](uint32_t a, uint32_t b) { return dr::mul_wide(a, b); });
+
     DR_MATH_UNOP(exp, ArrayOp::Exp);
     DR_MATH_UNOP(exp2, ArrayOp::Exp2);
     DR_MATH_UNOP(log, ArrayOp::Log);

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -7204,6 +7204,34 @@
     Returns:
         int | drjit.ArrayBase: the bit-reversed version of ``arg``.
 
+.. topic:: mul_hi
+
+    Return the high part of an integer product
+
+    This function multiplies two signed or unsigned 32 bit operands and returns
+    the upper 32 bit of the result.
+
+    Args:
+        arg0 (int | drjit.ArrayBase): A Python or Dr.Jit array
+        arg1 (int | drjit.ArrayBase): A Python or Dr.Jit array
+
+    Returns:
+        int | drjit.ArrayBase: High part of the multiplication result
+
+.. topic:: mul_wide
+
+    Return all bits of an integer product
+
+    This function multiplies two signed or unsigned 32 bit operands and returns
+    the full 64 bit result.
+
+    Args:
+        arg0 (int | drjit.ArrayBase): A Python or Dr.Jit array
+        arg1 (int | drjit.ArrayBase): A Python or Dr.Jit array
+
+    Returns:
+        int | drjit.ArrayBase: High part of the multiplication result
+
 .. topic:: compress
 
     Compress a mask into an array of nonzero indices.

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -452,3 +452,38 @@ def test23_rsqrt(t):
 
     assert dr.isinf(y[0]) == dr.isinf(z[0])
     assert y[1] == z[1]
+
+
+@pytest.mark.parametrize("opaque", [True, False])
+@pytest.test_arrays('int32, shape=(*)','int32, shape=(2, *)')
+def test24_mul_hi_wide(t, opaque):
+    np = pytest.importorskip("numpy")
+    if dr.is_unsigned_v(t):
+        a_s = 0xcafe9876
+        b_s = 0xfafecafe
+        with pytest.warns(RuntimeWarning):
+            c_s = np.uint32(a_s)*np.uint32(b_s)
+    else:
+        # Identical bit representation
+        a_s = -889284490
+        b_s = -83965186
+        with pytest.warns(RuntimeWarning):
+            c_s = np.int32(a_s)*np.int32(b_s)
+
+    a, b = t(a_s), t(b_s)
+
+    if opaque:
+        dr.make_opaque(a)
+        dr.make_opaque(b)
+
+    c = a*b
+    d   = dr.mul_hi(a, b)
+    d_s = dr.mul_hi(a_s, b_s)
+
+    assert dr.all(c == c_s)
+    assert dr.all(d == d_s)
+
+    e   = dr.mul_wide(a, b)
+    e_s = dr.mul_wide(a_s, b_s)
+
+    assert dr.all(e == e_s)


### PR DESCRIPTION
This commit adds the ``dr.mul_wide()`` operation, which performs a wide (e.g. i32 x i32 -> i64) integer multiplication. This is the core operation underlying the Philox pseudorandom number generator.

The commit also exposes ``dr.mul_hi()``, which is similar but only returns the upper part of the result.

They map directly onto the ``mul.wide`` and ``mul.hi`` PTX instructions (or analogous LLVM IR).