### PR TITLE
Feature completion for C++ drjit::Local

### DIFF
--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -494,11 +494,11 @@ trees:
 
     template <typename T> void visit_jit_pairs(T &v0, T &v1) {
         if constexpr (dr::is_jit_v<T> && dr::depth_v<T> == 1) {
-            /// Do something with 'v0' and 'v1'
+            // Do something with 'v0' and 'v1'
         } else if constexpr (dr::is_traversable_v<T>) {
-            /// Recurse and try again if the object is traversable
+            // Recurse and try again if the object is traversable
             dr::traverse_2(
-                /// Extract the fields of 'v0' and 'v1'
+                // Extract the fields of 'v0' and 'v1'
                 dr::fields(v0), dr::fields(v1),
                 // .. and call the following lambda function on them
                 [&](auto &x, auto &y) { visit_jit_pairs(x, y); }

--- a/include/drjit/local.h
+++ b/include/drjit/local.h
@@ -39,15 +39,9 @@ struct Local {
 
     ~Local() = default;
     Local(const Local &) = delete;
-    Local(Local &&l) {
-        for (size_t i = 0; i < Size; ++i)
-            m_data[i] = l.m_data[i];
-    }
+    Local(Local &&l) = default;
     Local &operator=(const Local &) = delete;
-    Local &operator=(Local &&l) {
-        for (size_t i = 0; i < Size; ++i)
-            m_data[i] = l.m_data[i];
-    }
+    Local &operator=(Local &&l) = default;
 
     Value read(const Index &offset, const Mask &active = true) const {
         if (active)
@@ -176,16 +170,16 @@ struct Local<Value_, Size_, Index_,
             jit_var_dec_ref(index);
     }
     Local(const Local &) = delete;
-    Local(Local &&l) {
-        m_arrays.swap(l.m_arrays);
-        l.m_arrays.clear();
-    }
+    Local(Local &&l) = default;
+
     Local &operator=(const Local &) = delete;
     Local &operator=(Local &&l) {
         for (uint32_t index : m_arrays)
             jit_var_dec_ref(index);
-        m_arrays.swap(l.m_arrays);
-        l.m_arrays.clear();
+        m_size = std::move(l.m_size);
+        m_value = std::move(l.m_value);
+        m_arrays = std::move(l.m_arrays);
+        return *this;
     }
 
     Value read(const Index &offset, const Mask &active = true) const {

--- a/include/drjit/local.h
+++ b/include/drjit/local.h
@@ -89,7 +89,7 @@ void init_impl(const T &value, const size_t size, vector<uint32_t>& arrays) {
         }
         arrays.push_back(result);
     } else if constexpr (is_traversable_v<T>) {
-        /// Recurse and try again if the object is traversable
+        // Recurse and try again if the object is traversable
         traverse_1(fields(value),
                     [&](auto &v) { init_impl(v, size, arrays); });
     }
@@ -107,7 +107,7 @@ void read_impl(T &result,
                         "variable arrays!");
         result = T::steal(jit_array_read(arrays[counter++], offset, active));
     } else if constexpr (is_traversable_v<T>) {
-        /// Recurse and try again if the object is traversable
+        // Recurse and try again if the object is traversable
         traverse_1(fields(result), [&](auto &r) {
             read_impl(r, offset, active, arrays, counter);
         });
@@ -136,7 +136,7 @@ void write_impl(const uint32_t &offset,
         arrays[counter++] = result;
 
     } else if constexpr (is_traversable_v<T>) {
-        /// Recurse and try again if the object is traversable
+        // Recurse and try again if the object is traversable
         traverse_1(fields(value),
                         [&](auto &v) { write_impl(offset, v, active, arrays, counter); });
     }

--- a/include/drjit/local.h
+++ b/include/drjit/local.h
@@ -38,9 +38,9 @@ struct Local {
     }
 
     ~Local() = default;
-    Local(const Local &) = delete;
+    Local(const Local &) = default;
     Local(Local &&l) = default;
-    Local &operator=(const Local &) = delete;
+    Local &operator=(const Local &) = default;
     Local &operator=(Local &&l) = default;
 
     Value read(const Index &offset, const Mask &active = true) const {
@@ -169,10 +169,21 @@ struct Local<Value_, Size_, Index_,
         for (uint32_t index : m_arrays)
             jit_var_dec_ref(index);
     }
-    Local(const Local &) = delete;
+    Local(const Local &l) {
+        *this = l;
+    }
     Local(Local &&l) = default;
 
-    Local &operator=(const Local &) = delete;
+    Local &operator=(const Local &l) {
+        for (uint32_t index : m_arrays)
+            jit_var_dec_ref(index);
+        m_size = l.m_size;
+        m_value = l.m_value;
+        m_arrays = l.m_arrays;
+        for (uint32_t index : m_arrays)
+            jit_var_inc_ref(index);
+        return *this;
+    }
     Local &operator=(Local &&l) {
         for (uint32_t index : m_arrays)
             jit_var_dec_ref(index);

--- a/include/drjit/local.h
+++ b/include/drjit/local.h
@@ -16,8 +16,18 @@
 
 NAMESPACE_BEGIN(drjit)
 
-template <typename Value, size_t Size, typename SFINAE = int> struct Local {
-    using Index = uint32_t;
+template <typename Value_,
+          size_t Size_,
+          typename Index_ = uint32_array_t<Value_>,
+          typename SFINAE = int>
+struct Local {
+    static constexpr size_t Size = Size_;
+    static_assert(Size != Dynamic, "Scalar local arrays are only fixed size. "
+                                   "If you meant to instantiate a JIT variant "
+                                   "or a DRJIT_STRUCT you may have forgotten to "
+                                   "add the Index template parameter.");
+    using Value = Value_;
+    using Index = Index_;
     using Mask = bool;
 
     Local() = default;
@@ -57,50 +67,156 @@ private:
     Value m_data[Size];
 };
 
-template <typename Value, size_t Size> struct Local<Value, Size, enable_if_array_t<Value>> {
-    static constexpr JitBackend Backend = backend_v<Value>;
-    using Index = uint32_array_t<Value>;
-    using Mask = mask_t<Value>;
+/**
+ * \brief Local memory implemented on top of drjit-core jit_array_*
+ * \details The array `value` of static or dynamic width will be used
+ * to initialize the entries of local memory with length `Size`.
+ * `Size` can be drjit::Dynamic, in which case a call to resize will
+ * be required before usage.
+ */
+template <typename Value_, size_t Size_, typename Index_>
+struct Local<Value_, Size_, Index_,
+             enable_if_t<is_array_v<Value_> || (is_array_v<Index_> && is_drjit_struct_v<Value_>)>>
+{
+    static constexpr JitBackend Backend = backend_v<Value_>;
+    static constexpr size_t Size = Size_;
+    using Value = Value_;
+    using Index = Index_;
+    using Mask = mask_t<Index>;
 
-    Local() {
-        m_index = jit_array_create(Backend, Value::Type, 1, Size);
+    /**
+     * \brief Allocate local memory
+     * \param value optional inital value (also used when resizing dynamic memory)
+     */
+    Local(Value value = empty<Value>())
+        : m_size(Size == Dynamic ? 1 : Size), m_value(value) {
+        initialize();
     }
 
-    Local(const Value &value) {
-        uint32_t tmp = jit_array_create(Backend, Value::Type, 1, Size);
-        m_index = jit_array_init(tmp, value.index());
-        jit_var_dec_ref(tmp);
+    ~Local() {
+        for (uint32_t index : m_arrays)
+            jit_var_dec_ref(index);
     }
-
-    ~Local() { jit_var_dec_ref(m_index); }
     Local(const Local &) = delete;
     Local(Local &&l) {
-        m_index = l.m_index;
-        l.m_index = 0;
+        m_arrays.swap(l.m_arrays);
+        l.m_arrays.clear();
     }
     Local &operator=(const Local &) = delete;
     Local &operator=(Local &&l) {
-        jit_var_dec_ref(m_index);
-        m_index = l.m_index;
-        l.m_index = 0;
+        for (uint32_t index : m_arrays)
+            jit_var_dec_ref(index);
+        m_arrays.swap(l.m_arrays);
+        l.m_arrays.clear();
     }
 
     Value read(const Index &offset, const Mask &active = true) const {
-        return Value::steal(jit_array_read(m_index, offset.index(), active.index()));
+        Value result;
+        size_t counter = 0;
+        auto callback  = [&](auto &result, auto &&callback) -> void {
+            using T = std::decay_t<decltype(result)>;
+            if constexpr (is_jit_v<T> && depth_v<T> == 1) {
+                if (counter >= m_arrays.size())
+                    jit_raise("Local::read(): internal error, ran out of "
+                              "variable arrays!");
+                result = T::steal(jit_array_read(m_arrays[counter++],
+                                                  offset.index(), active.index()));
+            } else if constexpr (is_traversable_v<T>) {
+                /// Recurse and try again if the object is traversable
+                traverse_1(fields(result), [&](auto &result) {
+                    callback(result, callback);
+                });
+            }
+        };
+        callback(result, callback);
+
+        if (counter != m_arrays.size())
+            jit_raise(
+                "Local::read(): internal error, did not access all variable "
+                "arrays!");
+
+        return result;
     }
 
     void write(const Index &offset, const Value &value, const Mask &active = true) {
-        uint32_t new_index = jit_array_write(m_index, offset.index(),
-                                             value.index(), active.index());
-        jit_var_dec_ref(m_index);
-        m_index = new_index;
+        size_t counter = 0;
+        auto callback  = [&](auto &value, auto &&callback) -> void {
+            using T = std::decay_t<decltype(value)>;
+            if constexpr (is_jit_v<T> && depth_v<T> == 1) {
+                if (counter >= m_arrays.size())
+                    jit_raise("Local::write(): internal error, ran out of "
+                                "variable arrays!");
+
+                if (value.index_ad())
+                    jit_raise("Local memory writes are not differentiable. You "
+                                "must use 'drjit.detach()' to disable gradient "
+                                "tracking of the written value.");
+
+                uint32_t result =
+                    jit_array_write(m_arrays[counter], offset.index(),
+                                     value.index(), active.index());
+                jit_var_dec_ref(m_arrays[counter]);
+                m_arrays[counter++] = result;
+
+            } else if constexpr (is_traversable_v<T>) {
+                /// Recurse and try again if the object is traversable
+                traverse_1(fields(value),
+                                [&](auto &value) { callback(value, callback); });
+            }
+        };
+        callback(value, callback);
+
+        if (counter != m_arrays.size())
+            jit_raise(
+                "Local.write(): internal error, did not access all variable "
+                "arrays!");
     }
 
-    size_t size() const { return Size; }
+    size_t size() { return m_size; }
+
+    /**
+     * Reserve a new array of `length` and discard any current contents
+     */
+    void resize(size_t size) {
+        for (uint32_t index : m_arrays)
+            jit_var_dec_ref(index);
+        m_arrays.clear();
+        m_size = size;
+        initialize();
+    }
 
 private:
-    uint32_t m_index;
-};
+    void initialize() {
+        auto callback = [&](auto &value, auto &&callback) -> void {
+            using T = std::decay_t<decltype(value)>;
+            if constexpr (is_jit_v<T> && depth_v<T> == 1) {
+                uint32_t result;
+                if (!value.empty()) {
+                    uint32_t i1  = value.index();
+                    size_t width = jit_var_size(i1);
+                    uint32_t i2  = jit_array_create(
+                        backend_v<T>, var_type<value_t<T>>::value,
+                        width, m_size);
+                    result = jit_array_init(i2, i1);
+                    jit_var_dec_ref(i2);
+                } else {
+                    result = jit_array_create(
+                        backend_v<T>, var_type<value_t<T>>::value,
+                        1, m_size);
+                }
+                m_arrays.push_back(result);
+            } else if constexpr (is_traversable_v<T>) {
+                /// Recurse and try again if the object is traversable
+                traverse_1(fields(value),
+                               [&](auto &value) { callback(value, callback); });
+            }
+        };
+        callback(m_value, callback);
+    }
 
+    size_t m_size;
+    Value m_value;
+    vector<uint32_t> m_arrays;
+};
 
 NAMESPACE_END(drjit)

--- a/tests/local_ext.cpp
+++ b/tests/local_ext.cpp
@@ -6,15 +6,68 @@
 namespace nb = nanobind;
 namespace dr = drjit;
 
+using nb::literals::operator""_a;
+
+template <typename Float, typename Local>
+auto bind_local(nb::module_ &m, const dr::string& name) {
+    auto c =  nb::class_<Local>(m, name.c_str())
+        .def(nb::init<>())
+        .def(nb::init<typename Local::Value>())
+        .def("__len__", &Local::size)
+        .def("read", &Local::read, "index"_a, "active"_a = true)
+        .def("write", &Local::write, "offset"_a, "value"_a, "active"_a = true);
+
+    if constexpr (dr::is_jit_v<Float>)
+        c = c.def("resize", &Local::resize);
+
+    return c;
+}
+
 template <typename Float>
 void bind(nb::module_ &m) {
     using UInt32 = dr::uint32_array_t<Float>;
+    using Local10 = dr::Local<Float, 10>;
+    using LocalDyn = dr::Local<Float, dr::Dynamic>;
 
-    m.def("lookup", [](UInt32 offset, Float value, UInt32 offset2) {
-        dr::Local<Float, 10> local(3.f);
-        local.write(offset, value);
-        return local.read(offset2);
-    });
+    bind_local<Float, Local10>(m, "Local10");
+
+    if constexpr (dr::is_jit_v<Float>)
+        bind_local<Float, LocalDyn>(m, "LocalDyn");
+
+    struct MyStruct
+    {
+        Float value;
+        UInt32 priority;
+        DRJIT_STRUCT(MyStruct, value, priority)
+
+        MyStruct(int i) : value(i), priority(i) {}
+    };
+
+    auto mystruct = nb::class_<MyStruct>(m, "MyStruct")
+        .def(nb::init<>())
+        .def(nb::init<int>())
+        .def_rw("value", &MyStruct::value)
+        .def_rw("priority", &MyStruct::priority);
+
+    nb::handle u32;
+    if constexpr (dr::is_array_v<UInt32>)
+        u32 = nb::type<UInt32>();
+    else
+        u32 = nb::handle((PyObject *) &PyLong_Type);
+
+    nb::handle f32;
+    if constexpr (dr::is_array_v<UInt32>)
+        f32 = nb::type<Float>();
+    else
+        f32 = nb::handle((PyObject *) &PyFloat_Type);
+
+    nb::dict fields;
+    fields["value"] = f32;
+    fields["priority"] = u32;
+    mystruct.attr("DRJIT_STRUCT") = fields;
+
+    using LocalStruct10 = dr::Local<MyStruct, 10, UInt32>;
+    bind_local<Float, LocalStruct10>(m, "LocalStruct10");
 }
 
 NB_MODULE(local_ext, m) {

--- a/tests/test_local_ext.py
+++ b/tests/test_local_ext.py
@@ -11,7 +11,7 @@ def get_pkg(t):
         return m.cuda
     elif backend == dr.JitBackend.Invalid:
         return m.scalar
-    
+
 def is_constant_valued(local, value):
     for i in range(len(local)):
         assert dr.allclose(local.read(i), value)
@@ -66,11 +66,11 @@ def test03_write_read(t):
         sum += local.read(i)
 
     expected = dr.sum(dr.arange(t, len(local))) + (dr.arange(t, width) * len(local))
-    
+
     if dr.backend_v(t) == dr.JitBackend.Invalid:
         sum = sum[0]
         expected = expected[0]
-    
+
     assert dr.allclose(sum, expected)
 
 
@@ -101,3 +101,16 @@ def test04_struct(t):
     if dr.backend_v(t) == dr.JitBackend:
         with pytest.raises(RuntimeError, match="out of bounds"):
             validate_index(10, 1)
+
+@pytest.test_arrays('float32,shape=(*)')
+def test05_loop(t):
+    pkg = get_pkg(t)
+    pkg.test_Local10_loop()
+    pkg.test_Local10_loop_struct()
+
+    if dr.backend_v(t) == dr.JitBackend:
+        pkg.test_LocalDyn_loop()
+        pkg.test_LocalDyn_loop_struct()
+
+    pkg.test_LocalStruct10_loop()
+    pkg.test_LocalStruct10_loop_struct()

--- a/tests/test_local_ext.py
+++ b/tests/test_local_ext.py
@@ -11,11 +11,93 @@ def get_pkg(t):
         return m.cuda
     elif backend == dr.JitBackend.Invalid:
         return m.scalar
+    
+def is_constant_valued(local, value):
+    for i in range(len(local)):
+        assert dr.allclose(local.read(i), value)
 
 
 @pytest.test_arrays('float32,shape=(*)')
-def test01_lookup(t):
+def test01_initialization(t):
     pkg = get_pkg(t)
+    initial = 25.4
 
-    assert dr.all(pkg.lookup(4, 5.0, 2) == 3.0)
-    assert dr.all(pkg.lookup(4, 5.0, 4) == 5.0)
+    l10 = pkg.Local10()
+    assert len(l10) == 10
+
+    with pytest.raises(AssertionError):
+        is_constant_valued(l10, initial)
+
+    l10 = pkg.Local10(initial)
+    assert len(l10) == 10
+
+    is_constant_valued(l10, initial)
+
+
+@pytest.test_arrays('float32,is_jit,shape=(*)')
+def test02_dynamic_initialization(t):
+    pkg = get_pkg(t)
+    initial = dr.full(t, 25.4, 15)
+
+    ldyn = pkg.LocalDyn(initial)
+    assert len(ldyn) == 1
+    is_constant_valued(ldyn, initial)
+
+    ldyn.resize(20)
+    assert len(ldyn) == 20
+    is_constant_valued(ldyn, initial)
+
+
+@pytest.test_arrays('float32,shape=(*)')
+def test03_write_read(t):
+    pkg = get_pkg(t)
+    width = 20
+
+    local = pkg.Local10()
+
+    for i in range(len(local)):
+        value = dr.arange(t, i, i+width)
+        if dr.backend_v(t) == dr.JitBackend.Invalid:
+            value = value[0]
+        local.write(i, value)
+
+    sum = dr.zeros(t, width)
+    for i in range(len(local)):
+        sum += local.read(i)
+
+    expected = dr.sum(dr.arange(t, len(local))) + (dr.arange(t, width) * len(local))
+    
+    if dr.backend_v(t) == dr.JitBackend.Invalid:
+        sum = sum[0]
+        expected = expected[0]
+    
+    assert dr.allclose(sum, expected)
+
+
+@pytest.test_arrays('float32,shape=(*)')
+def test04_struct(t):
+    pkg = get_pkg(t)
+    width = 20 if dr.backend_v(t) == dr.JitBackend else 1
+
+    values = dr.ones(pkg.MyStruct, width)
+    local = pkg.LocalStruct10(values)
+
+    def validate_index(idx, value):
+        struct = local.read(idx)
+        assert dr.width(struct) == width
+        assert dr.allclose(struct.value, value)
+        assert dr.allclose(struct.priority, value)
+
+    for i in range(10):
+        validate_index(i, 1)
+
+    values = dr.zeros(pkg.MyStruct, width)
+    local.write(0, values)
+
+    validate_index(0, 0)
+    for i in range(1,10):
+        validate_index(i, 1)
+
+    if dr.backend_v(t) == dr.JitBackend:
+        with pytest.raises(RuntimeError, match="out of bounds"):
+            validate_index(10, 1)


### PR DESCRIPTION
Closes #426 

Adding multiple features to the C++ version of drjit::Local:

- [x] Dynamic width of arrays
- [x] Dynamic size of local memory (for JIT variants)
- [x] Support for arbitrarily nested `DRJIT_STRUCT` data structures

All while retaining the stack-allocated scalar variant.

TODO before merging:
- [x] Tests for `DRJIT_STRUCT` support