### PR TITLE
SymPy integration

### DIFF
--- a/docs/interop.rst
+++ b/docs/interop.rst
@@ -10,7 +10,9 @@ Currently, the following ones are officially supported:
 
 - `NumPy <https://numpy.org>`__,
 - `PyTorch <https://pytorch.org>`__,
-- `JAX <https://jax.readthedocs.io/en/latest/installation.html>`__.
+- `JAX <https://jax.readthedocs.io/en/latest/installation.html>`__,
+- `SymPy <https://www.sympy.org>`__ (symbolic computation, see :ref:`below
+  <interop_sympy>`).
 
 There isn't much to it: given an input array from another framework, simply
 pass it to the constructor of the Dr.Jit array or tensor type you wish to
@@ -102,6 +104,130 @@ larger PyTorch program:
    tensor([1.0000e+00, 8.0000e+00, 2.5600e+02, 1.3107e+05])
 
 See the documentation of :py:func:`@drjit.wrap <wrap>` for further details.
+
+.. _interop_sympy:
+
+SymPy
+-----
+
+Dr.Jit can also interoperate with `SymPy <https://www.sympy.org>`__, a
+computer algebra system. This integration works differently from the
+PyTorch/JAX/TensorFlow targets described above: rather than exchanging *data*
+at runtime, the SymPy target operates at *compile time*. It converts Dr.Jit
+types into SymPy symbols, runs the decorated function in SymPy to obtain an
+expression, and then compiles that expression into Dr.Jit code.
+
+.. code-block:: python
+
+   import sympy as sp
+   from drjit.cuda.ad import Float, Array3f
+
+   @dr.wrap(source='drjit', target='sympy')
+   def norm(v):
+       return v.norm()
+
+   result = norm(Array3f(3, 4, 0))  # Float(5.0)
+
+The key idea is that the compiled result consists of *ordinary Dr.Jit
+operations*. All of the usual Dr.Jit semantics apply: the code is traced,
+parallelized, and—if AD-enabled types are used—automatically differentiable:
+
+.. code-block:: pycon
+
+   >>> x = Float(3.0)
+   >>> dr.enable_grad(x)
+   >>> @dr.wrap(source='drjit', target='sympy')
+   ... def f(x):
+   ...     return x**2 + 2*x + 1
+   >>> y = f(x)
+   >>> dr.backward(y)
+   >>> x.grad
+   [8]
+
+Parallelism
+^^^^^^^^^^^
+
+Recall that every Dr.Jit type is inherently an *array* of the concept it
+represents: a :py:class:`Float <drjit.auto.ad.Float>` is a dynamically sized
+array of floats, a :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>` is an array
+of 4×4 matrices, and so on. Operations on these types are applied to all
+elements in parallel.
+
+The SymPy wrapper preserves this property. The SymPy expression is compiled
+into Dr.Jit code that processes all elements simultaneously. For example,
+applying a ``@dr.wrap(source='drjit', target='sympy')``-decorated function to
+a :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>` that contains 1000 matrices
+will compute the result for all 1000 matrices in a single kernel. The
+expression is compiled only once and then evaluated in parallel across all
+elements.
+
+Type promotion
+^^^^^^^^^^^^^^
+
+Dr.Jit array types are automatically mapped to their natural SymPy equivalents
+when they enter the decorated function:
+
+- Scalar types (:py:class:`Float <drjit.auto.ad.Float>`,
+  :py:class:`UInt32 <drjit.auto.ad.UInt32>`, …) become ``sp.Symbol(real=True)``.
+  Note that SymPy does not distinguish integer and floating-point symbols—both
+  map to the same kind of symbol. Integer-specific operations like floor
+  division and modulo will produce SymPy expressions (``floor(x/2)``,
+  ``Mod(x, 3)``) that are correctly compiled to Dr.Jit code, but SymPy
+  treats all values as real numbers.
+- Static vectors (:py:class:`Array2f <drjit.auto.ad.Array2f>`,
+  :py:class:`Array3f <drjit.auto.ad.Array3f>`, …) become ``sp.Matrix``
+  column vectors. This means ``.dot()``, ``.cross()``, and ``.norm()`` work
+  immediately. Indexing (``v[0]``), slicing (``v[0:2]``), and unpacking
+  (``x, y, z = v``) also work, so existing code that treated vectors as lists
+  continues to work unchanged.
+- Dynamic arrays (:py:class:`ArrayXf <drjit.auto.ad.ArrayXf>`) also become
+  ``sp.Matrix`` column vectors. Their size is known when the function is first
+  called and used for compilation.
+- Matrix types (:py:class:`Matrix3f <drjit.auto.ad.Matrix3f>`,
+  :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>`, …) become square
+  ``sp.Matrix`` objects.
+
+Caching
+^^^^^^^
+
+Compiled functions are cached at two levels. An in-memory cache, keyed by the
+argument type signature, avoids recompilation when the same function is called
+repeatedly with arguments of the same types. A disk cache in
+``$HOME/.drjit/sympy/`` persists compiled bytecode across interpreter
+restarts, following Dr.Jit's kernel cache convention (``$HOME/.drjit/``). To
+clear the cache, simply delete that directory.
+
+Nested calls
+^^^^^^^^^^^^
+
+Functions decorated with ``@dr.wrap(source='drjit', target='sympy')`` can call
+each other. When a wrapped function is invoked during another wrapped
+function's compilation, it runs in SymPy mode and its expression is inlined
+into the outer function rather than triggering a separate compilation.
+
+Limitations
+^^^^^^^^^^^
+
+The SymPy target has several limitations to be aware of:
+
+- The decorated function must be **pure** and use only SymPy operations on its
+  arguments. Since the arguments are SymPy symbols (not Dr.Jit arrays), calling
+  Dr.Jit functions like :py:func:`dr.gather() <gather>`,
+  :py:func:`dr.scatter() <scatter>` will not work.
+
+- **No control flow on arguments.** Python ``if``/``else`` statements cannot
+  branch on SymPy symbols because they are not booleans. Use ``sp.Piecewise``
+  for conditional expressions instead.
+
+- **Expression complexity.** SymPy manipulates expressions algebraically, which
+  can become slow for large expressions. Operations like matrix inversion on
+  matrices larger than about 4×4 may produce very large expressions and take a
+  long time to compile. The compiled Dr.Jit code will be fast regardless, so
+  this is purely a one-time compilation cost.
+
+- **First-call overhead.** The first call to a wrapped function traces through
+  SymPy, performs CSE optimization, and compiles the result. This can take
+  noticeably longer than subsequent calls, which hit the cache.
 
 .. _interop_caveats:
 

--- a/docs/interop.rst
+++ b/docs/interop.rst
@@ -130,7 +130,8 @@ expression, and then compiles that expression into Dr.Jit code.
 
 The key idea is that the compiled result consists of *ordinary Dr.Jit
 operations*. All of the usual Dr.Jit semantics apply: the code is traced,
-parallelized, and—if AD-enabled types are used—automatically differentiable:
+parallelized across all array elements, and—if AD-enabled types are
+used—automatically differentiable:
 
 .. code-block:: pycon
 
@@ -143,23 +144,6 @@ parallelized, and—if AD-enabled types are used—automatically differentiable:
    >>> dr.backward(y)
    >>> x.grad
    [8]
-
-Parallelism
-^^^^^^^^^^^
-
-Recall that every Dr.Jit type is inherently an *array* of the concept it
-represents: a :py:class:`Float <drjit.auto.ad.Float>` is a dynamically sized
-array of floats, a :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>` is an array
-of 4×4 matrices, and so on. Operations on these types are applied to all
-elements in parallel.
-
-The SymPy wrapper preserves this property. The SymPy expression is compiled
-into Dr.Jit code that processes all elements simultaneously. For example,
-applying a ``@dr.wrap(source='drjit', target='sympy')``-decorated function to
-a :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>` that contains 1000 matrices
-will compute the result for all 1000 matrices in a single kernel. The
-expression is compiled only once and then evaluated in parallel across all
-elements.
 
 Type promotion
 ^^^^^^^^^^^^^^
@@ -174,18 +158,14 @@ when they enter the decorated function:
   division and modulo will produce SymPy expressions (``floor(x/2)``,
   ``Mod(x, 3)``) that are correctly compiled to Dr.Jit code, but SymPy
   treats all values as real numbers.
-- Static vectors (:py:class:`Array2f <drjit.auto.ad.Array2f>`,
-  :py:class:`Array3f <drjit.auto.ad.Array3f>`, …) become ``sp.Matrix``
-  column vectors. This means ``.dot()``, ``.cross()``, and ``.norm()`` work
-  immediately. Indexing (``v[0]``), slicing (``v[0:2]``), and unpacking
-  (``x, y, z = v``) also work, so existing code that treated vectors as lists
-  continues to work unchanged.
-- Dynamic arrays (:py:class:`ArrayXf <drjit.auto.ad.ArrayXf>`) also become
-  ``sp.Matrix`` column vectors. Their size is known when the function is first
-  called and used for compilation.
+- Arrays (:py:class:`Array2f <drjit.auto.ad.Array2f>`,
+  :py:class:`Array3f <drjit.auto.ad.Array3f>`, :py:class:`ArrayXf
+  <drjit.auto.ad.ArrayXf>`) become ``sp.Matrix`` column vectors.
 - Matrix types (:py:class:`Matrix3f <drjit.auto.ad.Matrix3f>`,
-  :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>`, …) become square
+  :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>`, ...) become square
   ``sp.Matrix`` objects.
+- Tensor types (:py:class:`TensorXf <drjit.auto.ad.TensorXf>`) cannot be used
+  in the SymPy wrapper.
 
 Caching
 ^^^^^^^
@@ -193,9 +173,9 @@ Caching
 Compiled functions are cached at two levels. An in-memory cache, keyed by the
 argument type signature, avoids recompilation when the same function is called
 repeatedly with arguments of the same types. A disk cache in
-``$HOME/.drjit/sympy/`` persists compiled bytecode across interpreter
-restarts, following Dr.Jit's kernel cache convention (``$HOME/.drjit/``). To
-clear the cache, simply delete that directory.
+``~/.drjit/sympy/`` persists compiled bytecode across interpreter restarts,
+following Dr.Jit's kernel cache convention (``~/.drjit/``). To clear the
+cache, simply delete that directory.
 
 Nested calls
 ^^^^^^^^^^^^

--- a/docs/interop.rst
+++ b/docs/interop.rst
@@ -10,7 +10,9 @@ Currently, the following ones are officially supported:
 
 - `NumPy <https://numpy.org>`__,
 - `PyTorch <https://pytorch.org>`__,
-- `JAX <https://jax.readthedocs.io/en/latest/installation.html>`__.
+- `JAX <https://jax.readthedocs.io/en/latest/installation.html>`__,
+- `SymPy <https://www.sympy.org>`__ (symbolic computation, see :ref:`below
+  <interop_sympy>`).
 
 There isn't much to it: given an input array from another framework, simply
 pass it to the constructor of the Dr.Jit array or tensor type you wish to
@@ -102,6 +104,151 @@ larger PyTorch program:
    tensor([1.0000e+00, 8.0000e+00, 2.5600e+02, 1.3107e+05])
 
 See the documentation of :py:func:`@drjit.wrap <wrap>` for further details.
+
+.. _interop_sympy:
+
+SymPy
+-----
+
+Dr.Jit can also interoperate with `SymPy <https://www.sympy.org>`__, a
+computer algebra system. This integration works differently from the
+PyTorch/JAX/TensorFlow targets described above: rather than exchanging *data*
+at runtime, the SymPy target operates at *compile time*. It converts Dr.Jit
+types into SymPy symbols, runs the decorated function in SymPy to obtain an
+expression, and then compiles that expression into Dr.Jit code.
+
+.. code-block:: python
+
+   import sympy as sp
+   from drjit.cuda.ad import Float, Array3f
+
+   @dr.wrap(source='drjit', target='sympy')
+   def norm(v):
+       return v.norm()
+
+   result = norm(Array3f(3, 4, 0))  # Float(5.0)
+
+The key idea is that the compiled result consists of *ordinary Dr.Jit
+operations*. All of the usual Dr.Jit semantics apply: the code is traced,
+parallelized across all array elements, and—if AD-enabled types are
+used—automatically differentiable. For example, SymPy can symbolically derive
+a Newton step that Dr.Jit then evaluates for many initial values in parallel:
+
+.. code-block:: python
+
+   @dr.wrap(source='drjit', target='sympy')
+   def newton_step(x, y):
+       variables = sp.Matrix([x, y])
+       objective = (x - 1)**2 + 2*(y + 2)**2 + (x + y + 1)**2
+       gradient = sp.Matrix([sp.diff(objective, v) for v in variables])
+       hessian = sp.hessian(objective, variables)
+       step = hessian.inv() * gradient
+       return x - step[0], y - step[1]
+
+   x = Float([-2, 0, 4])
+   y = Float([3, -1, 2])
+   x, y = newton_step(x, y)
+
+   assert dr.allclose(x, 1)
+   assert dr.allclose(y, -2)
+
+Type promotion
+^^^^^^^^^^^^^^
+
+Dr.Jit array types are automatically mapped to their natural SymPy equivalents
+when they enter the decorated function:
+
+- Scalar types (:py:class:`Float <drjit.auto.ad.Float>`,
+  :py:class:`UInt32 <drjit.auto.ad.UInt32>`, …) become ``sp.Symbol(real=True)``.
+  Note that SymPy does not distinguish integer and floating-point symbols—both
+  map to the same kind of symbol. Integer-specific operations like floor
+  division and modulo will produce SymPy expressions (``floor(x/2)``,
+  ``Mod(x, 3)``) that are correctly compiled to Dr.Jit code, but SymPy
+  treats all values as real numbers.
+- Arrays (:py:class:`Array2f <drjit.auto.ad.Array2f>`,
+  :py:class:`Array3f <drjit.auto.ad.Array3f>`, :py:class:`ArrayXf
+  <drjit.auto.ad.ArrayXf>`) become ``sp.Matrix`` column vectors.
+- Matrix types (:py:class:`Matrix3f <drjit.auto.ad.Matrix3f>`,
+  :py:class:`Matrix4f <drjit.auto.ad.Matrix4f>`, ...) become square
+  ``sp.Matrix`` objects.
+- Tensor types (:py:class:`TensorXf <drjit.auto.ad.TensorXf>`) cannot be used
+  in the SymPy wrapper.
+
+The output of a sympy function is always flattened, returning nested lists
+instead of matrices.
+
+Caching
+^^^^^^^
+
+Compiled functions are cached at two levels. An in-memory cache, keyed by the
+argument type signature, avoids recompilation when the same function is called
+repeatedly with arguments of the same types. A disk cache persists compiled
+bytecode across interpreter restarts. Like Dr.Jit's kernel cache, it is stored
+in ``~/.drjit/sympy/`` on Linux and macOS and
+``%TEMP%\drjit\sympy\`` on Windows. Setting ``DRJIT_CACHE_DIR`` changes the
+location to ``<DRJIT_CACHE_DIR>/sympy/``. To clear the cache, simply delete
+that directory.
+
+Nested calls
+^^^^^^^^^^^^
+
+Functions decorated with ``@dr.wrap(source='drjit', target='sympy')`` can call
+each other. When a wrapped function is invoked during another wrapped
+function's compilation, it runs in SymPy mode and its expression is inlined
+into the outer function rather than triggering a separate compilation.
+
+Limitations
+^^^^^^^^^^^
+
+The SymPy target has several limitations to be aware of:
+
+- The decorated function must be **pure** and use only SymPy operations on its
+  arguments. Since the arguments are SymPy symbols (not Dr.Jit arrays), calling
+  Dr.Jit functions like :py:func:`dr.gather() <gather>`,
+  :py:func:`dr.scatter() <scatter>` will not work.
+
+- **No control flow on arguments.** Python ``if``/``else`` statements cannot
+  branch on SymPy symbols because they are not booleans. Use ``sp.Piecewise``
+  for conditional expressions instead.
+
+- **Expression complexity.** SymPy manipulates expressions algebraically, which
+  can become slow for large expressions. Operations like matrix inversion on
+  matrices larger than about 4×4 may produce very large expressions and take a
+  long time to compile.
+
+- **First-call overhead.** The first call to a wrapped function traces through
+  SymPy, performs CSE optimization, and compiles the result. This can take
+  noticeably longer than subsequent calls, which hit the cache.
+
+- **Unsupported functions.** Dr.Jit has no direct equivalent for every SymPy
+  construct. Examples include distributions such as ``DiracDelta``, discrete
+  objects such as ``KroneckerDelta``, Bessel and Airy functions, elliptic
+  integrals, and functions such as ``zeta`` and ``polylog``. Some of these can
+  arise during symbolic differentiation. Rewrite them in terms of supported
+  arithmetic, elementary functions, or ``sp.Piecewise`` before returning from
+  the decorated function. Any unsupported expressions that remain after SymPy
+  evaluates the result cause code generation to fail.
+
+  This includes unevaluated derivatives. For example, differentiating a
+  quantization operation involving ``floor`` leaves an ``sp.Derivative`` in
+  the expression because the operation is discontinuous. If the desired
+  derivative is zero almost everywhere, replace that term before returning:
+
+  .. code-block:: python
+
+     @dr.wrap(source='drjit', target='sympy')
+     def quantization_gradient(x):
+         quantized = sp.floor(255*x + sp.Rational(1, 2)) / 255
+         gradient = sp.diff(quantized, x)
+         gradient = gradient.replace(
+             lambda e: isinstance(e, sp.Derivative),
+             lambda e: 0
+         )
+         return gradient.doit()
+
+  This replacement treats every unresolved derivative in ``gradient`` as
+  zero. It should only be used when that convention is appropriate for the
+  application.
 
 .. _interop_caveats:
 

--- a/drjit/interop.py
+++ b/drjit/interop.py
@@ -526,7 +526,7 @@ def create_sympy_wrapper():
     '''Lazily create the SympyWrapper class, importing SymPy and other
     dependencies only when first needed.'''
     import sympy as sp
-    import xxhash
+    import hashlib
     import marshal
     import inspect
     from pathlib import Path
@@ -759,7 +759,7 @@ def create_sympy_wrapper():
                 expr_key = repr(flat_exprs)
 
             key = f"{n_symbols=}; {self.simplify=}; {self.clear_derivatives=}; {expr_key=}"
-            key = xxhash.xxh64(key.encode()).hexdigest()
+            key = hashlib.sha256(key.encode()).hexdigest()
 
             cache_dir = _cache_dir()
             cache_file = cache_dir / f"{key}.pyc"

--- a/drjit/interop.py
+++ b/drjit/interop.py
@@ -732,10 +732,6 @@ def create_sympy_wrapper():
         def __init__(
             self,
             f_sp,
-            key_fn=None,
-            save_expr=False,
-            simplify=False,
-            clear_derivatives=True,
         ):
             self.f_sp = f_sp
             # The generated code uses ``dr.*`` calls, so ensure ``dr``
@@ -746,19 +742,12 @@ def create_sympy_wrapper():
             self.__globals__ = func_globals
             self.enabled = True
             self.sig = inspect.signature(f_sp)
-            self.key_fn = key_fn
-            self.save_expr = save_expr
-            self.simplify = simplify
-            self.clear_derivatives = clear_derivatives
             self.cache = {}
 
         def codegen(self, flat_exprs, n_symbols):
-            if self.key_fn is not None:
-                expr_key = repr(self.key_fn(flat_exprs))
-            else:
-                expr_key = repr(flat_exprs)
+            expr_key = repr(flat_exprs)
 
-            key = f"{n_symbols=}; {self.simplify=}; {self.clear_derivatives=}; {expr_key=}"
+            key = f"{n_symbols=}; {expr_key=}"
             key = hashlib.sha256(key.encode()).hexdigest()
 
             cache_dir = _cache_dir()
@@ -770,10 +759,7 @@ def create_sympy_wrapper():
             else:
                 def process(e):
                     e = e.doit(deep=True)
-                    if self.simplify:
-                        e = sp.simplify(e)
-                    if self.clear_derivatives:
-                        e = e.replace(lambda e: isinstance(e, sp.Derivative), lambda e: 0)
+                    e = e.replace(lambda e: isinstance(e, sp.Derivative), lambda e: 0)
                     e = e.replace(lambda e: isinstance(e, sp.DiracDelta), lambda e: 0)
                     return e
 

--- a/drjit/interop.py
+++ b/drjit/interop.py
@@ -420,6 +420,8 @@ class WrapADOp(dr.CustomOp):
                                             target_backend=self._target_backend))
 
 torch_wrapper = None
+sympy_wrapper_cls = None
+sympy_compile_context = False
 
 # Temporary storage of 'desc_o' needed for torch->drjit PyTorch forward-AD
 # See https://github.com/pytorch/pytorch/issues/117491
@@ -519,6 +521,332 @@ def create_torch_wrapper():
 
 
     return TorchWrapper
+
+def create_sympy_wrapper():
+    '''Lazily create the SympyWrapper class, importing SymPy and other
+    dependencies only when first needed.'''
+    import sympy as sp
+    import xxhash
+    import marshal
+    import inspect
+    from pathlib import Path
+    from sympy.printing.pycode import PythonCodePrinter
+
+    class DrJitPrinter(PythonCodePrinter):
+        '''Code printer that generates Dr.Jit compatible code from SymPy expressions.'''
+
+        def __init__(self, settings=None):
+            super().__init__(settings)
+            self.module_imports = {"drjit": {"sqrt", "exp", "pi"}}
+
+        def _print_Pi(self, expr):
+            return "dr.pi"
+
+        def _print_Exp1(self, expr):
+            return "dr.e"
+
+        def _print_Pow(self, expr):
+            base, exp_val = expr.as_base_exp()
+            base_str = self._print(base)
+            if exp_val == sp.Rational(1, 2) or exp_val == 0.5:
+                return f"dr.sqrt({base_str})"
+            if isinstance(exp_val, sp.Integer) and exp_val > 0 and exp_val <= 4:
+                result = "*".join([f"({base_str})"] * int(exp_val))
+                return f"({result})"
+            return f"({base_str})**({self._print(exp_val)})"
+
+        def _print_exp(self, expr):
+            return f"dr.exp({self._print(expr.args[0])})"
+
+        def _print_sqrt(self, expr):
+            return f"dr.sqrt({self._print(expr.args[0])})"
+
+        def _print_sin(self, expr):
+            return f"dr.sin({self._print(expr.args[0])})"
+
+        def _print_cos(self, expr):
+            return f"dr.cos({self._print(expr.args[0])})"
+
+        def _print_tan(self, expr):
+            return f"dr.tan({self._print(expr.args[0])})"
+
+        def _print_asin(self, expr):
+            return f"dr.asin({self._print(expr.args[0])})"
+
+        def _print_acos(self, expr):
+            return f"dr.acos({self._print(expr.args[0])})"
+
+        def _print_atan(self, expr):
+            return f"dr.atan({self._print(expr.args[0])})"
+
+        def _print_atan2(self, expr):
+            return f"dr.atan2({self._print(expr.args[0])}, {self._print(expr.args[1])})"
+
+        def _print_log(self, expr):
+            return f"dr.log({self._print(expr.args[0])})"
+
+        def _print_Abs(self, expr):
+            return f"dr.abs({self._print(expr.args[0])})"
+
+        def _print_sign(self, expr):
+            return f"dr.sign({self._print(expr.args[0])})"
+
+        def _print_Min(self, expr):
+            args = ", ".join(self._print(arg) for arg in expr.args)
+            return f"dr.minimum({args})"
+
+        def _print_Max(self, expr):
+            args = ", ".join(self._print(arg) for arg in expr.args)
+            return f"dr.maximum({args})"
+
+        def _print_ImmutableDenseMatrix(self, expr):
+            rows = []
+            for i in range(expr.rows):
+                row_elements = []
+                for j in range(expr.cols):
+                    row_elements.append(self._print(expr[i, j]))
+                rows.append("[" + ", ".join(row_elements) + "]")
+            return "[" + ", ".join(rows) + "]"
+
+        def _print_Matrix(self, expr):
+            return self._print_ImmutableDenseMatrix(expr)
+
+        def _print_Piecewise(self, expr):
+            result = None
+            for i in range(len(expr.args) - 1, -1, -1):
+                value_expr, cond_expr = expr.args[i]
+                value_str = self._print(value_expr)
+                if cond_expr == True:
+                    result = value_str
+                else:
+                    cond_str = self._print(cond_expr)
+                    if result is None:
+                        result = value_str
+                    else:
+                        result = f"dr.select({cond_str}, {value_str}, {result})"
+            return result if result is not None else "0"
+
+        def _print_DiracDelta(self, expr):
+            return "0.0"
+
+    def drjit_code(expr, cse=False, cse_prefix="x", **settings):
+        '''Generate Dr.Jit compatible code from a SymPy expression.'''
+        printer = DrJitPrinter(settings)
+
+        if cse:
+            replacements, reduced_exprs = sp.cse(
+                expr, symbols=sp.numbered_symbols(cse_prefix)
+            )
+            code_lines = []
+            for symbol, subexpr in replacements:
+                code_lines.append(f"{symbol} = {printer.doprint(subexpr)}")
+            if isinstance(reduced_exprs, list) and len(reduced_exprs) == 1:
+                reduced_exprs = reduced_exprs[0]
+            code_lines.append(printer.doprint(reduced_exprs))
+            return code_lines
+        else:
+            return printer.doprint(expr)
+
+    def _cache_dir():
+        d = Path.home() / ".drjit" / "sympy"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def flatten_scalars(leaves):
+        '''Extract the flat list of DrJit scalar components from leaves.'''
+        scalars = []
+        for leaf in leaves:
+            if isinstance(leaf, (type(None), int, float, bool, str)):
+                pass
+            elif dr.is_matrix_v(leaf):
+                for col in leaf:
+                    for elem in col:
+                        scalars.append(elem)
+            elif dr.is_vector_v(leaf):
+                for elem in leaf:
+                    scalars.append(elem)
+            elif dr.is_arithmetic_v(leaf):
+                scalars.append(leaf)
+            else:
+                raise RuntimeError(
+                    f"Unsupported DrJit type for SymPy: {type(leaf)}")
+        return scalars
+
+    def from_drjit_sympy(leaves):
+        '''Convert a flat list of DrJit leaves to SymPy equivalents.
+
+        Returns ``(sympy_leaves, n_scalars)`` where *sympy_leaves*
+        mirrors the input but with SymPy types, and *n_scalars* is the
+        total number of scalar components.
+        '''
+        sympy_leaves = []
+        counter = 0
+        for leaf in leaves:
+            if isinstance(leaf, (type(None), int, float, bool, str)):
+                sympy_leaves.append(leaf)
+            elif dr.is_matrix_v(leaf):
+                cols = []
+                for col in leaf:
+                    col_syms = []
+                    for elem in col:
+                        col_syms.append(sp.Symbol(f"i{counter}", real=True))
+                        counter += 1
+                    cols.append(col_syms)
+                sympy_leaves.append(sp.Matrix(cols))
+            elif dr.is_vector_v(leaf):
+                syms = []
+                for elem in leaf:
+                    syms.append(sp.Symbol(f"i{counter}", real=True))
+                    counter += 1
+                sympy_leaves.append(sp.Matrix(syms))
+            elif dr.is_arithmetic_v(leaf):
+                sympy_leaves.append(sp.Symbol(f"i{counter}", real=True))
+                counter += 1
+            else:
+                raise RuntimeError(
+                    f"Unsupported DrJit type for SymPy: {type(leaf)}")
+        return sympy_leaves, counter
+
+    def to_drjit_pytree(expr):
+        '''Convert a SymPy result to a plain Python PyTree.
+
+        Maps ``sp.MatrixBase`` to nested lists and ``sp.Tuple`` to
+        tuples so that ``flatten`` sees only plain Python containers.
+        '''
+        def fn(a):
+            if isinstance(a, sp.MatrixBase):
+                return apply(fn, a.tolist())
+            elif isinstance(a, sp.Tuple):
+                return apply(fn, tuple(a))
+            return ...
+        return apply(fn, expr)
+
+    class SympyWrapper:
+        '''Wrapper that compiles SymPy functions to optimized DrJit code.
+
+        Follows the same pattern as the PyTorch wrapper: ``flatten``/``unflatten``
+        handle PyTree structure, while ``from_drjit_sympy``/``to_drjit_pytree``
+        handle the DrJit <-> SymPy leaf conversion.
+        '''
+
+        def __init__(
+            self,
+            f_sp,
+            key_fn=None,
+            save_expr=False,
+            simplify=False,
+            clear_derivatives=True,
+        ):
+            self.f_sp = f_sp
+            # The generated code uses ``dr.*`` calls, so ensure ``dr``
+            # is available even if the user function didn't import it.
+            func_globals = f_sp.__globals__
+            if 'dr' not in func_globals:
+                func_globals = {**func_globals, 'dr': dr}
+            self.__globals__ = func_globals
+            self.enabled = True
+            self.sig = inspect.signature(f_sp)
+            self.key_fn = key_fn
+            self.save_expr = save_expr
+            self.simplify = simplify
+            self.clear_derivatives = clear_derivatives
+            self.cache = {}
+
+        def codegen(self, flat_exprs, n_symbols):
+            if self.key_fn is not None:
+                expr_key = repr(self.key_fn(flat_exprs))
+            else:
+                expr_key = repr(flat_exprs)
+
+            key = f"{n_symbols=}; {self.simplify=}; {self.clear_derivatives=}; {expr_key=}"
+            key = xxhash.xxh64(key.encode()).hexdigest()
+
+            cache_dir = _cache_dir()
+            cache_file = cache_dir / f"{key}.pyc"
+
+            if cache_file.exists():
+                with open(cache_file, "rb") as f:
+                    compiled = marshal.load(f)
+            else:
+                def process(e):
+                    e = e.doit(deep=True)
+                    if self.simplify:
+                        e = sp.simplify(e)
+                    if self.clear_derivatives:
+                        e = e.replace(lambda e: isinstance(e, sp.Derivative), lambda e: 0)
+                    e = e.replace(lambda e: isinstance(e, sp.DiracDelta), lambda e: 0)
+                    return e
+
+                flat_exprs = [process(e) for e in flat_exprs]
+
+                symbols_dr = ",".join((f"i{i}" for i in range(n_symbols)))
+                code_lines = drjit_code(flat_exprs, cse=True)
+                code = f"def func({symbols_dr}):\n"
+                for line in code_lines[:-1]:
+                    code += f"    {line}\n"
+                code += f"    r = {code_lines[-1]}\n"
+
+                if len(flat_exprs) == 1:
+                    code += "    r = [r]\n"
+
+                code += "    return tuple(r)"
+
+                (cache_dir / f"{key}.py").write_text(code)
+
+                compiled = compile(code, f"<generated {key}>", "exec")
+
+                with open(cache_file, "wb") as f:
+                    marshal.dump(compiled, f)
+
+            return compiled
+
+        def compile(self, desc, drjit_leaves):
+            # Convert DrJit leaves to SymPy equivalents
+            sympy_leaves, n_scalars = from_drjit_sympy(drjit_leaves)
+
+            # Reconstruct the PyTree with SymPy leaves
+            sympy_args = unflatten(list(desc), *sympy_leaves)
+
+            global sympy_compile_context
+            sympy_compile_context = True
+            try:
+                expr = self.f_sp(*sympy_args)
+            finally:
+                sympy_compile_context = False
+
+            # Convert SymPy output to plain PyTree, then flatten
+            pytree = to_drjit_pytree(expr)
+            desc_out, *flat_exprs = flatten(pytree)
+
+            compiled = self.codegen(flat_exprs, n_scalars)
+            func_code = compiled.co_consts[0]
+            f_dr = types.FunctionType(func_code, self.__globals__)
+
+            return f_dr, desc_out
+
+        def __call__(self, *args, **kwargs):
+            if self.enabled and not sympy_compile_context:
+                bound_args = self.sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                bound_args = tuple(bound_args.arguments.values())
+
+                # Flatten the DrJit PyTree
+                desc, *drjit_leaves = flatten(bound_args)
+                cache_key = repr(desc) + repr([type(v) for v in drjit_leaves])
+
+                cached = self.cache.get(cache_key)
+                if cached is None:
+                    f_dr, desc_out = self.compile(desc, drjit_leaves)
+                    self.cache[cache_key] = (f_dr, desc_out)
+                else:
+                    f_dr, desc_out = cached
+
+                flat_results = f_dr(*flatten_scalars(drjit_leaves))
+                return unflatten(list(desc_out), *flat_results)
+            else:
+                return self.f_sp(*args, **kwargs)
+
+    return SympyWrapper
 
 T = typing.TypeVar("T")
 
@@ -651,7 +979,7 @@ def wrap(source: typing.Union[str, types.ModuleType],
     # Get module names if source and target are not already strings
     source = source.__name__ if not isinstance(source, str) else source
     target = target.__name__ if not isinstance(target, str) else target
-    valid_types = ('drjit', 'torch', 'jax')
+    valid_types = ('drjit', 'torch', 'jax', 'sympy')
 
     if source not in valid_types:
         raise ValueError("drjit.wrap(): unknown 'source' argument.")
@@ -667,7 +995,16 @@ def wrap(source: typing.Union[str, types.ModuleType],
         # Nothing to do
         return lambda x: x
 
-    if source == 'drjit':
+    if source == 'drjit' and target == 'sympy':
+        global sympy_wrapper_cls
+
+        if sympy_wrapper_cls is None:
+            sympy_wrapper_cls = create_sympy_wrapper()
+
+        def wrapper(func):
+            return sympy_wrapper_cls(func)
+        return wrapper
+    elif source == 'drjit':
         def wrapper(func):
             return lambda *args, **kwargs: \
                 dr.custom(WrapADOp, func, target, *args, **kwargs)

--- a/drjit/interop.py
+++ b/drjit/interop.py
@@ -420,6 +420,8 @@ class WrapADOp(dr.CustomOp):
                                             target_backend=self._target_backend))
 
 torch_wrapper = None
+sympy_wrapper_cls = None
+sympy_compile_context = False
 
 # Temporary storage of 'desc_o' needed for torch->drjit PyTorch forward-AD
 # See https://github.com/pytorch/pytorch/issues/117491
@@ -519,6 +521,318 @@ def create_torch_wrapper():
 
 
     return TorchWrapper
+
+def create_sympy_wrapper():
+    '''Lazily create the SympyWrapper class, importing SymPy and other
+    dependencies only when first needed.'''
+    import sympy as sp
+    import hashlib
+    import marshal
+    import inspect
+    import os
+    import sys
+    import tempfile
+    from pathlib import Path
+    from sympy.printing.pycode import PythonCodePrinter
+
+    class DrJitPrinter(PythonCodePrinter):
+        '''Code printer that generates Dr.Jit compatible code from SymPy expressions.'''
+
+        def __init__(self, settings=None):
+            super().__init__(settings)
+            self.module_imports = {"drjit": {"sqrt", "exp", "pi"}}
+
+            functions = (
+                "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh",
+                "cos", "cosh", "erf", "exp", "floor", "hypot", "isnan",
+                "log", "log10", "log2", "sign", "sin", "sinh", "sqrt",
+                "tan", "tanh"
+            )
+            self.known_functions.update(
+                {name: f"drjit.{name}" for name in functions}
+            )
+            self.known_functions.update({
+                "Abs": "drjit.abs",
+                "Sqrt": "drjit.sqrt",
+                "ceiling": "drjit.ceil",
+                "ln": "drjit.log",
+                "loggamma": "drjit.lgamma",
+            })
+
+            self.known_functions.update({
+                "expm1": [(lambda x: True,
+                            lambda x: f"drjit.exp({x}) - 1")],
+                "hypot": [(lambda *args: True,
+                           lambda *args: self._fold("hypot", args))],
+                "log1p": [(lambda x: True,
+                            lambda x: f"drjit.log(1 + {x})")],
+            })
+
+        def _fold(self, name, args):
+            args = iter(args)
+            result = next(args)
+            for arg in args:
+                result = f"drjit.{name}({result}, {arg})"
+            return result
+
+        def _print_Pi(self, expr):
+            return "drjit.pi"
+
+        def _print_Exp1(self, expr):
+            return "drjit.e"
+
+        def _print_Pow(self, expr):
+            base, exp_val = expr.as_base_exp()
+            base_str = self._print(base)
+            if exp_val == sp.Rational(1, 2) or exp_val == 0.5:
+                return f"drjit.sqrt({base_str})"
+            if isinstance(exp_val, sp.Integer) and exp_val > 0 and exp_val <= 4:
+                result = "*".join([f"({base_str})"] * int(exp_val))
+                return f"({result})"
+            return f"({base_str})**({self._print(exp_val)})"
+
+        def _print_erfc(self, expr):
+            return f"1 - drjit.erf({self._print(expr.args[0])})"
+
+        def _print_gamma(self, expr):
+            return f"drjit.exp(drjit.lgamma({self._print(expr.args[0])}))"
+
+        def _print_factorial(self, expr):
+            return f"drjit.exp(drjit.lgamma({self._print(expr.args[0])} + 1))"
+
+        def _print_Min(self, expr):
+            return self._fold("minimum", map(self._print, expr.args))
+
+        def _print_Max(self, expr):
+            return self._fold("maximum", map(self._print, expr.args))
+
+        def _print_ImmutableDenseMatrix(self, expr):
+            rows = []
+            for i in range(expr.rows):
+                row_elements = []
+                for j in range(expr.cols):
+                    row_elements.append(self._print(expr[i, j]))
+                rows.append("[" + ", ".join(row_elements) + "]")
+            return "[" + ", ".join(rows) + "]"
+
+        def _print_Matrix(self, expr):
+            return self._print_ImmutableDenseMatrix(expr)
+
+        def _print_Piecewise(self, expr):
+            result = None
+            for i in range(len(expr.args) - 1, -1, -1):
+                value_expr, cond_expr = expr.args[i]
+                value_str = self._print(value_expr)
+                if cond_expr == True:
+                    result = value_str
+                else:
+                    cond_str = self._print(cond_expr)
+                    if result is None:
+                        result = value_str
+                    else:
+                        result = f"drjit.select({cond_str}, {value_str}, {result})"
+            return result if result is not None else "0"
+
+    def drjit_code(expr, cse_prefix="x", **settings):
+        '''Generate Dr.Jit compatible code from a SymPy expression. It always
+        uses Common Subexpression Elimination (CSE).'''
+        printer = DrJitPrinter(settings)
+
+        replacements, reduced_exprs = sp.cse(
+            expr, symbols=sp.numbered_symbols(cse_prefix)
+        )
+        code_lines = []
+        for symbol, subexpr in replacements:
+            code_lines.append(f"{symbol} = {printer.doprint(subexpr)}")
+        if isinstance(reduced_exprs, list) and len(reduced_exprs) == 1:
+            reduced_exprs = reduced_exprs[0]
+        code_lines.append(printer.doprint(reduced_exprs))
+        return code_lines
+
+    def _cache_dir():
+        root = os.environ.get("DRJIT_CACHE_DIR")
+        if root:
+            d = Path(root)
+        elif sys.platform == "win32":
+            d = Path(tempfile.gettempdir()) / "drjit"
+        else:
+            d = Path.home() / ".drjit"
+        d /= "sympy"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def flatten_scalars(leaves):
+        '''Extract the flat list of DrJit scalar components from leaves.'''
+        scalars = []
+        for leaf in leaves:
+            if isinstance(leaf, (type(None), int, float, bool, str)):
+                pass
+            elif dr.is_matrix_v(leaf):
+                for col in leaf:
+                    for elem in col:
+                        scalars.append(elem)
+            elif dr.is_vector_v(leaf):
+                for elem in leaf:
+                    scalars.append(elem)
+            elif dr.is_arithmetic_v(leaf):
+                scalars.append(leaf)
+            else:
+                raise RuntimeError(
+                    f"Unsupported DrJit type for SymPy: {type(leaf)}")
+        return scalars
+
+    def from_drjit_sympy(leaves):
+        '''Convert a flat list of DrJit leaves to SymPy equivalents.
+
+        Returns ``(sympy_leaves, n_scalars)`` where *sympy_leaves*
+        mirrors the input but with SymPy types, and *counter* is the
+        total number of scalar components.
+        '''
+        sympy_leaves = []
+        counter = 0
+        for leaf in leaves:
+            if isinstance(leaf, (type(None), int, float, bool, str)):
+                sympy_leaves.append(leaf)
+            elif dr.is_matrix_v(leaf):
+                cols = []
+                for col in leaf:
+                    col_syms = []
+                    for elem in col:
+                        col_syms.append(sp.Symbol(f"i{counter}", real=True))
+                        counter += 1
+                    cols.append(col_syms)
+                sympy_leaves.append(sp.Matrix(cols))
+            elif dr.is_vector_v(leaf):
+                syms = []
+                for elem in leaf:
+                    syms.append(sp.Symbol(f"i{counter}", real=True))
+                    counter += 1
+                sympy_leaves.append(sp.Matrix(syms))
+            elif dr.is_arithmetic_v(leaf):
+                sympy_leaves.append(sp.Symbol(f"i{counter}", real=True))
+                counter += 1
+            else:
+                raise RuntimeError(
+                    f"Unsupported DrJit type for SymPy: {type(leaf)}")
+        return sympy_leaves, counter
+
+    def to_drjit_pytree(expr):
+        '''Convert a SymPy result to a plain Python PyTree.
+
+        Maps ``sp.MatrixBase`` to nested lists and ``sp.Tuple`` to
+        tuples so that ``flatten`` sees only plain Python containers.
+        '''
+        def fn(a):
+            if isinstance(a, sp.MatrixBase):
+                return apply(fn, a.tolist())
+            elif isinstance(a, sp.Tuple):
+                return apply(fn, tuple(a))
+            return ...
+        return apply(fn, expr)
+
+    class SympyWrapper:
+        '''Wrapper that compiles SymPy functions to optimized DrJit code.
+
+        Follows the same pattern as the PyTorch wrapper: ``flatten``/``unflatten``
+        handle PyTree structure, while ``from_drjit_sympy``/``to_drjit_pytree``
+        handle the DrJit <-> SymPy leaf conversion.
+        '''
+
+        def __init__(
+            self,
+            f_sp,
+        ):
+            self.f_sp = f_sp
+            # Make Dr.Jit available to the generated code under its canonical
+            # module name.
+            self.__globals__ = {**f_sp.__globals__, 'drjit': dr}
+            self.enabled = True
+            self.sig = inspect.signature(f_sp)
+            self.cache = {}
+
+        def codegen(self, flat_exprs, n_symbols):
+            expr_key = repr(flat_exprs)
+
+            key = f"{sys.implementation.cache_tag}; {n_symbols=}; {expr_key=}"
+            key = hashlib.sha256(key.encode()).hexdigest()
+
+            cache_dir = _cache_dir()
+            cache_file = cache_dir / f"{key}.pyc"
+
+            if cache_file.exists():
+                with open(cache_file, "rb") as f:
+                    compiled = marshal.load(f)
+            else:
+                flat_exprs = [e.doit(deep = True) for e in flat_exprs]
+
+                symbols_dr = ",".join((f"i{i}" for i in range(n_symbols)))
+                code_lines = drjit_code(flat_exprs)
+                code = f"def func({symbols_dr}):\n"
+                for line in code_lines[:-1]:
+                    code += f"    {line}\n"
+                code += f"    r = {code_lines[-1]}\n"
+
+                if len(flat_exprs) == 1:
+                    code += "    r = [r]\n"
+
+                code += "    return tuple(r)"
+
+                (cache_dir / f"{key}.py").write_text(code)
+
+                compiled = compile(code, f"<generated {key}>", "exec")
+
+                with open(cache_file, "wb") as f:
+                    marshal.dump(compiled, f)
+
+            return compiled
+
+        def compile(self, desc, drjit_leaves):
+            # Convert DrJit leaves to SymPy equivalent symbols
+            sympy_leaves, n_scalars = from_drjit_sympy(drjit_leaves)
+
+            # Reconstruct the PyTree with SymPy leaves
+            sympy_args= unflatten(list(desc), *sympy_leaves)
+
+            global sympy_compile_context
+            sympy_compile_context = True
+            try:
+                expr = self.f_sp(*sympy_args)
+            finally:
+                sympy_compile_context = False
+
+            # Convert SymPy output to plain PyTree, then flatten
+            pytree = to_drjit_pytree(expr)
+            desc_out, *flat_exprs = flatten(pytree)
+
+            compiled = self.codegen(flat_exprs, n_scalars)
+            func_code = compiled.co_consts[0]
+            f_dr = types.FunctionType(func_code, self.__globals__)
+
+            return f_dr, desc_out
+
+        def __call__(self, *args, **kwargs):
+            if self.enabled and not sympy_compile_context:
+                bound_args = self.sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                bound_args = tuple(bound_args.arguments.values())
+
+                # Flatten the DrJit PyTree
+                desc, *drjit_leaves = flatten(bound_args)
+                cache_key = repr(desc) + repr([type(v) for v in drjit_leaves])
+
+                cached = self.cache.get(cache_key)
+                if cached is None:
+                    f_dr, desc_out = self.compile(desc, drjit_leaves)
+                    self.cache[cache_key] = (f_dr, desc_out)
+                else:
+                    f_dr, desc_out = cached
+
+                flat_results = f_dr(*flatten_scalars(drjit_leaves))
+                return unflatten(list(desc_out), *flat_results)
+            else:
+                return self.f_sp(*args, **kwargs)
+
+    return SympyWrapper
 
 T = typing.TypeVar("T")
 
@@ -651,7 +965,7 @@ def wrap(source: typing.Union[str, types.ModuleType],
     # Get module names if source and target are not already strings
     source = source.__name__ if not isinstance(source, str) else source
     target = target.__name__ if not isinstance(target, str) else target
-    valid_types = ('drjit', 'torch', 'jax')
+    valid_types = ('drjit', 'torch', 'jax', 'sympy')
 
     if source not in valid_types:
         raise ValueError("drjit.wrap(): unknown 'source' argument.")
@@ -667,7 +981,16 @@ def wrap(source: typing.Union[str, types.ModuleType],
         # Nothing to do
         return lambda x: x
 
-    if source == 'drjit':
+    if source == 'drjit' and target == 'sympy':
+        global sympy_wrapper_cls
+
+        if sympy_wrapper_cls is None:
+            sympy_wrapper_cls = create_sympy_wrapper()
+
+        def wrapper(func):
+            return sympy_wrapper_cls(func)
+        return wrapper
+    elif source == 'drjit':
         def wrapper(func):
             return lambda *args, **kwargs: \
                 dr.custom(WrapADOp, func, target, *args, **kwargs)

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1172,3 +1172,25 @@ def test48_sympy_pytree_tuple_output(t):
     ref = f_drjit(x, y)
     assert dr.allclose(res[0], ref[0])
     assert dr.allclose(res[1]["diff"], ref[1]["diff"])
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test49_sympy_second_derivative(t):
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return sp.sin(x) * sp.exp(x)
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f_dd(x):
+        y = f(x)
+        return sp.diff(y, x, 2)
+
+    x = rng.uniform(t, 10)
+
+    # d/dx[sin(x)*exp(x)] = exp(x)*(sin(x) + cos(x))
+    # d2/dx2[sin(x)*exp(x)] = 2*exp(x)*cos(x)
+    ref = 2 * dr.exp(x) * dr.cos(x)
+    assert dr.allclose(f_dd(x), ref)

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -858,3 +858,317 @@ def test31_wrap_backend_preservation(t):
     dr.enable_grad(x)
     y = f(x)
     assert dr.backend_v(y) == dr.backend_v(x)
+
+
+# ---------------------------------------------------------------------------
+#  SymPy wrapper tests (source='drjit', target='sympy')
+# ---------------------------------------------------------------------------
+
+import sys
+
+try:
+    import sympy as sp
+    has_sympy = True
+except ImportError:
+    has_sympy = False
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test32_sympy_quadratic(t):
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return x**2 + 2 * x + 1
+
+    def f_drjit(x):
+        return x**2 + 2 * x + 1
+
+    x = rng.uniform(t, 10)
+    assert dr.allclose(f(x), f_drjit(x))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test33_sympy_trig(t):
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return sp.sin(x) ** 2 + sp.cos(x) ** 2
+
+    def f_drjit(x):
+        return dr.sin(x) ** 2 + dr.cos(x) ** 2
+
+    x = rng.uniform(t, 10)
+    assert dr.allclose(f(x), f_drjit(x))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test34_sympy_output(t):
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return [sp.sin(x), (sp.cos(x), x**2)]
+
+    def f_drjit(x):
+        return [dr.sin(x), (dr.cos(x), x**2)]
+
+    x = rng.uniform(t, 10)
+    assert dr.allclose(f(x), f_drjit(x))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test35_sympy_caching(t):
+    call_count = 0
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        nonlocal call_count
+        call_count += 1
+        return x + y
+
+    f(t(1.0), t(2.0))
+    f(t(3.0), t(4.0))
+    assert call_count == 1
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test36_sympy_matrix_output(t):
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        return sp.Matrix([[x + y, x - y], [x * y, x / y]])
+
+    result = f(t(6.0), t(3.0))
+    assert isinstance(result, list) and len(result) == 2 and len(result[0]) == 2
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test37_sympy_nested(t):
+    @dr.wrap(source="drjit", target="sympy")
+    def inner(x):
+        return x**2
+
+    @dr.wrap(source="drjit", target="sympy")
+    def outer(x):
+        return inner(x) + 1
+
+    assert dr.allclose(outer(t(3.0)), t(10.0))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit,diff")
+def test38_sympy_ad_backward(t):
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return x**2 + 2 * x + 1
+
+    def f_drjit(x):
+        return x**2 + 2 * x + 1
+
+    x = t(3.0)
+    dr.enable_grad(x)
+    dr.backward(f(x))
+    grad_res = dr.grad(x)
+
+    x = t(3.0)
+    dr.enable_grad(x)
+    dr.backward(f_drjit(x))
+    grad_ref = dr.grad(x)
+
+    assert dr.allclose(grad_res, grad_ref)
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit,diff")
+def test39_sympy_grad(t):
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return x**2 + 2 * x + 1
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f_grad(x):
+        y = f(x)
+        return sp.diff(y, x)
+
+    def f_drjit(x):
+        return x**2 + 2 * x + 1
+
+    x = t(3.0)
+    grad_res = f_grad(x)
+
+    x = t(3.0)
+    dr.enable_grad(x)
+    dr.backward(f_drjit(x))
+    grad_ref = dr.grad(x)
+
+    assert dr.allclose(grad_res, grad_ref)
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test40_sympy_promote_vector(t):
+    mod = sys.modules[t.__module__]
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(v):
+        return v.norm()
+
+    def f_drjit(v):
+        return dr.norm(v)
+
+    v = mod.Array3f(1, 2, 3)
+    assert dr.allclose(f(v), f_drjit(v))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test41_sympy_vector_dot(t):
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, b):
+        return a.dot(b)
+
+    def f_drjit(a, b):
+        return dr.dot(a, b)
+
+    a = rng.random(mod.Array3f, (3, 8))
+    b = rng.random(mod.Array3f, (3, 8))
+    assert dr.allclose(f(a, b), f_drjit(a, b))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test42_sympy_promote_arrayXf(t):
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, b):
+        return a.dot(b)
+
+    def f_drjit(a, b):
+        return dr.dot(a, b)
+
+    a = rng.random(mod.ArrayXf, (6, 8))
+    b = rng.random(mod.ArrayXf, (6, 8))
+    assert dr.allclose(f(a, b), f_drjit(a, b))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test43_sympy_promote_matrix(t):
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, b):
+        return a * b
+
+    def f_drjit(a, b):
+        return a @ b
+
+    a = rng.random(mod.Matrix4f, (4, 4, 8))
+    b = rng.random(mod.Matrix4f, (4, 4, 8))
+
+    res = mod.Matrix4f(f(a, b))
+    ref = f_drjit(a, b)
+    assert dr.allclose(res, ref)
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test44_sympy_matrix_vector(t):
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, v):
+        return a * v
+
+    def f_drjit(a, v):
+        return a @ v
+
+    a = rng.random(mod.Matrix4f, (4, 4, 8))
+    v = rng.random(mod.Array4f, (4, 8))
+    assert dr.allclose(f(a, v), f_drjit(a, v))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test45_sympy_kwargs(t):
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        return x + y
+
+    assert dr.allclose(f(x=t(3.0), y=t(4.0)), t(7.0))
+    assert dr.allclose(f(t(3.0), y=t(4.0)), t(7.0))
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test46_sympy_pytree_dict(t):
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return {
+            "sum": x[0]["a"] + x[1]["b"],
+            "prod": x[0]["a"] * x[1]["b"],
+        }
+
+    def f_drjit(x):
+        return {
+            "sum": x[0]["a"] + x[1]["b"],
+            "prod": x[0]["a"] * x[1]["b"],
+        }
+
+    xt = [{"a": t(3.0)}, {"b": t(4.0)}]
+    res = f(xt)
+    ref = f_drjit(xt)
+    assert dr.allclose(res["sum"], ref["sum"])
+    assert dr.allclose(res["prod"], ref["prod"])
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test47_sympy_pytree_nested(t):
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return {"r": (x[0]["a"] + 2 * x[1]["b"][0],)}
+
+    def f_drjit(x):
+        return {"r": (x[0]["a"] + 2 * x[1]["b"][0],)}
+
+    a = rng.uniform(t, 8)
+    b = rng.uniform(t, 8)
+    xt = [{"a": a}, {"b": (b,)}]
+    assert dr.allclose(f(xt)["r"][0], f_drjit(xt)["r"][0])
+
+
+@pytest.mark.skipif(not has_sympy, reason="sympy not available")
+@pytest.test_arrays("float,shape=(*),jit")
+def test48_sympy_pytree_tuple_output(t):
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        return (x + y, {"diff": x - y})
+
+    def f_drjit(x, y):
+        return (x + y, {"diff": x - y})
+
+    x = rng.uniform(t, 8)
+    y = rng.uniform(t, 8)
+    res = f(x, y)
+    ref = f_drjit(x, y)
+    assert dr.allclose(res[0], ref[0])
+    assert dr.allclose(res[1]["diff"], ref[1]["diff"])

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+import sys
 
 import drjit as dr
 import pytest
@@ -858,3 +859,390 @@ def test31_wrap_backend_preservation(t):
     dr.enable_grad(x)
     y = f(x)
     assert dr.backend_v(y) == dr.backend_v(x)
+
+
+# ---------------------------------------------------------------------------
+#  SymPy wrapper tests (source='drjit', target='sympy')
+# ---------------------------------------------------------------------------
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test32_sympy_quadratic(t):
+    """Test that simple equations can be expressed in sympy, and compiled to drjit."""
+    pytest.importorskip("sympy")
+    rng = dr.rng()
+
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return x**2 + 2 * x + 1
+
+    def f_drjit(x):
+        return x**2 + 2 * x + 1
+
+    dr.set_flag(dr.JitFlag.KernelHistory, True)
+    x = rng.uniform(t, 10)
+    assert dr.allclose(f(x), f_drjit(x))
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test33_sympy_trig(t):
+    """Test that dr.wrap can handle builtin sympy functions."""
+    sp = pytest.importorskip("sympy")
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return sp.sin(x) ** 2 + sp.cos(x) ** 2
+
+    def f_drjit(x):
+        return dr.sin(x) ** 2 + dr.cos(x) ** 2
+
+    x = rng.uniform(t, 10)
+    assert dr.allclose(f(x), f_drjit(x))
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test34_sympy_output(t):
+    """dr.wrap should preserve nested list and tuple outputs from SymPy."""
+    sp = pytest.importorskip("sympy")
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return [sp.sin(x), (sp.cos(x), x**2)]
+
+    def f_drjit(x):
+        return [dr.sin(x), (dr.cos(x), x**2)]
+
+    x = rng.uniform(t, 10)
+    assert dr.allclose(f(x), f_drjit(x))
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test35_sympy_caching(t):
+    """dr.wrap should cache the symbolic trace for compatible inputs."""
+    pytest.importorskip("sympy")
+    call_count = 0
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        nonlocal call_count
+        call_count += 1
+        return x + y
+
+    f(t(1.0), t(2.0))
+    f(t(3.0), t(4.0))
+    assert call_count == 1
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test36_sympy_matrix_output(t):
+    """dr.wrap should convert a SymPy matrix into a nested list."""
+    sp = pytest.importorskip("sympy")
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        return sp.Matrix([[x + y, x - y], [x * y, x / y]])
+
+    result = f(t(6.0), t(3.0))
+    assert isinstance(result, list) and len(result) == 2 and len(result[0]) == 2
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test37_sympy_nested(t):
+    """SymPy wrappers should support calls to other SymPy wrappers."""
+    pytest.importorskip("sympy")
+    @dr.wrap(source="drjit", target="sympy")
+    def inner(x):
+        return x**2
+
+    @dr.wrap(source="drjit", target="sympy")
+    def outer(x):
+        return inner(x) + 1
+
+    assert dr.allclose(outer(t(3.0)), t(10.0))
+
+
+@pytest.test_arrays("float,shape=(*),jit,diff")
+def test38_sympy_ad_backward(t):
+    """SymPy wrapper outputs should remain differentiable by Dr.Jit."""
+    pytest.importorskip("sympy")
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return x**2 + 2 * x + 1
+
+    def f_drjit(x):
+        return x**2 + 2 * x + 1
+
+    x = t(3.0)
+    dr.enable_grad(x)
+    dr.backward(f(x))
+    grad_res = dr.grad(x)
+
+    x = t(3.0)
+    dr.enable_grad(x)
+    dr.backward(f_drjit(x))
+    grad_ref = dr.grad(x)
+
+    assert dr.allclose(grad_res, grad_ref)
+
+
+@pytest.test_arrays("float,shape=(*),jit,diff")
+def test39_sympy_grad(t):
+    """Using SymPy's AD system should work inside of dr.wrap."""
+    sp = pytest.importorskip("sympy")
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return x**2 + 2 * x + 1
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f_grad(x):
+        y = f(x)
+        return sp.diff(y, x)
+
+    def f_drjit(x):
+        return x**2 + 2 * x + 1
+
+    x = t(3.0)
+    grad_res = f_grad(x)
+
+    x = t(3.0)
+    dr.enable_grad(x)
+    dr.backward(f_drjit(x))
+    grad_ref = dr.grad(x)
+
+    assert dr.allclose(grad_res, grad_ref)
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test40_sympy_promote_vector(t):
+    """dr.wrap should promote fixed-size vectors to SymPy matrices."""
+    pytest.importorskip("sympy")
+    mod = sys.modules[t.__module__]
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(v):
+        return v.norm()
+
+    def f_drjit(v):
+        return dr.norm(v)
+
+    v = mod.Array3f(1, 2, 3)
+    assert dr.allclose(f(v), f_drjit(v))
+
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test41_sympy_promote_arrayXf(t):
+    """dr.wrap should promote dynamically sized vectors to SymPy matrices."""
+    pytest.importorskip("sympy")
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, b):
+        return a.dot(b)
+
+    def f_drjit(a, b):
+        return dr.dot(a, b)
+
+    a = rng.random(mod.ArrayXf, (6, 8))
+    b = rng.random(mod.ArrayXf, (6, 8))
+    assert dr.allclose(f(a, b), f_drjit(a, b))
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test42_sympy_promote_matrix(t):
+    """SymPy matrix multiplication should match Dr.Jit matrix multiplication."""
+    pytest.importorskip("sympy")
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, b):
+        return a * b
+
+    def f_drjit(a, b):
+        return a @ b
+
+    a = rng.random(mod.Matrix4f, (4, 4, 8))
+    b = rng.random(mod.Matrix4f, (4, 4, 8))
+
+    res = mod.Matrix4f(f(a, b))
+    ref = f_drjit(a, b)
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test43_sympy_matrix_vector(t):
+    """SymPy matrix-vector multiplication should match Dr.Jit."""
+    pytest.importorskip("sympy")
+    mod = sys.modules[t.__module__]
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(a, v):
+        return a * v
+
+    def f_drjit(a, v):
+        return a @ v
+
+    a = rng.random(mod.Matrix4f, (4, 4, 8))
+    v = rng.random(mod.Array4f, (4, 8))
+    assert dr.allclose(f(a, v), f_drjit(a, v))
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test44_sympy_kwargs(t):
+    """SymPy wrappers should accept positional and keyword arguments."""
+    pytest.importorskip("sympy")
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        return x + y
+
+    assert dr.allclose(f(x=t(3.0), y=t(4.0)), t(7.0))
+    assert dr.allclose(f(t(3.0), y=t(4.0)), t(7.0))
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test45_sympy_pytree_dict(t):
+    """SymPy wrappers should preserve dictionaries nested in input PyTrees."""
+    pytest.importorskip("sympy")
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return {
+            "sum": x[0]["a"] + x[1]["b"],
+            "prod": x[0]["a"] * x[1]["b"],
+        }
+
+    def f_drjit(x):
+        return {
+            "sum": x[0]["a"] + x[1]["b"],
+            "prod": x[0]["a"] * x[1]["b"],
+        }
+
+    xt = [{"a": t(3.0)}, {"b": t(4.0)}]
+    res = f(xt)
+    ref = f_drjit(xt)
+    assert dr.allclose(res["sum"], ref["sum"])
+    assert dr.allclose(res["prod"], ref["prod"])
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test46_sympy_pytree_nested(t):
+    """SymPy wrappers should handle deeply nested input and output PyTrees."""
+    pytest.importorskip("sympy")
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return {"r": (x[0]["a"] + 2 * x[1]["b"][0],)}
+
+    def f_drjit(x):
+        return {"r": (x[0]["a"] + 2 * x[1]["b"][0],)}
+
+    a = rng.uniform(t, 8)
+    b = rng.uniform(t, 8)
+    xt = [{"a": a}, {"b": (b,)}]
+    assert dr.allclose(f(xt)["r"][0], f_drjit(xt)["r"][0])
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test47_sympy_pytree_tuple_output(t):
+    """SymPy wrappers should preserve mixed tuple and dictionary outputs."""
+    pytest.importorskip("sympy")
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x, y):
+        return (x + y, {"diff": x - y})
+
+    def f_drjit(x, y):
+        return (x + y, {"diff": x - y})
+
+    x = rng.uniform(t, 8)
+    y = rng.uniform(t, 8)
+    res = f(x, y)
+    ref = f_drjit(x, y)
+    assert dr.allclose(res[0], ref[0])
+    assert dr.allclose(res[1]["diff"], ref[1]["diff"])
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test48_sympy_second_derivative(t):
+    """SymPy should compute higher-order derivatives of wrapped functions."""
+    sp = pytest.importorskip("sympy")
+    rng = dr.rng()
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return sp.sin(x) * sp.exp(x)
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f_dd(x):
+        y = f(x)
+        return sp.diff(y, x, 2)
+
+    x = rng.uniform(t, 10)
+
+    # d/dx[sin(x)*exp(x)] = exp(x)*(sin(x) + cos(x))
+    # d2/dx2[sin(x)*exp(x)] = 2*exp(x)*cos(x)
+    ref = 2 * dr.exp(x) * dr.cos(x)
+    assert dr.allclose(f_dd(x), ref)
+
+
+@pytest.test_arrays("float,shape=(*),jit")
+def test49_sympy_newton_optimization(t):
+    """The 2D Newton optimization example in the documentation should converge."""
+    sp = pytest.importorskip("sympy")
+
+    @dr.wrap(source="drjit", target="sympy")
+    def newton_step(x, y):
+        variables = sp.Matrix([x, y])
+        objective = (x - 1)**2 + 2*(y + 2)**2 + (x + y + 1)**2
+        gradient = sp.Matrix([sp.diff(objective, v) for v in variables])
+        hessian = sp.hessian(objective, variables)
+        step = hessian.inv() * gradient
+        return x - step[0], y - step[1]
+
+    x = t([-2, 0, 4])
+    y = t([3, -1, 2])
+    x, y = newton_step(x, y)
+
+    assert dr.allclose(x, 1)
+    assert dr.allclose(y, -2)
+
+
+@pytest.test_arrays("float32,shape=(*),jit")
+def test50_sympy_math_functions(t):
+    """SymPy math functions should compile to array-valued Dr.Jit operations."""
+    sp = pytest.importorskip("sympy")
+    expm1 = sp.Function("expm1")
+    hypot = sp.Function("hypot")
+    isnan = sp.Function("isnan")
+    log1p = sp.Function("log1p")
+    log2 = sp.Function("log2")
+
+    @dr.wrap(source="drjit", target="sympy")
+    def f(x):
+        return (
+            sp.sinh(x), sp.cosh(x), sp.tanh(x),
+            sp.asinh(x), sp.acosh(x + 1), sp.atanh(x / 2),
+            sp.floor(x), sp.ceiling(x), sp.erf(x), sp.erfc(x),
+            sp.loggamma(x + 1), sp.gamma(x + 1), sp.factorial(x),
+            expm1(x), log1p(x), log2(x),
+            hypot(x, x + 1, x + 2), isnan(x),
+        )
+
+    x = t([0.25, 0.5, 1.25])
+    result = f(x)
+    reference = (
+        dr.sinh(x), dr.cosh(x), dr.tanh(x),
+        dr.asinh(x), dr.acosh(x + 1), dr.atanh(x / 2),
+        dr.floor(x), dr.ceil(x), dr.erf(x), 1 - dr.erf(x),
+        dr.lgamma(x + 1), dr.exp(dr.lgamma(x + 1)),
+        dr.exp(dr.lgamma(x + 1)), dr.exp(x) - 1, dr.log(1 + x),
+        dr.log2(x), dr.hypot(dr.hypot(x, x + 1), x + 2), dr.isnan(x),
+    )
+    assert dr.allclose(result, reference)


### PR DESCRIPTION
This PR adds integration to sympy using the `dr.wrap` decorator.

[SymPy](https://www.sympy.org/en/index.html) is a symbolic expressions engine. This PR adds it as a target for `dr.wrap`, allowing us to compute higher order derivatives (hessians) etc in Dr.Jit. In contrast to other targets for this decorator the SymPy target does not exchange data between the libraries at runtime, but rather traces the symbolic expressions generated by the wrapped function, and compiles it to Dr.Jit. The wrapped function therefore acts like an ordinary Dr.Jit function, while we can use the complicated symbolic operations supported by SymPy. The wrapped functions are restricted to per-lane operations. Inverting a `Matrix4f` inside of this wrapper will generate the necessary code for Dr.Jit to invert the matrix. Calling the function with a Matrix array in Dr.Jit will therefore invert each matrix per SIMD lane.