### PR TITLE
When traversing Python objects, check that `__dict__` exists

### DIFF
--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -349,9 +349,11 @@ void traverse_py_cb_ro_impl(nb::handle self, nb::callable c) {
 
     PyTraverseCallback traverse_cb(std::move(c));
 
-    auto dict    = nb::borrow<nb::dict>(nb::getattr(self, "__dict__"));
-    for (auto value : dict.values())
-        traverse("traverse_py_cb_ro", traverse_cb, value);
+    if (nb::hasattr(self, "__dict__")) {
+        auto dict = nb::borrow<nb::dict>(nb::getattr(self, "__dict__"));
+        for (auto value : dict.values())
+            traverse("traverse_py_cb_ro", traverse_cb, value);
+    }
 }
 
 /**
@@ -391,9 +393,11 @@ void traverse_py_cb_rw_impl(nb::handle self, nb::callable c) {
 
     PyTraverseCallback traverse_cb(std::move(c));
 
-    auto dict = nb::borrow<nb::dict>(nb::getattr(self, "__dict__"));
-    for (auto value : dict.values())
-        traverse("traverse_py_cb_rw", traverse_cb, value, true);
+    if (nb::hasattr(self, "__dict__")) {
+        auto dict = nb::borrow<nb::dict>(nb::getattr(self, "__dict__"));
+        for (auto value : dict.values())
+            traverse("traverse_py_cb_rw", traverse_cb, value, true);
+    }
 }
 
 void export_detail(nb::module_ &) {


### PR DESCRIPTION
Python objects bound to C++ classes do not necessarily all have a `__dict__` member. For example, _trampolined_ classes can still be instantiated without them necessarily being a custom Python implementation.

Fixes https://github.com/mitsuba-renderer/mitsuba3/issues/1741