### PR TITLE
Fix `dr.rotate()` to match C++ implementation

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -672,7 +672,7 @@ def rotate(dtype, axis, angle):
         raise Exception("drjit.rotate(): unsupported input type!")
 
     s, c = sincos(angle * .5)
-    q = dtype(c, *(axis * s))
+    q = dtype(*(axis * s), c)
     return q
 
 


### PR DESCRIPTION
The Python implementation `dr.rotate()` did not match the C++ implementation:

https://github.com/mitsuba-renderer/drjit/blob/08ab24364a23d4f3f3f8db948e347baa63a3c6e6/include/drjit/quaternion.h#L343-L347