### PR TITLE
Random number generation API redesign

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,9 +213,12 @@ if (DRJIT_MASTER_PROJECT)
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/interop.py
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/ast.pyi
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/ast.py
+      ${CMAKE_CURRENT_BINARY_DIR}/drjit/dda.py
+      ${CMAKE_CURRENT_BINARY_DIR}/drjit/nn.py
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/detail.pyi
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/detail.py
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/opt.py
+      ${CMAKE_CURRENT_BINARY_DIR}/drjit/random.py
       ${CMAKE_CURRENT_BINARY_DIR}/drjit/py.typed
       DESTINATION drjit
     )

--- a/docs/coop_vec.rst
+++ b/docs/coop_vec.rst
@@ -55,8 +55,9 @@ multiplication.
    m, n = 3, 16
 
    # Create a random matrix + offset
-   A = dr.normal(TensorXf, (m, n))
-   b = dr.rand(TensorXf, m)
+   rng = dr.rng(seed=0)
+   A = rng.normal(TensorXf, (m, n))
+   b = rng.random(TensorXf, m)
 
    # Pack 'A' and 'b' into a buffer with an optimal layout
    buffer, A_view, b_view = nn.pack(A, b)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -123,9 +123,18 @@ Rearranging array contents
 Random number generation
 ------------------------
 
-.. autofunction:: rand
-.. autofunction:: normal
-.. autofunction:: seed
+.. autofunction:: rng
+
+.. py:module:: drjit.random
+
+.. autoclass:: Generator
+
+   .. automethod:: random
+   .. automethod:: uniform
+   .. automethod:: normal
+   .. automethod:: clone
+
+.. py:module:: drjit
 
 Mask operations
 ---------------

--- a/docs/type_ref.rst
+++ b/docs/type_ref.rst
@@ -596,6 +596,21 @@ Random number generators
    .. autoproperty:: inc
    .. autoproperty:: state
 
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+
 
 LLVM array namespace (``drjit.llvm``)
 _______________________________________
@@ -1170,6 +1185,22 @@ Random number generators
    .. autoproperty:: inc
    .. autoproperty:: state
 
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+
+
 LLVM array namespace with automatic differentiation (``drjit.llvm.ad``)
 _______________________________________________________________________
 
@@ -1737,6 +1768,22 @@ Random number generators
    .. autoproperty:: inc
    .. autoproperty:: state
 
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+
+
 CUDA array namespace (``drjit.cuda``)
 _______________________________________
 
@@ -2143,6 +2190,22 @@ Random number generators
    .. autoproperty:: inc
    .. autoproperty:: state
 
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+
+
 CUDA array namespace with automatic differentiation (``drjit.cuda.ad``)
 _______________________________________________________________________
 
@@ -2548,6 +2611,22 @@ Random number generators
    .. automethod:: __isub__
    .. autoproperty:: inc
    .. autoproperty:: state
+
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+
 
 Automatic array namespace (``drjit.cuda``)
 __________________________________________
@@ -3132,6 +3211,22 @@ Random number generators
    .. autoproperty:: inc
    .. autoproperty:: state
 
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+
+
 Automatic array namespace with automatic differentiation (``drjit.auto.ad``)
 ____________________________________________________________________________
 
@@ -3714,3 +3809,19 @@ Random number generators
    .. automethod:: __isub__
    .. autoproperty:: inc
    .. autoproperty:: state
+
+.. autoclass:: Philox4x32
+
+   .. automethod:: __init__
+   .. automethod:: next_uint32x4
+   .. automethod:: next_uint64x2
+   .. automethod:: next_float16x4
+   .. automethod:: next_float32x4
+   .. automethod:: next_float64x2
+   .. automethod:: next_float16x4_normal
+   .. automethod:: next_float32x4_normal
+   .. automethod:: next_float64x2_normal
+   .. autoproperty:: seed
+   .. autoproperty:: counter
+   .. autoproperty:: iterations
+

--- a/drjit/random.py
+++ b/drjit/random.py
@@ -1,0 +1,225 @@
+import drjit as dr
+import sys
+import typing
+
+ArrayT = typing.TypeVar('ArrayT', bound=dr.ArrayBase)
+Shape = typing.Union[int, typing.Tuple[int, ...]]
+ArrayOrInt = typing.Union[int, dr.ArrayBase]
+ArrayOrFloat = typing.Union[float, dr.ArrayBase]
+
+class Generator:
+    def random(self, dtype: typing.Type[ArrayT], shape: Shape) -> ArrayT:
+        """
+        Return a Dr.Jit array or tensor containing uniformly distributed
+        pseudorandom variates.
+
+        This function supports floating point arrays/tensors of various
+        configurations and precisions, e.g.:
+
+        .. code-block:: python
+
+           from drjit.cuda import Float, TensorXf, Array3f, Matrix4f
+
+           # Example usage
+           rng = dr.rng(seed=0)
+           rand_array = rng.random(Float, 128)
+           rand_tensor = rng.random(TensorXf16, shape=(128, 128))
+           rand_vec = rng.random(Array3f, (3, 128))
+           rand_mat = rng.random(Matrix4f64, (4, 4, 128))
+
+        The output is uniformly distributed the half-open interval :math:`[0, 1)`.
+        Integer arrays are not supported.
+
+        Args:
+            source (type[ArrayT]): A Dr.Jit tensor or array type.
+
+            shape (int | tuple[int, ...]): The target shape
+
+        Returns:
+            ArrayT: The generated array of random variates.
+        """
+        raise NotImplementedError("random(): use a subclass that implements this function")
+
+    def uniform(self, dtype: typing.Type[ArrayT], shape: Shape, low: ArrayOrFloat = 0.0, high: ArrayOrFloat = 1.0):
+        """
+        Return a Dr.Jit array or tensor containing uniformly distributed
+        pseudorandom variates.
+
+        This function resembles :py:func:`random()` but additionally ensures
+        that variates are distributed on the half-open interval
+        :math:`[\texttt{low}, \texttt{high})`.
+
+        Args:
+            source (type[ArrayT]): A Dr.Jit tensor or array type.
+
+            shape (int | tuple[int, ...]): The target shape
+
+            low (float | drjit.ArrayBase): The low value of the desired interval
+
+            high (float | drjit.ArrayBase): The high value of the desired interval
+
+        Returns:
+            ArrayT: The generated array of random variates.
+        """
+
+        return dr.fma(self.random(dtype, shape), high-low, low)
+
+    def normal(self, dtype: typing.Type[ArrayT], shape: Shape, loc: ArrayOrFloat = 0.0, scale: ArrayOrFloat = 1.0) -> ArrayT:
+        """
+        Return a Dr.Jit array or tensor containing pseudorandom variates
+        following a standard normal distribution
+
+        This function supports arrays/tensors of various configurations and
+        precisions--see the similar :py:func:`drjit.random()` for examples on
+        how to call this function.
+
+        Args:
+            source (type[ArrayT]): A Dr.Jit tensor or array type.
+
+            shape (int | tuple[int, ...]): The target shape
+
+            loc (float | drjit.ArrayBase): The mean of the normal distribution (``0.0`` by default)
+
+            scale (float | drjit.ArrayBase): The standard deviation of the normal distribution (``1.0`` by default)
+
+        Returns:
+            ArrayT: The generated array of random variates.
+        """
+        raise NotImplementedError("normal(): use a subclass that implements this function")
+
+    def clone(self) -> 'Generator':
+        raise NotImplementedError("clone(): use a subclass that implements this function")
+
+class Philox4x32Generator(Generator):
+    """
+    Implementation of the :py:class:`Generator` interface based on the Philox4x32 RNG.
+    """
+
+    _seed : ArrayOrInt
+    _counter : ArrayOrInt
+
+    DRJIT_STRUCT = { '_seed' : ArrayOrInt, '_counter' : ArrayOrInt }
+
+    def __init__(self, seed: ArrayOrInt = 0, counter: ArrayOrInt = 0):
+        seed_tp = dr.uint64_array_t(seed)
+        counter_tp = dr.uint32_array_t(seed)
+        self._seed = seed_tp(seed)
+        self._counter = counter_tp(counter)
+
+    def clone(self) -> 'Generator':
+        return Philox4x32Generator(self._seed, self._counter)
+
+    def _sample(self, dtype: typing.Type[ArrayT], shape: Shape, fn_name: str) -> ArrayT:
+        counter, seed = self._counter, self._seed
+
+        if isinstance(shape, int):
+            shape = (shape, )
+
+        is_jit = dr.is_jit_v(dtype)
+        is_tensor = dr.is_tensor_v(dtype)
+
+        if is_jit:
+            # When JIT-compiling random number generation, ensure that
+            # seed/counter have the right type and are opaque.
+
+            leaf_tp = dr.leaf_t(dtype)
+            mod = sys.modules[leaf_tp.__module__]
+            seed_tp = dr.uint64_array_t(leaf_tp)
+            counter_tp = dr.uint32_array_t(leaf_tp)
+
+            symbolic = dr.flag(dr.JitFlag.SymbolicScope)
+
+            if type(seed) is not seed_tp:
+                if symbolic:
+                    raise RuntimeError('To generate random numbers within a symbolic loop, you must initialize the Generator with a seed of the underlying JIT backend, e.g.: rng = dr.rng(seed=dr.cuda.UInt32(0))')
+
+                seed = seed_tp(seed)
+                counter = counter_tp(counter)
+
+            if not symbolic:
+                dr.make_opaque(counter, seed)
+
+            # Compute the number of lanes for parallel generation
+            if is_tensor:
+                lane_count = dr.prod(shape)
+            else:
+                lane_count = shape[-1]
+
+            lane_index = dr.arange(counter_tp, lane_count)
+        else:
+            mod = dr.scalar
+            lane_index = 0
+
+        # Philox4x32 generates multiple values at once. Put them
+        # into a pool and pop from this pool as needed
+        pool = []
+        def next_sample():
+            nonlocal counter, pool
+
+            # When the pool is empty, generate the next batch
+            if not pool:
+                rng = mod.Philox4x32(seed, counter, lane_index)
+                pool += list(getattr(rng, fn_name)())
+                counter += 1
+
+            return pool.pop()
+
+        if (is_jit and dr.depth_v(dtype) <= 1) or not dr.is_array_v(dtype):
+            # Simple case: scalars and JIT-compiled 1D arrays/tensors
+            s = next_sample()
+            if is_tensor:
+                value = dtype(s, shape)
+            else:
+                if len(shape) > 1:
+                    raise RuntimeError('could not construct output: the provided "shape" and "dtype" parameters are incompatible.')
+                value = dtype(s)
+        else:
+            # Complex case: vectors, matrices, non-JIT arrays, etc.
+            def fill(v):
+                if dr.depth_v(v) == 1:
+                    if is_jit:
+                        v[:] = next_sample()
+                    else:
+                        for i in range(len(v)):
+                            v[i] = next_sample()
+                else:
+                    for i in range(len(v)):
+                        fill(v[i])
+
+            value = dr.empty(dtype, shape)
+            fill(value)
+
+
+        self._seed, self._counter = seed, counter
+
+        return value
+
+    def random(self, dtype: typing.Type[ArrayT], shape: Shape) -> ArrayT:
+        tp = dr.type_v(dtype)
+        if tp == dr.VarType.Float16:
+            fn_name = 'next_float16x4'
+        elif tp == dr.VarType.Float32:
+            fn_name = 'next_float32x4'
+        elif tp == dr.VarType.Float64 or dtype is float:
+            fn_name = 'next_float64x2'
+        else:
+            raise RuntimeError('Unsupported "dtype": must be a Dr.Jit float16/float32/float64 array.')
+        return self._sample(dtype, shape, fn_name)
+
+    def normal(self, dtype: typing.Type[ArrayT], shape: Shape, loc: ArrayOrFloat = 0.0, scale: ArrayOrFloat = 1.0) -> ArrayT:
+        tp = dr.type_v(dtype)
+        if tp == dr.VarType.Float16:
+            fn_name = 'next_float16x4_normal'
+        elif tp == dr.VarType.Float32:
+            fn_name = 'next_float32x4_normal'
+        elif tp == dr.VarType.Float64 or dtype is float:
+            fn_name = 'next_float64x2_normal'
+        else:
+            raise RuntimeError('Unsupported "dtype": must be a Dr.Jit float16/float32/float64 array.')
+        return dr.fma(self._sample(dtype, shape, fn_name), scale, loc)
+
+    def __repr__(self) -> str:
+        seed = self._seed if isinstance(self._seed, int) else self._seed[0]
+        counter = self._counter if isinstance(self._counter, int) else self._counter[0]
+        return f'Philox4x32Generator[seed={seed}, counter={counter}]'
+

--- a/include/drjit/random.h
+++ b/include/drjit/random.h
@@ -1,4 +1,6 @@
 /*
+ * The PCG32 part of this file uses the following license:
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,16 +26,89 @@
 #include <drjit/math.h>
 #include <drjit/while_loop.h>
 
-#define PCG32_DEFAULT_STATE  0x853c49e6748fea9bULL
-#define PCG32_DEFAULT_STREAM 0xda3e39cb94b95bdbULL
-#define PCG32_MULT           0x5851f42d4c957f2dULL
-#define PCG32_MULT_REV       0xc097ef87329e28a5ULL
-
 NAMESPACE_BEGIN(drjit)
 
-/// PCG32 pseudorandom number generator proposed by Melissa O'Neill
+/**
+ * \brief Implementation of PCG32, a member of the PCG family of random number
+ * generators proposed by Melissa O'Neill.
+ *
+ * PCG32 is a stateful pseudorandom number generator that combines a linear
+ * congruential generator (LCG) with a permutation function. It provides high
+ * statistical quality with a remarkably fast and compact implementation.
+ * Details on the PCG family of pseudorandom number generators can be found
+ * `here <https://www.pcg-random.org/index.html>`__.
+ *
+ * To create random tensors of different sizes in Python, prefer the
+ * higher-level :py:func:`dr.rng() <drjit.rng>` interface, which internally uses
+ * the :py:class:`Philox4x32` generator. The properties of PCG32 makes it most
+ * suitable for Monte Carlo applications requiring long sequences of random
+ * variates.
+ *
+ * Key properties of the PCG variant implemented here include:
+ *
+ * * **Compact**: 128 bits total state (64-bit state + 64-bit increment)
+ *
+ * * **Output**: 32-bit output with a period of 2^64 per stream
+ *
+ * * **Streams**: Multiple independent streams via the increment parameter
+ *   (with caveats, see below)
+ *
+ * * **Low-cost sample generation**: a single 64 bit integer multiply-add plus
+ *   a bit permutation applied to the output.
+ *
+ * * **Extra features**: provides fast multi-step advance/rewind functionality.
+ *
+ * **Caveats**: PCG32 produces random high-quality variates within each random
+ * number stream. For a given initial state, PCG32 can also produce multiple
+ * output streams by specifying a different sequence increment (``initseq``) to
+ * the constructor. However, the level of statistical independence *across
+ * streams* is generally insufficient when doing so. To obtain a series of
+ * high-quality independent parallel streams, it is recommended to use another
+ * method (e.g., the Tiny Encryption Algorithm) to seed the `state` and `inc`
+ * parameters. This ensures independence both within and across streams.
+ *
+ * In Python, the :py:class:`PCG32` class is implemented as a :ref:`PyTree
+ * <pytrees>`, which means that it is compatible with symbolic function calls,
+ * loops, etc.
+ *
+ * .. note::
+ *
+ *    Please watch out for the following pitfall when using the PCG32 class in
+ *    long-running Dr.Jit calculations (e.g., steps of a gradient-based
+ * optimizer). Consuming random variates (e.g., through :py:func:`next_float`)
+ * changes the internal RNG state. If this state is never explicitly evaluated,
+ *    the computation graph describing the state transformation keeps growing
+ *    without bound, causing kernel compilation of increasingly large programs
+ *    to eventually become a bottleneck. To evaluate the RNG, simply run
+ *
+ *    .. code-block:: python
+ *
+ *       rng: PCG32 = ....
+ *       dr.eval(rng)
+ *
+ *    For computation involving very large arrays, storing the RNG state (16
+ *    bytes per entry) can be prohibitive. In this case, it is better to keep
+ *    the RNG in symbolic form and re-seed it at every optimization iteration.
+ *
+ *    In cases where a sampler is repeatedly used in a symbolic loop, it is
+ *    more efficient to use the PCG32 API directly to seed once and reuse the
+ *    random number generator throughout the loop.
+ *
+ * Comparison with \ref Philox4x32:
+ *
+ * * :py:class:`PCG32 <drjit.auto.PCG32>`: State-based, better for sequential
+ *   generation, low per-sample cost.
+ *
+ * * :py:class:`Philox4x32 <drjit.auto.Philox4x32>`: Counter-based, better for
+ *   parallel generation, higher per-sample cost.
+ */
 template <typename T> struct PCG32 {
-    /* Some convenient type aliases for vectorization */
+    static constexpr uint64_t PCG32_DEFAULT_STATE  = 0x853c49e6748fea9bULL;
+    static constexpr uint64_t PCG32_DEFAULT_STREAM = 0xda3e39cb94b95bdbULL;
+    static constexpr uint64_t PCG32_MULT           = 0x5851f42d4c957f2dULL;
+    static constexpr uint64_t PCG32_MULT_REV       = 0xc097ef87329e28a5ULL;
+
+    // Type aliases for vectorization
     using  Int64     = int64_array_t<T>;
     using  Int32     = int32_array_t<T>;
     using UInt64     = uint64_array_t<T>;
@@ -137,7 +212,7 @@ template <typename T> struct PCG32 {
 
         return UInt64(v0) | sl<32>(UInt64(v1));
     }
-    
+
     /// Masked version of \ref prev_uint64
     DRJIT_INLINE UInt64 prev_uint64(const Mask &mask) {
         UInt32 v1 = prev_uint32(mask);
@@ -188,12 +263,12 @@ template <typename T> struct PCG32 {
             return prev_uint32(mask);
     }
 
-    /// Generate a half precision floating point value on the interval [0, 1)
+    /// Generate a half precision floating point value on the half-open interval :math:`[0, 1)`.
     DRJIT_INLINE Float16 next_float16() {
         return Float16(next_float32());
     }
 
-    /// Generate a half precision floating point value on the interval [0, 1)
+    /// Generate a half precision floating point value on the half-open interval :math:`[0, 1)`.
     DRJIT_INLINE Float16 prev_float16() {
         return Float16(prev_float32());
     }
@@ -208,12 +283,12 @@ template <typename T> struct PCG32 {
         return Float16(prev_float32(mask));
     }
 
-    /// Generate a single precision floating point value on the interval [0, 1)
+    /// Generate a single precision floating point value on the half-open interval :math:`[0, 1)`.
     DRJIT_INLINE Float32 next_float32() {
         return reinterpret_array<Float32>(sr<9>(next_uint32()) | 0x3f800000u) - 1.f;
     }
 
-    /// Generate previous precision floating point value on the interval [0, 1)
+    /// Generate previous precision floating point value on the half-open interval :math:`[0, 1)`.
     DRJIT_INLINE Float32 prev_float32() {
         return reinterpret_array<Float32>(sr<9>(prev_uint32()) | 0x3f800000u) - 1.f;
     }
@@ -229,7 +304,7 @@ template <typename T> struct PCG32 {
     }
 
     /**
-     * \brief Generate a double precision floating point value on the interval [0, 1)
+     * \brief Generate a double precision floating point value on the half-open interval :math:`[0, 1)`.
      *
      * \remark Since the underlying random number generator produces 32 bit output,
      * only the first 32 mantissa bits will be filled (however, the resolution is still
@@ -584,14 +659,262 @@ template <typename T> struct PCG32 {
     /// Inequality operator
     bool operator!=(const PCG32 &other) const { return state != other.state || inc != other.inc; }
 
-    UInt64 state;  // RNG state.  All values are possible.
-    UInt64 inc;    // Controls which RNG sequence (stream) is selected. Must *always* be odd.
+public:
+    UInt64 state; //< RNG state.  All values are possible.
+    UInt64 inc;   //< Controls which RNG sequence (stream) is selected. Must *always* be odd.
 
     DRJIT_STRUCT_NODEF(PCG32, state, inc)
+
 private:
     struct initialize_state { };
     PCG32(initialize_state, const UInt64 &state, const UInt64 &inc)
         : state(state), inc(inc) { }
+};
+
+/**
+ * \brief Philox4x32 counter-based PRNG
+ *
+ * This class implements the Philox 4x32 counter-based pseudo-random number
+ * generator based on the paper `Parallel Random Numbers: As Easy as 1, 2, 3
+ * <https://www.thesalmons.org/john/random123/papers/random123sc11.pdf>`__ by
+ * Salmon et al. [2011]. It uses strength-reduced cryptographic primitives to
+ * realize a complex transition function that turns a seed and set of counter
+ * values onto 4 pseudorandom outputs. Incrementing any of the counters or
+ * choosing a different seed produces statistically independent samples.
+ *
+ * The implementation here uses a reduced number of bits (32) for the
+ * arithmetic and sets the default number of rounds to 7. However, even with
+ * these simplifications it passes the `Test01
+ * <https://en.wikipedia.org/wiki/TestU01>`__ stringent ``BigCrush`` tests (a
+ * battery of statistical tests for non-uniformity and correlations). Please
+ * see the paper `Random number generators for massively parallel simulations
+ * on GPU <https://arxiv.org/abs/1204.6193>`__ by Manssen et al. [2012] for
+ * details.
+ *
+ * Functions like :py:func:`next_uint32x4()` or :py:func:`next_float32x4()`
+ * advance the PRNG state by incrementing the counter ``counter[3]``.
+ *
+ * Key properties include:
+ * - Counter-based design: generation from counter + key
+ * - 192-bit bit state: 4x32-bit counters, 64-bit key
+ * - Trivial jump-ahead capability through counter manipulation
+ *
+ * The :py:class:`Philox4x32` class is implemented as a :ref:`PyTree <pytrees>`,
+ * making it compatible with symbolic function calls, loops, etc.
+ *
+ * .. note::
+ *
+ *    :py:class:`Philox4x32` naturally produces 4 samples at a time, which may
+ *    be awkward for applications that need individual random values.
+ *
+ * .. note::
+ *
+ *    For a comparison of use cases between :py:class:`Philox4x32` and
+ *    :py:class:`PCG32`, see the :py:class:`PCG32` class documentation. In
+ *    brief: use :py:class:`PCG32` for sequential generation with lowest cost
+ *    per sample; use :py:class:`Philox4x32` for parallel generation where
+ *    independent streams are critical.
+ */
+template <typename T> struct Philox4x32 {
+    /// Multipliers
+    static constexpr uint32_t PHILOX_M0 = 0xD2511F53;
+    static constexpr uint32_t PHILOX_M1 = 0xCD9E8D57;
+
+    // Key offsets
+    static constexpr uint32_t PHILOX_W0 = 0x9E3779B9;
+    static constexpr uint32_t PHILOX_W1 = 0xBB67AE85;
+
+    // Type aliases for vectorization
+    using  Int64    = int64_array_t<T>;
+    using  Int32    = int32_array_t<T>;
+    using UInt64    = uint64_array_t<T>;
+    using UInt32    = uint32_array_t<T>;
+    using Float16   = float16_array_t<T>;
+    using Float32   = float32_array_t<T>;
+    using Float64   = float64_array_t<T>;
+    using Array2u   = Array<UInt32, 2>;
+    using Array2u64 = Array<UInt64, 2>;
+    using Array4u   = Array<UInt32, 4>;
+    using Array4f   = Array<Float32, 4>;
+    using Array4f16 = Array<Float16, 4>;
+    using Array2f64 = Array<Float64, 2>;
+    using Mask      = mask_t<UInt64>;
+
+    /**
+     * \brief Construct a Philox PRNG
+     *
+     * The function takes a ``seed`` and three of four ``counter`` component.
+     * The last component is zero-initialized and incremented by calls to the
+     * ``sample_*`` methods.
+     *
+     * \param seed The 64-bit seed value used as the key for the Philox step function
+     * \param counter_0 The first 32-bit counter (least significant)
+     * \param counter_1 The second 32-bit counter (default: 0)
+     * \param counter_2 The third 32-bit counter (default: 0)
+     * \param iterations Number of rounds (default: 7)
+     */
+    Philox4x32(const UInt64 &seed,
+               const UInt32 &counter_0,
+               const UInt32 &counter_1 = 0,
+               const UInt32 &counter_2 = 0,
+               uint32_t iterations = 7)
+        : seed(UInt32(seed >> 32), UInt32(seed)),
+          counter(counter_0, counter_1, counter_2, 0),
+          iterations(iterations) { }
+
+    /**
+     * \brief Generate 4 random 32-bit unsigned integers
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 4 independent 32-bit random values.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array4u next_uint32x4(const Mask &mask = true) {
+        auto [state, _1, _2] = while_loop(
+            // Initial loop state
+            make_tuple(counter, seed, UInt32(0)),
+
+            // Loop condition
+            [iterations=iterations](Array4u &, Array2u &, UInt32 &it) {
+                return it < iterations;
+            },
+
+            // Loop update step
+            [](Array4u &state, Array2u &key, UInt32 &it) {
+                state = step(state, key);
+                key += Array2u(PHILOX_W0, PHILOX_W1);
+                it += 1;
+            },
+
+            // Descriptive label
+            "drjit::Philox4x32::next_uint32x4()"
+        );
+
+        counter[3] = select(mask, counter[3] + 1, counter[3]);
+
+        return state;
+    }
+
+    /**
+     * \brief Generate 2 random 64-bit unsigned integers
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 2 independent 64-bit random values.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array2u64 next_uint64x2(const Mask &mask = true) {
+        Array4u result = next_uint32x4(mask);
+        return Array2u64(
+            (UInt64(result.y()) << 32) | result.x(),
+            (UInt64(result.w()) << 32) | result.z()
+        );
+    }
+
+    /** \brief Generate 4 uniformly distributed half-precision floats in on
+     * the half-open interval :math:`[0, 1)`.
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 4 independent half precision floats.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array4f16 next_float16x4(const Mask &mask = true) {
+        return Array4f16(next_float32x4(mask));
+    }
+
+    /** \brief Generate 4 uniformly distributed single-precision floats in on
+     * the half-open interval :math:`[0, 1)`.
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 4 independent single precision floats.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array4f next_float32x4(const Mask &mask = true) {
+        return reinterpret_array<Array4f>(sr<9>(next_uint32x4(mask)) |
+                                          0x3f800000u) - 1.f;
+    }
+
+    /** \brief Generate 2 uniformly distributed double-precision floats in on
+     * the half-open interval :math:`[0, 1)`.
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 2 independent double precision floats.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array2f64 next_float64x2(const Mask &mask = true) {
+        return reinterpret_array<Array2f64>(sr<12>(next_uint64x2(mask)) |
+                                            0x3ff0000000000000ull) - 1.0;
+    }
+
+    /** \brief Generate 4 normally distributed half-precision floats
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 4 half precision floats following a standard normal distribution.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array4f16 next_float16x4_normal(const Mask &mask = true) {
+        return Array4f16(next_float32x4_normal(mask));
+    }
+
+    /** \brief Generate 4 normally distributed single-precision floats
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 4 single precision floats following a standard normal distribution.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array4f next_float32x4_normal(const Mask &mask = true) {
+        Array4f value = next_float32x4(mask);
+        auto [s0, c0] = sincos(TwoPi<Float32> * value.x());
+        auto [s1, c1] = sincos(TwoPi<Float32> * value.y());
+        Float32 scale0 = sqrt(-log2(1.f - value.z())) * sqrt(2 * LogTwo<Float32>),
+                scale1 = sqrt(-log2(1.f - value.w())) * sqrt(2 * LogTwo<Float32>);
+        return Array4f(c0 * scale0, s0 * scale0, c1 * scale1, s1 * scale1);
+    }
+
+    /** \brief Generate 2 normally distributed double-precision floats
+     *
+     * Advances the internal counter and applies the Philox mapping to
+     * produce 2 double precision floats following a standard normal distribution.
+     *
+     * \param mask Optional mask to control which lanes are updated
+     */
+    Array2f64 next_float64x2_normal(const Mask &mask = true) {
+        Array2f64 value = next_float64x2(mask);
+        auto [s, c] = sincos(TwoPi<Float64> * value.y());
+        Float64 scale = sqrt(-log2(1.0 - value.x())) * sqrt(2 * LogTwo<Float64>);
+        return Array2f64(c * scale, s * scale);
+    }
+
+public:
+    Array2u seed;
+    Array4u counter;
+    uint32_t iterations;
+
+    DRJIT_STRUCT_NODEF(Philox4x32, iterations, seed, counter)
+
+private:
+    static Array4u step(const Array4u &state, const Array2u &key) {
+        UInt64 hilo0 = mul_wide(PHILOX_M0, state[0]),
+               hilo1 = mul_wide(PHILOX_M1, state[2]);
+
+        UInt32 lo0 = UInt32(hilo0),
+               lo1 = UInt32(hilo1),
+               hi0 = UInt32(hilo0 >> 32),
+               hi1 = UInt32(hilo1 >> 32);
+
+        return Array4u(
+            hi1 ^ state[1] ^ key[0],
+            lo1,
+            hi0 ^ state[3] ^ key[1],
+            lo0
+        );
+    }
 };
 
 NAMESPACE_END(drjit)

--- a/include/drjit/traversable_base.h
+++ b/include/drjit/traversable_base.h
@@ -168,6 +168,8 @@ struct DRJIT_EXTRA_EXPORT TraversableBase : public nanobind::intrusive_base {
         static_assert(                                                         \
             std::is_base_of<drjit::TraversableBase,                            \
                             std::remove_pointer_t<decltype(this)>>::value);    \
+        DRJIT_MARK_USED(payload);                                              \
+        DRJIT_MARK_USED(fn);                                                   \
         if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
             Base::traverse_1_cb_ro(payload, fn);                               \
         DRJIT_MAP(DR_TRAVERSE_MEMBER_RO, __VA_ARGS__)                          \
@@ -187,6 +189,8 @@ struct DRJIT_EXTRA_EXPORT TraversableBase : public nanobind::intrusive_base {
         static_assert(                                                         \
             std::is_base_of<drjit::TraversableBase,                            \
                             std::remove_pointer_t<decltype(this)>>::value);    \
+        DRJIT_MARK_USED(payload);                                              \
+        DRJIT_MARK_USED(fn);                                                   \
         if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
             Base::traverse_1_cb_rw(payload, fn);                               \
         DRJIT_MAP(DR_TRAVERSE_MEMBER_RW, __VA_ARGS__)                          \

--- a/src/extra/CMakeLists.txt
+++ b/src/extra/CMakeLists.txt
@@ -11,10 +11,9 @@ add_library(
   resample.cpp
 )
 
-set_source_files_properties(resample.cpp PROPERTIES COMPILE_FLAGS -ffp-contract=off)
-
 if (NOT MSVC)
   target_compile_options(drjit-extra PRIVATE $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-fno-stack-protector>)
+  set_source_files_properties(resample.cpp PROPERTIES COMPILE_FLAGS -ffp-contract=off)
 else()
   # C24127 conditional expression is constant (a few in robin_hash.h)
   # C24324 structure was padded due to alignment specifier

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -22,8 +22,8 @@ configure_file(
 
 set(PY_FILES
   config.py __init__.py ast.py detail.py interop.py dda.py opt.py nn.py
-  _sh_eval.py _reduce.py scalar/__init__.py llvm/__init__.py llvm/ad.py
-  cuda/__init__.py cuda/ad.py)
+  random.py _sh_eval.py _reduce.py scalar/__init__.py llvm/__init__.py
+  llvm/ad.py cuda/__init__.py cuda/ad.py)
 
 set(PY_FILES_OUT "")
 

--- a/src/python/cuda.cpp
+++ b/src/python/cuda.cpp
@@ -18,7 +18,7 @@ void export_cuda(nb::module_ &m) {
 
     ArrayBinding b;
     dr::bind_all<Guide>(b);
-    bind_pcg32<Guide>(m);
+    bind_rng<Guide>(m);
     bind_texture_all<Guide>(m);
 
     m.attr("Float32") = m.attr("Float");

--- a/src/python/cuda_ad.cpp
+++ b/src/python/cuda_ad.cpp
@@ -19,7 +19,7 @@ void export_cuda_ad(nb::module_ &m) {
 
     ArrayBinding b;
     dr::bind_all<Guide>(b);
-    bind_pcg32<Guide>(m);
+    bind_rng<Guide>(m);
     bind_texture_all<Guide>(m);
 
     m.attr("Float32") = m.attr("Float");

--- a/src/python/freeze.h
+++ b/src/python/freeze.h
@@ -15,8 +15,15 @@
 #include <drjit-core/jit.h>
 #include <drjit/autodiff.h>
 #include <string>
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4324) // structure was padded due to alignment specifier
+#endif
 #include <tsl/robin_map.h>
 #include <tsl/robin_set.h>
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 #include <drjit/fwd.h>
 
 #include "../ext/nanobind/src/buffer.h"

--- a/src/python/llvm.cpp
+++ b/src/python/llvm.cpp
@@ -18,7 +18,7 @@ void export_llvm(nb::module_ &m) {
 
     ArrayBinding b;
     dr::bind_all<Guide>(b);
-    bind_pcg32<Guide>(m);
+    bind_rng<Guide>(m);
     bind_texture_all<Guide>(m);
 
     m.attr("Float32") = m.attr("Float");

--- a/src/python/llvm_ad.cpp
+++ b/src/python/llvm_ad.cpp
@@ -19,7 +19,7 @@ void export_llvm_ad(nb::module_ &m) {
 
     ArrayBinding b;
     dr::bind_all<Guide>(b);
-    bind_pcg32<Guide>(m);
+    bind_rng<Guide>(m);
     bind_texture_all<Guide>(m);
 
     m.attr("Float32") = m.attr("Float");

--- a/src/python/random.h
+++ b/src/python/random.h
@@ -5,8 +5,9 @@
 #include "base.h"
 
 template <typename Guide>
-void bind_pcg32(nb::module_ &m) {
+void bind_rng(nb::module_ &m) {
     using UInt64 = dr::uint64_array_t<Guide>;
+    using UInt32 = dr::uint32_array_t<Guide>;
     using Int64 = dr::int64_array_t<Guide>;
     using PCG32 = dr::PCG32<UInt64>;
     using Mask = dr::mask_t<UInt64>;
@@ -14,12 +15,12 @@ void bind_pcg32(nb::module_ &m) {
     auto pcg32 = nb::class_<PCG32>(m, "PCG32", doc_PCG32)
         .def(nb::init<size_t, const UInt64 &, const UInt64 &>(),
              "size"_a = 1,
-             "initstate"_a.sig("UInt64(0x853c49e6748fea9b)") = PCG32_DEFAULT_STATE,
-             "initseq"_a.sig("UInt64(0xda3e39cb94b95bdb)") = PCG32_DEFAULT_STREAM, doc_PCG32_PCG32)
+             "initstate"_a.sig("UInt64(0x853c49e6748fea9b)") = PCG32::PCG32_DEFAULT_STATE,
+             "initseq"_a.sig("UInt64(0xda3e39cb94b95bdb)") = PCG32::PCG32_DEFAULT_STREAM, doc_PCG32_PCG32)
         .def(nb::init<const PCG32 &>(), doc_PCG32_PCG32_2)
         .def("seed", &PCG32::seed,
-             "initstate"_a.sig("UInt64(0x853c49e6748fea9b)")  = PCG32_DEFAULT_STATE,
-             "initseq"_a.sig("UInt64(0xda3e39cb94b95bdb)") = PCG32_DEFAULT_STREAM, doc_PCG32_seed)
+             "initstate"_a.sig("UInt64(0x853c49e6748fea9b)")  = PCG32::PCG32_DEFAULT_STATE,
+             "initseq"_a.sig("UInt64(0xda3e39cb94b95bdb)") = PCG32::PCG32_DEFAULT_STREAM, doc_PCG32_seed)
         .def("next_uint32",
              nb::overload_cast<>(&PCG32::next_uint32),
              doc_PCG32_next_uint32)
@@ -216,4 +217,31 @@ void bind_pcg32(nb::module_ &m) {
     fields["state"] = u64;
     fields["inc"] = u64;
     pcg32.attr("DRJIT_STRUCT") = fields;
+
+    using Philox4x32 = dr::Philox4x32<UInt32>;
+
+    auto philox = nb::class_<Philox4x32>(m, "Philox4x32", doc_Philox4x32)
+        .def(nb::init<const UInt64 &, const UInt32 &, const UInt32 &, const UInt32 &, uint32_t>(),
+             "seed"_a, "counter_0"_a , "counter_1"_a = 0, "counter_2"_a = 0, "iterations"_a = 7,
+             doc_Philox4x32_Philox4x32)
+        .def(nb::init<const Philox4x32 &>(), "Copy constructor")
+        .def("next_uint32x4", &Philox4x32::next_uint32x4, "mask"_a = true,
+             doc_Philox4x32_next_uint32x4)
+        .def("next_uint64x2", &Philox4x32::next_uint64x2, "mask"_a = true,
+             doc_Philox4x32_next_uint64x2)
+        .def("next_float16x4", &Philox4x32::next_float16x4, "mask"_a = true,
+             doc_Philox4x32_next_float16x4)
+        .def("next_float32x4", &Philox4x32::next_float32x4, "mask"_a = true,
+             doc_Philox4x32_next_float32x4)
+        .def("next_float64x2", &Philox4x32::next_float64x2, "mask"_a = true,
+             doc_Philox4x32_next_float64x2)
+        .def("next_float16x4_normal", &Philox4x32::next_float16x4_normal, "mask"_a = true,
+             doc_Philox4x32_next_float16x4_normal)
+        .def("next_float32x4_normal", &Philox4x32::next_float32x4_normal, "mask"_a = true,
+             doc_Philox4x32_next_float32x4_normal)
+        .def("next_float64x2_normal", &Philox4x32::next_float64x2_normal, "mask"_a = true,
+             doc_Philox4x32_next_float64x2_normal)
+        .def_rw("seed", &Philox4x32::seed)
+        .def_rw("counter", &Philox4x32::counter)
+        .def_rw("iterations", &Philox4x32::iterations);
 }

--- a/src/python/scalar.cpp
+++ b/src/python/scalar.cpp
@@ -15,7 +15,7 @@
 void export_scalar(nb::module_& m) {
     ArrayBinding b;
     dr::bind_all<float>(b);
-    bind_pcg32<float>(m);
+    bind_rng<float>(m);
     bind_texture_all<float>(m);
 
     m.attr("Bool") = nb::borrow(&PyBool_Type);

--- a/tests/call_ext.cpp
+++ b/tests/call_ext.cpp
@@ -152,10 +152,10 @@ template <typename Float> struct B : Base<Float> {
         return value - x;
     }
 
-    virtual Float nested(Float x, UInt32 s) override {
+    virtual Float nested(Float x, UInt32 s_param) override {
         using BaseArray = dr::replace_value_t<Float, Base<Float>*>;
-        BaseArray self = dr::reinterpret_array<BaseArray>(s);
-        return self->nested(x, s);
+        BaseArray self = dr::reinterpret_array<BaseArray>(s_param);
+        return self->nested(x, s_param);
     }
 
     virtual Float nested_self(Float x) override {
@@ -164,8 +164,8 @@ template <typename Float> struct B : Base<Float> {
         return self->nested(x, this->s);
     }
 
-    virtual std::pair<Sampler<Float> *, Float> sample(Sampler<Float> *s) override {
-        return { s, 0 };
+    virtual std::pair<Sampler<Float> *, Float> sample(Sampler<Float> *sampler) override {
+        return { sampler, 0 };
     }
 
     virtual void dummy() override { }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def traverse(o):
             array_packages.append(o)
 
         for o2 in o.__dict__.values():
-            if isinstance(o2, type) and issubclass(o2, dr.ArrayBase):
+            if isinstance(o2, type) and issubclass(o2, dr.ArrayBase) and o2 is not dr.ArrayBase:
                 array_types.append(o2)
 
         traverse(getattr(o, 'ad', None))

--- a/tests/test_coop_vec.py
+++ b/tests/test_coop_vec.py
@@ -407,8 +407,9 @@ def test15_matvec_in_vcall(t, transpose):
     Float = dr.array_t(t)
     UInt32 = dr.uint32_array_t(Float)
     size = 64
-    A = dr.normal(t, (size, size))
-    b = dr.normal(t, size)
+    rng = dr.rng()
+    A = rng.normal(t, (size, size))
+    b = rng.normal(t, size)
     _, A, b = nn.pack(A, b)
 
     def mult_it():

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -3601,12 +3601,14 @@ def test96_coop_vec(t, auto_opaque, layout):
         nn.Exp(),
     )
 
-    net = net.alloc(TensorXf16, 2)
+    rng = dr.rng(seed=0)
+    net = net.alloc(TensorXf16, size=2, rng=rng)
 
     weights, net = nn.pack(net, layout=layout)
 
+    rng = dr.rng()
     for i in range(3):
-        x = dr.rand(ArrayXf, (2, 2 * i + 4))
+        x = rng.random(ArrayXf, (2, 2 * i + 4))
 
         res = frozen(net=net, x=x)
         ref = func(net = net, x = x)
@@ -3652,13 +3654,14 @@ def test97_coop_vec_bwd(t, auto_opaque):
 
     weights, net = nn.pack(net, layout="training")
 
-    x = dr.rand(ArrayXf, (2, 2))
+    rng = dr.rng()
+    x = rng.random(ArrayXf, (2, 2))
 
     for i in range(3):
         dr.enable_grad(weights)
         dr.clear_grad(weights)
 
-        x = dr.rand(ArrayXf, (2, i * 2 + 4))
+        x = rng.random(ArrayXf, (2, i * 2 + 4))
 
         loss_res = frozen(net, x)
         grad_res = dr.grad(weights)

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 @pytest.test_arrays('shape=(*), float32', 'shape=(*), float64')
-def test01_basic(t):
+def test01_pcg32_basic(t):
     m = sys.modules[t.__module__]
     f32 = m.PCG32().next_float32()
     f64 = m.PCG32().next_float64()
@@ -31,45 +31,12 @@ def test01_basic(t):
         assert f == f64
         assert f_n == f64_n
 
-@pytest.test_arrays('shape=(*), float32', 'shape=(*, *), float32', 'tensor, float32', 'shape=(3), float32')
-def test02_rand_shape(t):
-    if not dr.is_dynamic_v(t):
-        x = dr.rand(t, 3)
-        assert x.shape[-1] == 3
-    elif dr.depth_v(t) > 1 and dr.size_v(t) == dr.Dynamic:
-        x = dr.rand(t, (2, 15))
-        assert x.shape == (2, 15)
-    else:
-        x = dr.rand(t, 15)
-        assert x.shape[-1] == 15
-
-    if dr.is_tensor_v(t):
-        x = dr.rand(t, (15, 20))
-        assert x.shape == (15, 20)
-
-@pytest.test_arrays('shape=(3), float32')
-def test02_rand_shape_v2(t):
-    x = dr.rand(t, 3)
-    x.shape == (3,) == 15
 
 @pytest.test_arrays('shape=(*), float32')
-def test03_seed(t):
-    dr.seed(0)
-    v0 = dr.rand(t, 10)
-    v1 = dr.rand(t, 10)
-    dr.seed(0)
-    v2 = dr.rand(t, 10)
-    v3 = dr.rand(t, 10, seed=5)
-    v4 = dr.rand(t, 10, seed=5)
-
-    assert not dr.all(v0 == v1) and dr.all(v0 == v2)
-    assert not dr.all(v0 == v3) and not dr.all(v1 == v3) and dr.all(v3 == v4)
-
-@pytest.test_arrays('shape=(*), float32')
-def test04_prev_sample(t):
+def test02_pcg32_prev_sample(t):
     m = sys.modules[t.__module__]
     pcg = m.PCG32()
-    
+
     uint32 = pcg.next_uint32()
     uint32_prev = pcg.prev_uint32()
     assert uint32 == uint32_prev
@@ -151,3 +118,144 @@ def test04_prev_sample(t):
         f_n = pcg.next_float_normal(float)
         f_n_prev = pcg.prev_float_normal(float)
         assert dr.all(f_n == f_n_prev)
+
+
+@pytest.test_arrays('shape=(4, *), uint32', 'shape=(4), uint32')
+def test03_philox(t):
+    # Test data from OpenRAND
+
+    ref = \
+        ((0x5d5ce31a, 0x44c9c0bc, 0x4e3d18c6, 0x5d1fb025),
+         (0x35a82af1, 0x9bf3750e, 0xde264205, 0xff8aa6c9),
+         (0xad537add, 0x459b3aaf, 0x3f5c4716, 0x23ac1969),
+         (0x4bfca5c6, 0xcf907aaa, 0xafcebe2d, 0xdd7dc9de),
+         (0x4a32c886, 0xd9762338, 0xc86f6072, 0x9067c5db),
+         (0xe494fe2c, 0x9674b214, 0x65493727, 0x6385a822),
+         (0x7dc9de38, 0xb1cb2a5c, 0x3037f445, 0x7d2a1a),
+         (0x91375fbf, 0x582efbd0, 0x2adef277, 0x8aae3eef),
+         (0xdbadd0bd, 0x74b615dd, 0x216a0f2c, 0x7761df5b),
+         (0x5e709dea, 0x45f0edeb, 0x7c7b296b, 0x2d2fd83c),
+         (0x4a1ae0aa, 0x102ec9ca, 0x1e247d26, 0x514a3826),
+         (0x3d196f14, 0x10169eeb, 0x272f0272, 0xbb259fc8),
+         (0xaf9c9024, 0x5ca87d4, 0x33868095, 0x124b6a37),
+         (0x6f70a947, 0xb5e70e52, 0x79112edb, 0x26a73257),
+         (0xedfaa927, 0x53a0af72, 0x6c866deb, 0xad913511),
+         (0x4fbe687b, 0x75380bcf, 0x8a3178ee, 0xc3533b8),
+         (0x75bdc2d8, 0x1a3097f, 0x156cb857, 0xefea48b3),
+         (0xa1060344, 0x6543d5a5, 0xaae13a43, 0x2cad2bc6))
+
+    m = sys.modules[t.__module__]
+
+    for i in range(3):
+        for j in range(3):
+            rng = m.Philox4x32(seed=i, counter_0=j, counter_1=0x12345, counter_2=0xAAAAAAAA, iterations=10)
+            offset = (i*3+j)*2
+            r0 = t(ref[offset+0])
+            r1 = t(ref[offset+1])
+            v0 = rng.next_uint32x4()
+            v1 = rng.next_uint32x4()
+            assert dr.all(v0 == r0)
+            assert dr.all(v1 == r1)
+
+
+@pytest.test_arrays('shape=(*), float32',
+                    'shape=(*, *), float32',
+                    'tensor, float32',
+                    'shape=(3), float32')
+def test04_rng_shape(t):
+    rng = dr.rng()
+    incompat = 'could not construct output: the provided "shape" and "dtype" parameters are incompatible.'
+
+    if not dr.is_dynamic_v(t):
+        x = rng.random(t, 3)
+        assert type(x) is t
+        assert x.shape[-1] == 3
+        with pytest.raises(RuntimeError, match=incompat):
+            rng.random(t, 4)
+    elif dr.depth_v(t) > 1 and dr.size_v(t) == dr.Dynamic:
+        x = rng.random(t, (2, 15))
+        assert type(x) is t
+        assert x.shape == (2, 15)
+        with pytest.raises(RuntimeError, match=incompat):
+            rng.random(t, (2, 3, 4))
+    else:
+        x = rng.random(t, 15)
+        assert type(x) is t
+        assert x.shape[-1] == 15
+
+        if not dr.is_tensor_v(t):
+            with pytest.raises(RuntimeError, match=incompat):
+                rng.random(t, (2, 3))
+
+    if dr.is_tensor_v(t):
+        x = rng.random(t, (15, 20))
+        assert type(x) is t
+        assert x.shape == (15, 20)
+
+@pytest.test_arrays('shape=(*), float32')
+def test06_rng_seed(t):
+    # Test that same seed produces same sequence
+    rng1 = dr.rng(seed=0)
+    v0 = rng1.random(t, 10)
+    rng1_c = rng1.clone()
+    v1 = rng1.random(t, 10)
+    v1_2 = rng1_c.random(t, 10)
+
+    rng2 = dr.rng(seed=0)
+    v2 = rng2.random(t, 10)
+    v3 = rng2.random(t, 10)
+
+    assert dr.all(v0 == v2) and dr.all(v1 == v3) and dr.all(v1 == v1_2)
+    assert dr.all(v0 != v1)
+
+    rng3 = dr.rng(seed=5)
+    v4 = rng3.random(t, 10)
+
+    assert dr.all(v4 != v0)
+
+
+@pytest.test_arrays('shape=(*), float')
+def test06_rng_distr(t):
+    rng = dr.rng()
+    x = rng.random(t, 100)
+    assert type(x) is t
+    assert dr.all((x >= 0) & (x < 1))
+
+    x = rng.uniform(t, 100, low=10, high=20)
+    assert dr.all((x >= 10) & (x < 20))
+
+    x = rng.normal(t, 10000)
+    assert dr.allclose(dr.mean(x), 0, atol = 5e-2)
+    assert dr.allclose(dr.mean(dr.square(x)), 1, atol = 5e-2)
+
+    x = rng.normal(t, 10000, loc=2, scale=3)
+    assert dr.allclose(dr.mean(x), 2, atol = 5e-2)
+    if dr.type_v(x) != dr.VarType.Float16:
+        assert dr.allclose(dr.mean(dr.square(x-2)), 9, atol = 5e-1)
+
+@pytest.test_arrays('shape=(*), float, jit')
+@pytest.mark.parametrize('seed_mode', (0, 1))
+@dr.syntax
+def test06_rng_symbolic(t, seed_mode):
+    """Test symbolic recording of dr.rng() operations"""
+    Index = dr.uint32_array_t(t)
+    if seed_mode == 0:
+        seed = Index(0)
+    else:
+        seed = 0
+
+    rng = dr.rng(seed=seed)
+    i = Index(0)
+    while i < 10:
+        i += 1
+        if seed_mode == 1:
+            with pytest.raises(RuntimeError) as e:
+                rng.uniform(t, 1)
+            expected_error = 'To generate random numbers within a symbolic loop, you must initialize the Generator with a seed of the underlying JIT backend, e.g.: rng = dr.rng(seed=dr.cuda.UInt32(0))'
+            assert expected_error in str(e)
+        else:
+            rng.uniform(t, 1)
+
+    if seed_mode == 0:
+        x = rng.uniform(t, 1)
+        assert dr.allclose(x, 0.467728)


### PR DESCRIPTION
This PR moves the tentative ``dr.rand()`` and ``dr.randn()`` functions into a *generator object* similar to how this works in NumPy and other array APIs. It can be used as follows

```python
rng: dr.random.Generator = dr.rng(seed=123)

value = rng.random(Float, 1000)
value_2 = rng.normal(TensorXf16, shape=(100, 100))
```

Furthermore, the PRNG underlying this interface was switched to a new algorithm named ``Philox4x32``.

This redesign was motivated by the following considerations:

The previously used ``PCG32`` PRNG has very low per-sample cost, but it tends to suffer from correlations between separate parallel streams if not correctly seeded. Another pseudorandom number generator must therefore be added to initialize PCG32 in practice, which increases computational cost and conceptual complexity.

On top of this, the `rng.random()` / `rng.normal()` interface are designed to initialize differently-sized arrays, which means that the PRNG cannot be reused. Therefore, the main benefit of PCG32---low per-sample cost---is not actually that helpful here. This interface is better served by a counter-based PRNG that uses a complex transition function to turn one or more counters into pseudorandom output.

The implementation adopts ``Philox`` from the paper [Parallel Random Numbers: As Easy as 1, 2, 3](https://www.thesalmons.org/john/random123/papers/random123sc11.pdf) by Salmon et al. (2011). This method uses a combination of wide multiplication and XOR operations to transform a seed and four counters into high-quality pseudorandom outputs. Changing either the seed or any of the counters yields a new statistically independent sample. This method is more expensive per sample but relative foolproof, which makes it a better fit for this API. A previous set of changes to Dr.Jit and Dr.Jit-Core added the necessary wide multiplication instructions to compile Philox to efficient machine code.

The commit also adapts functionality using random numbers internally (specifically, ``nn.Module.alloc()``) to optionally take a ``Generator`` object.