### PR TITLE
Create the auto stub output directory before generation

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -288,7 +288,8 @@ if (NOT (DRJIT_SANITIZE_ASAN OR DRJIT_SANITIZE_UBSAN))
       ${DRJIT_PYTHON_DST_DIR}/auto/__init__.py
       ${DRJIT_PYTHON_DST_DIR}/auto/ad.py
 
-    COMMAND cmake -E touch
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DRJIT_PYTHON_DST_DIR}/auto
+    COMMAND ${CMAKE_COMMAND} -E touch
       ${DRJIT_PYTHON_DST_DIR}/auto/py.typed
       ${DRJIT_PYTHON_DST_DIR}/auto/__init__.py
       ${DRJIT_PYTHON_DST_DIR}/auto/ad.py


### PR DESCRIPTION
## Motivation

`drjit/auto` contains generated files and is not present in the source tree. If that output directory is absent when `drjit-auto-stub` is rebuilt, `cmake -E touch` fails because it cannot create parent directories.

This corresponds to conda-forge's [directory-creation patch](https://github.com/conda-forge/drjit-cpp-feedstock/blob/15bc7e077faecf9097ca897dea4252fb06bc6b17/recipe/patches/drjit/0003-Make-directory-before-creating-files.patch), which can be removed after this change is released.

## Change

Create `${DRJIT_PYTHON_DST_DIR}/auto` with `${CMAKE_COMMAND}` before generating files in it.

## Testing

- Removed `build/drjit/auto` and reproduced the current `cmake -E touch` failure with Unix Makefiles.
- Rebuilt `drjit-auto-stub` successfully with this change using Unix Makefiles and Ninja.
- Verified the generated files exist and `drjit.auto` imports.
- `git diff --check`