### PR TITLE
Oklab color space conversion

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -161,6 +161,8 @@ Miscellaneous operations
 .. autofunction:: copy
 .. autofunction:: linear_to_srgb
 .. autofunction:: srgb_to_linear
+.. autofunction:: linear_srgb_to_oklab
+.. autofunction:: oklab_to_linear_srgb
 .. autofunction:: reorder_threads
 
 Just-in-time compilation

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -261,6 +261,7 @@ _______________________
 .. autofunction:: float32_array_t
 .. autofunction:: float64_array_t
 .. autofunction:: replace_type_t
+.. autofunction:: replace_shape_t
 .. autofunction:: detached_t
 .. autofunction:: expr_t
 .. autofunction:: array_t

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -438,6 +438,46 @@
     Returns:
         type: Result of the conversion as described above.
 
+.. topic:: replace_shape_t
+
+    Converts the provided Dr.Jit type into an analogous version with the
+    specified shape.
+
+    The optional third argument can be used to override the desired kind of
+    Dr.Jit array and can be set to one of ``"array"``, ``"matrix"``,
+    ``"quaternion"``, or ``"complex"``.
+
+    This function implements the following set of behaviors:
+
+    1. When invoked with a Dr.Jit array *type* ``arg0``, it returns an analogous
+       version with a different shape, as specified via ``arg1``.
+
+       For example, when called with :py:class:`drjit.cuda.Array1f` and ``(3,
+       -1)``, it will return :py:class:`drjit.cuda.Array3f`.
+
+       When called with :py:class:`drjit.cuda.Array3f` and ``(2, 2,
+       -1)``, it will return :py:class:`drjit.cuda.Array22f`.
+
+       When called with :py:class:`drjit.cuda.Array3f`, ``(2, 2, -1)`` and
+       ``"matrix"``, the function instead returns
+       :py:class:`drjit.cuda.Matrix2f`.
+
+    2. When the input is not a type, it returns ``replace_type_t(type(arg0), arg1)``.
+
+    3. When the input is not a Dr.Jit type, the function returns ``arg0``.
+
+    Args:
+        arg0 (object): An arbitrary Python object
+
+        arg1 (tuple[int]): The desired shape
+
+        arg2 (str | None): Optional: use this to override the desired array
+          kind. The following values are legal: ``"array"``, ``"matrix"``,
+          ``"quaternion"``, or ``"complex"``.
+
+    Returns:
+        type: Result of the conversion as described above.
+
 .. topic:: is_complex_v
 
     Check whether the input is a Dr.Jit array instance or type representing a complex number.

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -23,3 +23,36 @@ def test01_srgb_conversion(t):
     assert dr.allclose(dr.srgb_to_linear(-1, clip=False), -1)
     assert dr.allclose(dr.linear_to_srgb(2, clip=False), 1.353256046149386)
     assert dr.allclose(dr.srgb_to_linear(2, clip=False), 4.95384575159204)
+
+@pytest.test_arrays('float32, shape=(3, *)')
+def test01_oklab_conversion(t):
+    """Spot-check the Oklab/sRGB conversion routines"""
+
+    EXAMPLES = [
+        # (linear_srgb, oklab)
+        # Primary colors
+        ([1.0, 0.0, 0.0], [0.62795536, 0.22486305, 0.12584630]),  # Red
+        ([0.0, 1.0, 0.0], [0.86643961, -0.23388754, 0.17949847]),  # Green
+        ([0.0, 0.0, 1.0], [0.45201372, -0.03245699, -0.31152815]),  # Blue
+
+        # Secondary colors
+        ([1.0, 1.0, 0.0], [0.96798272, -0.07136906, 0.19856974]),  # Yellow
+        ([0.0, 1.0, 1.0], [0.90539923, -0.14944391, -0.03939817]),  # Cyan
+        ([1.0, 0.0, 1.0], [0.70167386, 0.27456628, -0.16915606]),  # Magenta
+
+        # Grayscale (should have a=b≈0)
+        ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0]),  # Black
+        ([1.0, 1.0, 1.0], [0.99999999, 0.0, 0.0]),  # White (using 0 for near-zero)
+        ([0.5, 0.5, 0.5], [0.79370052, 0.0, 0.0]),  # 50% Gray (linear)
+        ([0.25, 0.25, 0.25], [0.62996052, 0.0, 0.0]),  # 25% Gray (linear)
+
+        # Mixed colors
+        ([0.5, 0.25, 0.75], [0.71168106, 0.08614060, -0.10325682]),
+        ([0.75, 0.5, 0.25], [0.81430313, 0.02048597, 0.07594870]),
+        ([0.3, 0.6, 0.1], [0.78130967, -0.10163317, 0.11875259]),
+    ]
+
+    for i, (src, dst) in enumerate(EXAMPLES):
+        print(i)
+        assert dr.allclose(dr.linear_srgb_to_oklab(t(src)), t(dst))
+        assert dr.allclose(dr.oklab_to_linear_srgb(t(dst)), t(src))

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,25 @@
+import drjit as dr
+import pytest
+
+
+@pytest.test_arrays('float32, shape=(*)')
+def test01_srgb_conversion(t):
+    """Spot-check the linear/sRGB conversion routines"""
+
+    assert dr.allclose(dr.linear_to_srgb(0), 0)
+    assert dr.allclose(dr.srgb_to_linear(0), 0)
+    assert dr.allclose(dr.linear_to_srgb(1), 1)
+    assert dr.allclose(dr.srgb_to_linear(1), 1)
+    assert dr.allclose(dr.linear_to_srgb(.5), 0.7353569830524495)
+    assert dr.allclose(dr.srgb_to_linear(.5), 0.21404114048223244)
+
+    # Out of bounds
+    assert dr.allclose(dr.linear_to_srgb(-1), 0)
+    assert dr.allclose(dr.srgb_to_linear(-1), 0)
+    assert dr.allclose(dr.linear_to_srgb(2), 1)
+    assert dr.allclose(dr.srgb_to_linear(2), 1)
+
+    assert dr.allclose(dr.linear_to_srgb(-1, clip=False), -1)
+    assert dr.allclose(dr.srgb_to_linear(-1, clip=False), -1)
+    assert dr.allclose(dr.linear_to_srgb(2, clip=False), 1.353256046149386)
+    assert dr.allclose(dr.srgb_to_linear(2, clip=False), 4.95384575159204)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -213,3 +213,15 @@ def test02_expr_t(t):
     with pytest.raises(TypeError) as ei:
         dr.expr_t(MyStruct, m.Float)
     assert "expr_t(): incompatible types" in str(ei.value)
+
+@pytest.test_arrays("float, shape=(*), is_jit")
+def test03_replace_shape(t):
+    m = sys.modules[t.__module__]
+
+    assert dr.replace_shape_t(m.Float, (-1,)) is m.Float
+    assert dr.replace_shape_t(m.Float, (0, -1)) is m.Array0f
+    assert dr.replace_shape_t(m.Float, (1, -1)) is m.Array1f
+    assert dr.replace_shape_t(m.Float, (-1, -1)) is m.ArrayXf
+    assert dr.replace_shape_t(m.Float, (2, 2, -1)) is m.Array22f
+    assert dr.replace_shape_t(m.Float, (2, 2, -1), 'matrix') is m.Matrix2f
+    assert dr.replace_shape_t(m.Float, (2, -1), 'complex') is m.Complex2f


### PR DESCRIPTION
Optimizing colors in RGB space often produces poor visual results because RGB distances don't match human perception. Perceptual color spaces solve this: their distances align with how humans see color differences. Simply switching to a perceptual norm can visibly improve the quality of many algorithms without other changes.

[Oklab](https://bottosson.github.io/posts/oklab/) [Ottosson, 2020] is a perceptual color space designed specifically for image processing. It improves on CIELAB's hue shift problems and HSV's poor perceptual uniformity, while requiring only two 3x3 matrix multiplications and a cube root.

Key properties of Oklab:
- L, a, b coordinates are perceptually orthogonal
- Smooth, uniform color gradients without hue shifts
- Accurate lightness prediction across all hues
- Differentiable transformations suitable for optimization
- Predictable color mixing behavior

This commit adds two conversion functions:
- ``linear_srgb_to_oklab()``: Convert linear sRGB to Oklab space
- ``oklab_to_linear_srgb()``: Convert Oklab back to linear sRGB

Using these functions for perceptual color optimization is straightforward: convert both colors to Oklab with ``linear_srgb_to_oklab()``, then compute the L2 norm of their difference. This gives a perceptually uniform distance metric. Note that the functions expect *linear* sRGB values. For typical gamma-encoded image data, first apply ``dr.srgb_to_linear()``.

This PR bundles two related changes (one used by the OKLab functions, the other one for sRGB encoding):

1. Added ``drjit.replace_shape_t()`` convenience type trait

   In generic Dr.Jit functions (i.e., ones that are supposed to work with many different inputs), it can be rather tedious to obtain a specific intermediate or output type.

   For example, perhaps a function is called with ``Float`` but then it needs access to an equivalent `Matrix2f` type.

   This commit adds a function that makes this possible--in this case, we can run

   ```
   Matrix2f = dr.replace_shape_t(Float, (2, 2, -1), 'matrix')
   ```

2. Improve ``dr.linear_to_srgb()``, ``dr.srgb_to_linear()``

   This commit adds documentation and testing coverage to the sRGB <-> linear color space conversions.

   The behavior of both functions for the ``clamp=False`` is modified as follows: they are now *odd*, i.e., ``f(-x) = -f(x)``. Displays/compositors with extended color spaces (e.g., Display P3) use this convention to encode "out-of-gamut" colors.
