### PR TITLE
Support for excess register spilling to CUDA shared memory

### DIFF
--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -6156,6 +6156,17 @@
     When enabled, traversal of complex objects, that usually are opaque to
     loops and conditionals, is enabled.
 
+.. topic:: JitFlag_SpillToSharedMemory
+
+    Enable spilling of excess registers into shared memory.
+
+    This flag activates an optimization that stores registers in shared memory
+    when register pressure is high, reducing the need to spill to slower 
+    local memory. This can improve performance by lowering memory latency on 
+    register-intensive kernels. This flag only applies to the CUDA backend.
+
+    This flag is *enabled* by default.
+
 .. topic:: JitFlag_Default
 
     The default set of optimization flags consisting of

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -114,6 +114,7 @@ NB_MODULE(_drjit_ext, m_) {
         .value("KernelFreezing", JitFlag::KernelFreezing, doc_JitFlag_KernelFreezing)
         .value("FreezingScope", JitFlag::FreezingScope, doc_JitFlag_FreezingScope)
         .value("EnableObjectTraversal", JitFlag::EnableObjectTraversal, doc_JitFlag_EnableObjectTraversal)
+        .value("SpillToSharedMemory", JitFlag::SpillToSharedMemory, doc_JitFlag_SpillToSharedMemory)
         .value("Default", JitFlag::Default, doc_JitFlag_Default)
 
         // Deprecated aliases


### PR DESCRIPTION
This PR adds support for spilling excess registers to shared memory in the CUDA backend.
For more details, see [#160](https://github.com/mitsuba-renderer/drjit-core/pull/160).