### PR TITLE
Add `dr.scatter_cas()` and `dr.scatter_exch()`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -63,6 +63,8 @@ Scatter/gather operations
 .. autofunction:: scatter_add
 .. autofunction:: scatter_add_kahan
 .. autofunction:: scatter_inc
+.. autofunction:: scatter_exch
+.. autofunction:: scatter_cas
 .. autofunction:: slice
 
 Reductions

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1553,6 +1553,7 @@ void set_label(T &value, Labels... prefix) {
  */
 template <typename T>
 struct scoped_disable_symbolic {
+
     scoped_disable_symbolic() {
         if constexpr(drjit::is_jit_v<T>) {
             uint32_t index = jit_var_mask_default(T::Backend, 1);
@@ -1565,6 +1566,9 @@ struct scoped_disable_symbolic {
         if constexpr (drjit::is_jit_v<T>)
             jit_var_mask_pop(T::Backend);
     }
+
+    scoped_disable_symbolic(const scoped_disable_symbolic &) = delete;
+    scoped_disable_symbolic &operator=(const scoped_disable_symbolic &) = delete;
 };
 
 template <typename T> bool grad_enabled(const T &value) {

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1219,6 +1219,14 @@ void scatter_add_kahan(Target &&target_1, Target &&target_2,
 }
 
 template <typename Target>
+Target scatter_exch(Target &target, const Target &value,
+                    const uint32_array_t<Target> &index,
+                    const mask_t<Target> &mask = true) {
+    static_assert(is_jit_v<Target> && depth_v<Target> == 1, "Only 1D arrays are supported!");
+    return target.scatter_exch_(value, index, mask);
+}
+
+template <typename Target>
 std::pair<Target, bool_array_t<Target>>
 scatter_cas(Target &target, const Target &compare, const Target &value,
             const uint32_array_t<Target> &index,

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1128,9 +1128,9 @@ void scatter(Target &target, const Value &value, const Index &index,
 }
 
 template <typename Index>
-Index scatter_inc(Index &target, const Index &index, const mask_t<Index> &value = true) {
+Index scatter_inc(Index &target, const Index &index, const mask_t<Index> &mask = true) {
     static_assert(is_jit_v<Index> && std::is_same_v<scalar_t<Index>, uint32_t> && depth_v<Index> == 1);
-    return target.scatter_inc_(index, value);
+    return target.scatter_inc_(index, mask);
 }
 
 template <typename Target, typename Value, typename Index, typename Mask = mask_t<Index>>

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1218,6 +1218,15 @@ void scatter_add_kahan(Target &&target_1, Target &&target_2,
     value.scatter_add_kahan_(target_1, target_2, index, mask);
 }
 
+template <typename Target>
+std::pair<Target, bool_array_t<Target>>
+scatter_cas(Target &target, const Target &compare, const Target &value,
+            const uint32_array_t<Target> &index,
+            const mask_t<Target> &mask = true) {
+    static_assert(is_jit_v<Target> && depth_v<Target> == 1, "Only 1D arrays are supported!");
+    return value.scatter_cas_(target, compare, index, mask);
+}
+
 template <typename T, typename TargetType>
 decltype(auto) migrate(const T &value, TargetType target) {
     static_assert(std::is_enum_v<TargetType>);

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -636,6 +636,20 @@ struct DRJIT_TRIVIAL_ABI DiffArray
                                  offset.index(), mask.index());
     }
 
+    template <typename Index, typename Mask>
+    std::pair<DiffArray, DiffArray>
+    scatter_cas_(DiffArray &target, const DiffArray &compare,
+                 const Index &index, const Mask &mask) const {
+        uint32_t target_index = target.index();
+        uint32_t old, success;
+        jit_var_scatter_cas(&target_index, compare.index(), (uint32_t) m_index,
+                            index.index(), mask.index(), &old, &success);
+        target.release();
+        target = steal(target_index);
+
+        return { steal(old), steal(success) };
+    }
+
     //! @}
     // -----------------------------------------------------------------------
 

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -637,11 +637,23 @@ struct DRJIT_TRIVIAL_ABI DiffArray
     }
 
     template <typename Index, typename Mask>
+    DiffArray scatter_exch_(const DiffArray &value, const Index &index,
+                            const Mask &mask) {
+        uint32_t target_index = (uint32_t) m_index;
+        DiffArray result = steal(
+            jit_var_scatter_exch(&target_index, value.index(), index.index(), mask.index()));
+        m_index = target_index;
+
+        return result;
+    }
+
+    template <typename Index, typename Mask>
     std::pair<DiffArray, DiffArray>
     scatter_cas_(DiffArray &target, const DiffArray &compare,
                  const Index &index, const Mask &mask) const {
         uint32_t target_index = target.index();
         uint32_t old, success;
+
         jit_var_scatter_cas(&target_index, compare.index(), (uint32_t) m_index,
                             index.index(), mask.index(), &old, &success);
         target.release();

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -553,6 +553,20 @@ struct DRJIT_TRIVIAL_ABI JitArray
         return steal(jit_var_scatter_inc(&m_index, index.index(), mask.index()));
     }
 
+    template <typename Index, typename Mask>
+    std::pair<JitArray, JitArray>
+    scatter_cas_(JitArray &target, const JitArray &compare,
+                 const Index &index, const Mask &mask) const {
+        uint32_t target_index = target.index();
+        uint32_t old, success;
+        jit_var_scatter_cas(&target_index, compare.index(), m_index,
+                            index.index(), mask.index(), &old, &success);
+        target.release();
+        target = steal(target_index);
+
+        return { steal(old), steal(success) };
+    }
+
     //! @}
     // -----------------------------------------------------------------------
 

--- a/include/drjit/jit.h
+++ b/include/drjit/jit.h
@@ -554,6 +554,13 @@ struct DRJIT_TRIVIAL_ABI JitArray
     }
 
     template <typename Index, typename Mask>
+    JitArray scatter_exch_(const JitArray&value, const Index &index,
+                           const Mask &mask) {
+        return steal(jit_var_scatter_exch(&m_index, value.index(),
+                                          index.index(), mask.index()));
+    }
+
+    template <typename Index, typename Mask>
     std::pair<JitArray, JitArray>
     scatter_cas_(JitArray &target, const JitArray &compare,
                  const Index &index, const Mask &mask) const {

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -237,6 +237,9 @@ struct ArraySupplement : ArrayMeta {
     using ScatterAddKahan = void (*)(const ArrayBase *, const ArrayBase *,
                                      const ArrayBase *, ArrayBase *,
                                      ArrayBase *);
+    using ScatterCAS = void (*)(const ArrayBase *, const ArrayBase *,
+                                const ArrayBase *, const ArrayBase *,
+                                ArrayBase *, ArrayBase *, ArrayBase *);
     using UnaryOp  = void (*)(const ArrayBase *, ArrayBase *);
     using BinaryOp = void (*)(const ArrayBase *, const ArrayBase *, ArrayBase *);
 
@@ -288,6 +291,9 @@ struct ArraySupplement : ArrayMeta {
 
             /// Kahan-compensated scatter-addition
             ScatterAddKahan scatter_add_kahan;
+
+            /// Scatter-CAS operation
+            ScatterCAS scatter_cas;
 
             /// Return a pointer to the underlying storage
             Data data;
@@ -837,6 +843,16 @@ template <typename T> void bind_memop(ArrayBinding &b) {
             (ArraySupplement::ScatterAddKahan) +
             [](const T *a, const UInt32 *b, const Mask *c, T *d, T *e) {
                 scatter_add_kahan(*d, *e, *a, *b, *c);
+            };
+    }
+
+    if constexpr (depth_v<T> == 1 && is_jit_v<T>) {
+        b.scatter_cas = (ArraySupplement::ScatterCAS)
+            +[](const T *a, const T *b, const UInt32 *c, const Mask *d,
+                T *e, T *f, Mask *g) {
+                auto [h, i] = scatter_cas(*e, *a, *b, *c, *d);
+                new (f) T(h);
+                new (g) Mask(i);
             };
     }
 

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -7036,12 +7036,12 @@
 
     .. code-block:: python
 
-       my_index = dr.scatter_inc(target=ctr, index=UInt32(0), mask=active)
+       my_index = dr.scatter_inc(target=ctr, index=UInt32(0), active=active)
        dr.scatter(
            target=data_compact_1,
            value=data_1,
            index=my_index,
-           mask=active
+           active=active
        )
 
        dr.eval(data_compact_1) # Run Kernel #1
@@ -7050,7 +7050,7 @@
            target=data_compact_2,
            value=data_2,
            index=my_index, # <-- oops, reusing my_index in another kernel.
-           mask=active     #     This raises an exception.
+           active=active   #     This raises an exception.
        )
 
     To get the above code to work, you will need to evaluate ``my_index`` at the

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -1234,10 +1234,10 @@ void export_memop(nb::module_ &m) {
           "active"_a = true, doc_scatter_add_kahan)
      .def("scatter_exch", &scatter_exch,
           "target"_a, "value"_a, "index"_a, "active"_a = true,
-          "") // FIXME add doc
+          doc_scatter_exch)
      .def("scatter_cas", &scatter_cas,
           "target"_a, "compare"_a, "value"_a, "index"_a, "active"_a = true,
-          "") // FIXME add doc
+          doc_scatter_cas)
      .def("ravel",
           [](nb::handle array, char order) {
               return ravel(array, order);

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -548,6 +548,93 @@ void scatter_add_kahan(nb::handle_t<dr::ArrayBase> target_1,
     }
 }
 
+nb::object scatter_cas(nb::handle_t<dr::ArrayBase> target, nb::object compare,
+                       nb::object value, nb::object index, nb::object active) {
+    nb::handle tp = target.type();
+    const ArraySupplement &s = supp(tp);
+
+    if (s.ndim != 1 || s.backend == (uint8_t) JitBackend::None)
+        nb::raise("drjit.scatter_cas(): 'target' must be a JIT-compiled 1D array");
+
+    ArrayMeta target_meta = s,
+              active_meta = target_meta,
+              index_meta  = target_meta;
+
+    active_meta.type = (uint16_t) VarType::Bool;
+    index_meta.type = (uint16_t) VarType::UInt32;
+
+    nb::handle active_tp = meta_get_type(active_meta),
+               index_tp = meta_get_type(index_meta);
+
+    // FIXME: create helper
+    if (!index.type().is(index_tp)) {
+        try {
+            index = index_tp(index);
+        } catch (nb::python_error &e) {
+            nb::raise_from(e, PyExc_TypeError,
+                           "drjit.scatter_cas(): 'index' argument has an "
+                           "unsupported type, please provide an instance that "
+                           "is convertible to drjit.uint32_array_t(target).");
+        }
+    }
+
+    if (!active.type().is(active_tp)) {
+        try {
+            active = active_tp(active);
+        } catch (nb::python_error &e) {
+            nb::raise_from(e, PyExc_TypeError,
+                           "drjit.scatter_cas(): 'active' argument has an "
+                           "unsupported type, please provide an instance that "
+                           "is convertible to drjit.mask_t(target).");
+        }
+    }
+
+    if (!compare.type().is(tp)) {
+        try {
+            compare = tp(compare);
+        } catch (nb::python_error &e) {
+            nb::raise_from(e, PyExc_TypeError,
+                           "drjit.scatter_cas(): 'compare' argument has an "
+                           "unsupported type, please provide an instance that "
+                           "is convertible to the type of 'target'.");
+        }
+    }
+
+    if (!value.type().is(tp)) {
+        try {
+            value = tp(value);
+        } catch (nb::python_error &e) {
+            nb::raise_from(e, PyExc_TypeError,
+                           "drjit.scatter_cas(): 'value' argument has an "
+                           "unsupported type, please provide an instance that "
+                           "is convertible to the type of 'target'.");
+        }
+    }
+
+    if (s.scatter_cas) {
+        nb::object old = nb::inst_alloc(tp);
+        nb::object success = nb::inst_alloc(active_tp);
+
+        s.scatter_cas(
+            inst_ptr(compare),
+            inst_ptr(value),
+            inst_ptr(index),
+            inst_ptr(active),
+            inst_ptr(target),
+            inst_ptr(old),
+            inst_ptr(success)
+        );
+
+        nb::inst_mark_ready(old);
+        nb::inst_mark_ready(success);
+
+        return nb::make_tuple(old, success);
+    } else {
+        nb::raise("drjit.scatter_cas(): not unsupported for type '%s'.",
+                  nb::type_name(tp).c_str());
+    }
+}
+
 static void ravel_recursive(nb::handle result, nb::handle value,
                             nb::handle index_dtype, const size_t *shape,
                             const int64_t *strides, Py_ssize_t offset,
@@ -1165,6 +1252,9 @@ void export_memop(nb::module_ &m) {
      .def("scatter_add_kahan", &scatter_add_kahan,
           "target_1"_a, "target_2"_a, "value"_a, "index"_a,
           "active"_a = true, doc_scatter_add_kahan)
+     .def("scatter_cas", &scatter_cas,
+          "target"_a, "compare"_a, "value"_a, "index"_a, "active"_a = true,
+          "") // FIXME add doc
      .def("ravel",
           [](nb::handle array, char order) {
               return ravel(array, order);


### PR DESCRIPTION
This PR adds:
* `dr.scatter_exch(target, value, index, active)`: atomically exchange values in an array and return the previous values.
* `dr.scatter_cas(target, compare, value, index, active)`: performs an atomic compare-and-swap operation on array elements.

All of the logic required to implement these operations, are in `drjit-core`: https://github.com/mitsuba-renderer/drjit-core/pull/177
This PR just adds Python bindings, a C++ interface, tests and documentation.