### PR TITLE
Fix packet scatter to raw pointers

### DIFF
--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1109,10 +1109,9 @@ void scatter(Target &target, const Value &value, const Index &index,
                 // Use the outer static array to select the generic element-wise
                 // fallback; JIT/AD packet scatter requires an array target.
                 using ValueD = std::decay_t<Value>;
-                constexpr bool Supported =
-                    ValueD::Size != Dynamic && !is_jit_v<ValueD>;
+                constexpr bool Supported = !is_dynamic_v<ValueD>;
                 static_assert(Supported,
-                              "Raw-pointer packet scatter requires a statically sized non-JIT value");
+                              "Raw-pointer packet scatter requires a fully statically sized value");
                 if constexpr (Supported) {
                     ValueD::template scatter_packet_<ValueD::Size>(
                         target, value, uint32_array_t<value_t<Value>>(index),
@@ -1147,7 +1146,7 @@ void scatter(Target &target, const Value &value, const Index &index,
 // overload resolution.
 template <typename Target, typename Value, typename Index,
           typename Mask = mask_t<Index>,
-          enable_if_t<std::is_pointer_v<Target>> * = nullptr>
+          enable_if_t<std::is_pointer_v<Target>> = 0>
 void scatter(Target &&target, const Value &value, const Index &index,
              const Mask &mask = true, ReduceMode mode = ReduceMode::Auto) {
     scatter(target, value, index, mask, mode);

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1109,12 +1109,17 @@ void scatter(Target &target, const Value &value, const Index &index,
                 // Use the outer static array to select the generic element-wise
                 // fallback; JIT/AD packet scatter requires an array target.
                 using ValueD = std::decay_t<Value>;
-                static_assert(ValueD::Size != Dynamic,
-                              "Raw-pointer packet scatter requires a statically sized value");
-                if constexpr (ValueD::Size != Dynamic)
+                if constexpr (ValueD::Size == Dynamic) {
+                    static_assert(ValueD::Size != Dynamic,
+                                  "Raw-pointer packet scatter requires a statically sized value");
+                } else if constexpr (is_jit_v<ValueD>) {
+                    static_assert(!is_jit_v<ValueD>,
+                                  "Raw-pointer packet scatter does not support JIT/AD values");
+                } else {
                     ValueD::template scatter_packet_<ValueD::Size>(
                         target, value, uint32_array_t<value_t<Value>>(index),
                         mask, mode);
+                }
             }
         }
     } else if constexpr (is_drjit_struct_v<Value>) {

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1109,8 +1109,9 @@ void scatter(Target &target, const Value &value, const Index &index,
                 using ValueD = std::decay_t<Value>;
                 static_assert(ValueD::Size != Dynamic,
                               "Raw-pointer packet scatter requires a statically sized value");
-                ValueD::template scatter_packet_<ValueD::Size>(
-                    target, value, index, mask, mode);
+                if constexpr (ValueD::Size != Dynamic)
+                    ValueD::template scatter_packet_<ValueD::Size>(
+                        target, value, index, mask, mode);
             }
         }
     } else if constexpr (is_drjit_struct_v<Value>) {

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1107,15 +1107,21 @@ void scatter(Target &target, const Value &value, const Index &index,
                     target, value, uint32_array_t<value_t<Value>>(index), mask, mode);
             } else {
                 // Use the outer static array to select the generic element-wise
-                // fallback; JIT/AD packet scatter requires an array target.
+                // fallback. Nested native dynamic elements recurse through
+                // scatter_(), while JIT/AD elements require an array target.
                 using ValueD = std::decay_t<Value>;
-                constexpr bool Supported = !is_dynamic_v<ValueD>;
-                static_assert(Supported,
-                              "Raw-pointer packet scatter requires a fully statically sized value");
-                if constexpr (Supported) {
+                constexpr bool StaticOuter = ValueD::Size != Dynamic;
+                constexpr bool NativeValue =
+                    !is_jit_v<ValueD> && !is_diff_v<ValueD>;
+                if constexpr (StaticOuter && NativeValue) {
+                    // Keep the index depth so each nested packet layer applies
+                    // its own flattening stride during recursive dispatch.
                     ValueD::template scatter_packet_<ValueD::Size>(
-                        target, value, uint32_array_t<value_t<Value>>(index),
+                        target, value, uint32_array_t<Index>(index),
                         mask, mode);
+                } else {
+                    static_assert(detail::false_v<ValueD>,
+                                  "Raw-pointer packet scatter requires a statically sized non-JIT/AD value");
                 }
             }
         }

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1109,13 +1109,11 @@ void scatter(Target &target, const Value &value, const Index &index,
                 // Use the outer static array to select the generic element-wise
                 // fallback; JIT/AD packet scatter requires an array target.
                 using ValueD = std::decay_t<Value>;
-                if constexpr (ValueD::Size == Dynamic) {
-                    static_assert(ValueD::Size != Dynamic,
-                                  "Raw-pointer packet scatter requires a statically sized value");
-                } else if constexpr (is_jit_v<ValueD>) {
-                    static_assert(!is_jit_v<ValueD>,
-                                  "Raw-pointer packet scatter does not support JIT/AD values");
-                } else {
+                constexpr bool Supported =
+                    ValueD::Size != Dynamic && !is_jit_v<ValueD>;
+                static_assert(Supported,
+                              "Raw-pointer packet scatter requires a statically sized non-JIT value");
+                if constexpr (Supported) {
                     ValueD::template scatter_packet_<ValueD::Size>(
                         target, value, uint32_array_t<value_t<Value>>(index),
                         mask, mode);
@@ -1145,6 +1143,8 @@ void scatter(Target &target, const Value &value, const Index &index,
     }
 }
 
+// Accept pointer prvalues such as buffer.data() without changing lvalue
+// overload resolution.
 template <typename Target, typename Value, typename Index,
           typename Mask = mask_t<Index>,
           enable_if_t<std::is_pointer_v<Target>> * = nullptr>

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1106,6 +1106,8 @@ void scatter(Target &target, const Value &value, const Index &index,
                 TargetD::template scatter_packet_<Value::Size>(
                     target, value, uint32_array_t<value_t<Value>>(index), mask, mode);
             } else {
+                // Use the outer static array to select the generic element-wise
+                // fallback; JIT/AD packet scatter requires an array target.
                 using ValueD = std::decay_t<Value>;
                 static_assert(ValueD::Size != Dynamic,
                               "Raw-pointer packet scatter requires a statically sized value");

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1069,8 +1069,27 @@ Target gather(Source &&source, const Index &index, const Mask &mask_ = true,
     (void) mode;
 }
 
+namespace detail {
+    template <typename Target, typename Index>
+    Target broadcast_index(const Index &index) {
+        using Scalar = scalar_t<Index>;
+        static_assert(Target::Size != Dynamic);
+
+        Index scaled = index * Scalar(Target::Size);
+        Target result;
+        for (size_t i = 0; i < Target::Size; ++i) {
+            if constexpr (depth_v<Target> == depth_v<Index> + 1)
+                result.entry(i) = scaled + Scalar(i);
+            else
+                result.entry(i) =
+                    broadcast_index<value_t<Target>>(scaled + Scalar(i));
+        }
+        return result;
+    }
+}
+
 template <typename Target, typename Value, typename Index, typename Mask = mask_t<Index>>
-void scatter(Target &target, const Value &value, const Index &index,
+void scatter(Target &&target, const Value &value, const Index &index,
              const Mask &mask_ = true, ReduceMode mode = ReduceMode::Auto) {
     DRJIT_MARK_USED(mode);
     // Broadcast mask to match shape of Index
@@ -1101,8 +1120,15 @@ void scatter(Target &target, const Value &value, const Index &index,
         if constexpr (depth_v<Value> == depth_v<Index>) {
             value.scatter_(target, uint32_array_t<Value>(index), mask, mode);
         } else {
-            Target::template scatter_packet_<Value::Size>(
-                target, value, uint32_array_t<value_t<Value>>(index), mask, mode);
+            if constexpr (is_array_v<Target>) {
+                using TargetD = std::decay_t<Target>;
+                TargetD::template scatter_packet_<Value::Size>(
+                    target, value, uint32_array_t<value_t<Value>>(index), mask, mode);
+            } else {
+                using TargetIndex = replace_scalar_t<Value, scalar_t<Index>>;
+                scatter(target, value,
+                        detail::broadcast_index<TargetIndex>(index), mask, mode);
+            }
         }
     } else if constexpr (is_drjit_struct_v<Value>) {
         static_assert(is_drjit_struct_v<Target>,

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1113,7 +1113,8 @@ void scatter(Target &target, const Value &value, const Index &index,
                               "Raw-pointer packet scatter requires a statically sized value");
                 if constexpr (ValueD::Size != Dynamic)
                     ValueD::template scatter_packet_<ValueD::Size>(
-                        target, value, index, mask, mode);
+                        target, value, uint32_array_t<value_t<Value>>(index),
+                        mask, mode);
             }
         }
     } else if constexpr (is_drjit_struct_v<Value>) {

--- a/include/drjit/array_router.h
+++ b/include/drjit/array_router.h
@@ -1069,27 +1069,8 @@ Target gather(Source &&source, const Index &index, const Mask &mask_ = true,
     (void) mode;
 }
 
-namespace detail {
-    template <typename Target, typename Index>
-    Target broadcast_index(const Index &index) {
-        using Scalar = scalar_t<Index>;
-        static_assert(Target::Size != Dynamic);
-
-        Index scaled = index * Scalar(Target::Size);
-        Target result;
-        for (size_t i = 0; i < Target::Size; ++i) {
-            if constexpr (depth_v<Target> == depth_v<Index> + 1)
-                result.entry(i) = scaled + Scalar(i);
-            else
-                result.entry(i) =
-                    broadcast_index<value_t<Target>>(scaled + Scalar(i));
-        }
-        return result;
-    }
-}
-
 template <typename Target, typename Value, typename Index, typename Mask = mask_t<Index>>
-void scatter(Target &&target, const Value &value, const Index &index,
+void scatter(Target &target, const Value &value, const Index &index,
              const Mask &mask_ = true, ReduceMode mode = ReduceMode::Auto) {
     DRJIT_MARK_USED(mode);
     // Broadcast mask to match shape of Index
@@ -1125,9 +1106,11 @@ void scatter(Target &&target, const Value &value, const Index &index,
                 TargetD::template scatter_packet_<Value::Size>(
                     target, value, uint32_array_t<value_t<Value>>(index), mask, mode);
             } else {
-                using TargetIndex = replace_scalar_t<Value, scalar_t<Index>>;
-                scatter(target, value,
-                        detail::broadcast_index<TargetIndex>(index), mask, mode);
+                using ValueD = std::decay_t<Value>;
+                static_assert(ValueD::Size != Dynamic,
+                              "Raw-pointer packet scatter requires a statically sized value");
+                ValueD::template scatter_packet_<ValueD::Size>(
+                    target, value, index, mask, mode);
             }
         }
     } else if constexpr (is_drjit_struct_v<Value>) {
@@ -1151,6 +1134,14 @@ void scatter(Target &&target, const Value &value, const Index &index,
                 ((Value *) target)[index] = value;
         }
     }
+}
+
+template <typename Target, typename Value, typename Index,
+          typename Mask = mask_t<Index>,
+          enable_if_t<std::is_pointer_v<Target>> * = nullptr>
+void scatter(Target &&target, const Value &value, const Index &index,
+             const Mask &mask = true, ReduceMode mode = ReduceMode::Auto) {
+    scatter(target, value, index, mask, mode);
 }
 
 template <typename Index>

--- a/tests/memop_ext.cpp
+++ b/tests/memop_ext.cpp
@@ -57,13 +57,13 @@ NB_MODULE(memop_ext, m) {
 
     m.def("packet_scatter_ptr", []() {
         std::array<float, 6> target { };
-        dr::scatter(target.data(), dr::Packet<float, 3>(1.f, 2.f, 3.f), 1u);
+        dr::scatter(target.data(), dr::Packet<float, 3>(1.f, 2.f, 3.f), int32_t(1));
         return target;
     });
 
     m.def("nested_packet_scatter_ptr", []() {
         using FloatP = dr::Packet<float, 4>;
-        using UInt32P = dr::Packet<uint32_t, 4>;
+        using Int32P = dr::Packet<int32_t, 4>;
         using Vector4fP = dr::Array<FloatP, 4>;
 
         std::array<float, 16> target { };
@@ -73,7 +73,7 @@ NB_MODULE(memop_ext, m) {
             FloatP(9.f, 10.f, 11.f, 12.f),
             FloatP(13.f, 14.f, 15.f, 16.f));
 
-        dr::scatter(target.data(), value, UInt32P(0u, 1u, 2u, 3u));
+        dr::scatter(target.data(), value, Int32P(0, 1, 2, 3));
         return target;
     });
 

--- a/tests/memop_ext.cpp
+++ b/tests/memop_ext.cpp
@@ -35,7 +35,7 @@ template <JitBackend Backend> void bind(nb::module_ m) {
     });
 
     m.def("packet_scatter_assign", [](Float target, Float v0, Float v1, UInt32 index) {
-        dr::scatter(target, Array2f(v0, v1), index);
+        dr::scatter<Float>(target, Array2f(v0, v1), index);
         return target;
     });
 
@@ -58,6 +58,22 @@ NB_MODULE(memop_ext, m) {
     m.def("packet_scatter_ptr", []() {
         std::array<float, 6> target { };
         dr::scatter(target.data(), dr::Packet<float, 3>(1.f, 2.f, 3.f), 1u);
+        return target;
+    });
+
+    m.def("nested_packet_scatter_ptr", []() {
+        using FloatP = dr::Packet<float, 4>;
+        using UInt32P = dr::Packet<uint32_t, 4>;
+        using Vector4fP = dr::Array<FloatP, 4>;
+
+        std::array<float, 16> target { };
+        Vector4fP value(
+            FloatP(1.f, 2.f, 3.f, 4.f),
+            FloatP(5.f, 6.f, 7.f, 8.f),
+            FloatP(9.f, 10.f, 11.f, 12.f),
+            FloatP(13.f, 14.f, 15.f, 16.f));
+
+        dr::scatter(target.data(), value, UInt32P(0u, 1u, 2u, 3u));
         return target;
     });
 

--- a/tests/memop_ext.cpp
+++ b/tests/memop_ext.cpp
@@ -77,6 +77,41 @@ NB_MODULE(memop_ext, m) {
         return target;
     });
 
+    m.def("deep_nested_packet_scatter_ptr", []() {
+        using FloatP = dr::Packet<float, 4>;
+        using Int32P = dr::Packet<int32_t, 4>;
+        using Vector2fP = dr::Array<FloatP, 2>;
+        using Matrix2fP = dr::Array<Vector2fP, 2>;
+
+        std::array<float, 16> target { };
+        Matrix2fP value(
+            Vector2fP(FloatP(1.f, 5.f, 9.f, 13.f),
+                      FloatP(2.f, 6.f, 10.f, 14.f)),
+            Vector2fP(FloatP(3.f, 7.f, 11.f, 15.f),
+                      FloatP(4.f, 8.f, 12.f, 16.f)));
+
+        dr::scatter(target.data(), value, Int32P(0, 1, 2, 3));
+        return target;
+    });
+
+    m.def("nested_dynamic_scatter_ptr", []() {
+        using FloatD = dr::DynamicArray<float>;
+        using UInt32D = dr::DynamicArray<uint32_t>;
+        using Vector3fD = dr::Array<FloatD, 3>;
+
+        FloatD x = dr::empty<FloatD>(2),
+               y = dr::empty<FloatD>(2),
+               z = dr::empty<FloatD>(2);
+        x.entry(0) = 1.f; x.entry(1) = 4.f;
+        y.entry(0) = 2.f; y.entry(1) = 5.f;
+        z.entry(0) = 3.f; z.entry(1) = 6.f;
+
+        UInt32D index = dr::arange<UInt32D>(2);
+        std::array<float, 6> target { };
+        dr::scatter(target.data(), Vector3fD(x, y, z), index);
+        return target;
+    });
+
 #if defined(DRJIT_ENABLE_LLVM)
     bind<JitBackend::LLVM>(m.def_submodule("llvm"));
 #endif

--- a/tests/memop_ext.cpp
+++ b/tests/memop_ext.cpp
@@ -1,7 +1,9 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
 #include <nanobind/stl/pair.h>
 #include <drjit/python.h>
 #include <drjit/autodiff.h>
+#include <drjit/packet.h>
 #include <drjit/util.h>
 
 namespace nb = nanobind;
@@ -32,6 +34,11 @@ template <JitBackend Backend> void bind(nb::module_ m) {
         return target;
     });
 
+    m.def("packet_scatter_assign", [](Float target, Float v0, Float v1, UInt32 index) {
+        dr::scatter(target, Array2f(v0, v1), index);
+        return target;
+    });
+
     m.def("packet_gather_dynamic", [](Float source, UInt32 index) -> Pair {
         Float out[2];
         dr::gather_packet_dynamic(2, source, index, out, true);
@@ -47,6 +54,12 @@ template <JitBackend Backend> void bind(nb::module_ m) {
 
 NB_MODULE(memop_ext, m) {
     nb::module_::import_("drjit");
+
+    m.def("packet_scatter_ptr", []() {
+        std::array<float, 6> target { };
+        dr::scatter(target.data(), dr::Packet<float, 3>(1.f, 2.f, 3.f), 1u);
+        return target;
+    });
 
 #if defined(DRJIT_ENABLE_LLVM)
     bind<JitBackend::LLVM>(m.def_submodule("llvm"));

--- a/tests/test_memop_ext.py
+++ b/tests/test_memop_ext.py
@@ -97,8 +97,26 @@ def test04_nested_packet_scatter_ptr():
     ]
 
 
+def test05_deep_nested_packet_scatter_ptr():
+    with dr.detail.scoped_rtld_deepbind():
+        pkg = pytest.importorskip("memop_ext")
+
+    result = pkg.deep_nested_packet_scatter_ptr()
+
+    assert list(result) == list(range(1, 17))
+
+
+def test06_nested_dynamic_scatter_ptr():
+    with dr.detail.scoped_rtld_deepbind():
+        pkg = pytest.importorskip("memop_ext")
+
+    result = pkg.nested_dynamic_scatter_ptr()
+
+    assert list(result) == [1, 2, 3, 4, 5, 6]
+
+
 @pytest.test_arrays('float32,is_diff,shape=(*)')
-def test05_packet_scatter_assign(t):
+def test07_packet_scatter_assign(t):
     pkg = get_pkg(t)
     UInt32 = sys.modules[t.__module__].UInt32
     target = dr.zeros(t, 4)

--- a/tests/test_memop_ext.py
+++ b/tests/test_memop_ext.py
@@ -72,3 +72,24 @@ def test02_scatter(t, fn, packet):
     assert dr.allclose(dr.grad(target), dr.grad(target_r))
     for v, v_r in zip(vals, vals_r):
         assert dr.allclose(dr.grad(v), dr.grad(v_r))
+
+
+def test03_packet_scatter_ptr():
+    with dr.detail.scoped_rtld_deepbind():
+        pkg = pytest.importorskip("memop_ext")
+
+    result = pkg.packet_scatter_ptr()
+
+    assert list(result) == [0, 0, 0, 1, 2, 3]
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test04_packet_scatter_assign(t):
+    pkg = get_pkg(t)
+    UInt32 = sys.modules[t.__module__].UInt32
+    target = dr.zeros(t, 4)
+    index = UInt32(0, 1)
+
+    result = pkg.packet_scatter_assign(target, t(10, 20), t(30, 40), index)
+
+    assert dr.allclose(result, t(10, 30, 20, 40))

--- a/tests/test_memop_ext.py
+++ b/tests/test_memop_ext.py
@@ -83,8 +83,22 @@ def test03_packet_scatter_ptr():
     assert list(result) == [0, 0, 0, 1, 2, 3]
 
 
+def test04_nested_packet_scatter_ptr():
+    with dr.detail.scoped_rtld_deepbind():
+        pkg = pytest.importorskip("memop_ext")
+
+    result = pkg.nested_packet_scatter_ptr()
+
+    assert list(result) == [
+        1, 5, 9, 13,
+        2, 6, 10, 14,
+        3, 7, 11, 15,
+        4, 8, 12, 16,
+    ]
+
+
 @pytest.test_arrays('float32,is_diff,shape=(*)')
-def test04_packet_scatter_assign(t):
+def test05_packet_scatter_assign(t):
     pkg = get_pkg(t)
     UInt32 = sys.modules[t.__module__].UInt32
     target = dr.zeros(t, 4)


### PR DESCRIPTION
## Motivation

`dr::scatter()` accepts raw-pointer targets, but packet values currently try to call `scatter_packet_` on the pointer type. Pointer expressions such as `.data()` also cannot bind to the existing lvalue target parameter. This prevents [Momentum's rasterizer](https://github.com/facebookresearch/momentum/blob/v0.1.114/momentum/rasterizer/image.cpp#L166) from building.

conda-forge currently carries [a patch for this behavior](https://github.com/conda-forge/drjit-cpp-feedstock/blob/9a731565e61ff8d4373c79715ea59a606a05e2d2/recipe/patches/drjit/0004-Fix-scatter-for-raw-pointer-target.patch). It can be removed after this fix is included in a Dr.Jit release.

## Changes

- Preserve the existing lvalue overload and add a constrained overload for pointer expressions.
- Dispatch raw-pointer packet scatters through the outer static array, selecting the generic element-wise fallback; JIT/AD specializations require an array target.
- Normalize scalar and SIMD indices to unsigned 32-bit values without changing their nesting depth, so each recursive packet layer contributes its flattening stride.
- Require a static native outer packet with one clear compile-time diagnostic, without instantiating pointer-incompatible overloads, while preserving native nested `DynamicArray` recursion.
- Cover padded, nested, and deeply nested packet layouts, native nested `DynamicArray` values, signed indices, and explicit-template lvalue calls.

## Testing

- Fresh GCC 15/CMake build: the extension compiled and the four focused raw-pointer packet tests passed, covering scalar, nested, deeply nested, and native nested `DynamicArray` values.
- Standalone scalar, masked, nested, and signed-index packet scatter probes passed.
- A depth-three packet value with a depth-one SIMD index produces `[1, ..., 16]`, confirming recursive flattening without collisions.
- Native nested `DynamicArray` packet scatter produces `[1, 2, 3, 4, 5, 6]`; dynamically sized outer values and JIT/AD packet values fail with only the intended unsupported-value diagnostic.
- The previous vendored broadcast fallback also supports native nested `DynamicArray` values but fails to compile for static arrays containing JIT/AD elements; Momentum's raw-pointer callers use native fixed-size packets.
- `tests/test_call_ext.py`: 128 passed
- Unpatched Dr.Jit reproduces Momentum rasterizer failures at both pointer-expression and packet-dispatch call sites.
- With this change, Momentum's rasterizer and pymomentum renderer build, and `pymomentum/test/test_renderer.py` passes all 8 tests.
- `python -m py_compile tests/test_memop_ext.py`
- `git diff --check`
