### PR TITLE
Debug mode: handle `frame.f_lineno == None` in `trace_func`

### DIFF
--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -232,9 +232,15 @@ static nb::handle trace_func_handle;
 
 /// Python debug tracing callback that informs Dr.Jit about the currently executing line of code
 nb::object trace_func(nb::handle frame, nb::handle, nb::handle) {
-    const size_t lineno = nb::cast<size_t>(frame.attr("f_lineno"));
-    const char *filename = nb::cast<const char *>(frame.attr("f_code").attr("co_filename"));
-    jit_set_source_location(filename, lineno);
+    const auto f_lineno = frame.attr("f_lineno");
+    if (f_lineno.is_none()) {
+        // No valid source location available.
+        jit_set_source_location(nullptr, (size_t) -1);
+    } else {
+        const size_t lineno = nb::cast<size_t>(f_lineno);
+        const char *filename = nb::cast<const char *>(frame.attr("f_code").attr("co_filename"));
+        jit_set_source_location(filename, lineno);
+    }
     return nb::borrow(trace_func_handle);
 }
 

--- a/tests/test_assert.py
+++ b/tests/test_assert.py
@@ -1,3 +1,5 @@
+import os
+
 import drjit as dr
 import pytest
 
@@ -116,3 +118,13 @@ def test04_assert_false_loop(t, mode, capsys):
             dr.eval(i)
             captured = capsys.readouterr()
             assert "Assertion failure!" in str(captured.err)
+
+
+def test05_debug_trace_func():
+    """
+    This could lead to `std::bad_cast` or a PyTest internal error
+    when DrJit's `trace_func()` did not correctly handle `frame.f_lineno == None`.
+    """
+    with dr.scoped_set_flag(dr.JitFlag.Debug, True):
+        for _ in os.walk("."):
+            pass


### PR DESCRIPTION
Before this change, enabling DrJit's debug mode could result in crashes due to `std::bad_cast` (`frame.f_lineno == None` could not be cast to `size_t`).

Requires https://github.com/mitsuba-renderer/drjit-core/pull/158 on the drjit-core side.