### PR TITLE
Fix product reduction gradient when an element is zero

### DIFF
--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -2198,6 +2198,22 @@ struct BlockReduceEdge : Special {
         }
     }
 
+    JitVar mul_weight(size_t size) const {
+        Index i0 = m_value_in.index();
+        JitVar z = scalar(i0, 0.0),
+               o = scalar(i0, 1.0),
+               n_zero = dr::block_sum(dr::select(m_value_in == z, o, z),
+                                      m_block_size, m_symbolic),
+               nz_prod = dr::block_reduce(ReduceOp::Mul,
+                                          dr::select(m_value_in == z, o, m_value_in),
+                                          m_block_size, m_symbolic),
+               w_zero = dr::select(n_zero == o, nz_prod, z);
+
+        return dr::select(
+            m_value_in == z, dr::repeat(w_zero, m_block_size, size),
+            dr::repeat(m_value_out, m_block_size, size) / m_value_in);
+    }
+
     void forward(const ADVariable *source, ADVariable *target) override {
         JitVar source_grad = source->grad;
 
@@ -2211,9 +2227,8 @@ struct BlockReduceEdge : Special {
                 break;
 
             case ReduceOp::Mul:
-                result = dr::block_sum(
-                    source_grad / m_value_in,
-                    m_block_size, m_symbolic) * m_value_out;
+                result = dr::block_sum(source_grad * mul_weight(source->size),
+                                       m_block_size, m_symbolic);
                 break;
 
             case ReduceOp::Min:
@@ -2245,7 +2260,8 @@ struct BlockReduceEdge : Special {
                 break;
 
             case ReduceOp::Mul:
-                result = dr::repeat(target_grad * m_value_out, m_block_size, source->size) / m_value_in;
+                result = dr::repeat(target_grad, m_block_size, source->size) *
+                         mul_weight(source->size);
                 break;
 
             case ReduceOp::Min:
@@ -2914,7 +2930,15 @@ Index ad_var_reduce(JitBackend backend, VarType vt, ReduceOp op, Index i0) {
             case ReduceOp::Mul: {
                     JitVar v0 = JitVar::borrow(jit_index(i0)),
                            z  = scalar(i0, 0.0),
-                           w0 = dr::select(v0 == z, z, result / v0);
+                           o  = scalar(i0, 1.0),
+                           n_zero = JitVar::steal(jit_var_reduce(
+                               backend, vt, ReduceOp::Add,
+                               dr::select(v0 == z, o, z).index())),
+                           nz_prod = JitVar::steal(jit_var_reduce(
+                               backend, vt, ReduceOp::Mul,
+                               dr::select(v0 == z, o, v0).index())),
+                           w_zero = dr::select(n_zero == o, nz_prod, z),
+                           w0 = dr::select(v0 == z, w_zero, result / v0);
                     return ad_var_new("prod", std::move(result),
                                       Arg(i0, std::move(w0)));
                 }

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -620,6 +620,24 @@ def test027_prod(t):
     assert len(y) == 1 and dr.allclose(y[0], 80)
     assert dr.allclose(dr.grad(x), [80, 40, 16, 10])
 
+    x = t(2, 0, 4)
+    dr.enable_grad(x)
+    y = dr.prod(x)
+    dr.backward(y)
+    assert dr.allclose(y[0], 0)
+    assert dr.allclose(dr.grad(x), [0, 8, 0])
+
+    x = t(0, 3, 0)
+    dr.enable_grad(x)
+    dr.backward(dr.prod(x))
+    assert dr.allclose(dr.grad(x), [0, 0, 0])
+
+    x = t(2, 0, 4)
+    dr.enable_grad(x)
+    y = dr.prod(x)
+    dr.forward(x)
+    assert dr.allclose(dr.grad(y), 8)
+
 
 @pytest.test_arrays('is_diff,float,shape=(*)')
 def test028_max_bwd(t):
@@ -1939,6 +1957,13 @@ def test122_block_mul_fwd(t):
     assert dr.all(y == [2, 12, 30])
     assert dr.all(y.grad == [40, 240, 600])
 
+    x = t(2, 0, 4, 0, 0, 5)
+    dr.enable_grad(x)
+    y = dr.block_reduce(dr.ReduceOp.Mul, x, 3)
+    x.grad = [1, 1, 1, 1, 1, 1]
+    dr.forward_to(y)
+    assert dr.all(y.grad == [8, 0])
+
 
 @pytest.test_arrays('is_diff,float32,shape=(*)')
 def test123_block_mul_bwd(t):
@@ -1948,6 +1973,13 @@ def test123_block_mul_bwd(t):
     y.grad = [1, 10, 100]
     dr.backward_to(x)
     assert dr.all(x.grad == [2, 1, 40, 30, 600, 500])
+
+    x = t(2, 0, 4, 0, 0, 5)
+    dr.enable_grad(x)
+    y = dr.block_reduce(dr.ReduceOp.Mul, x, 3)
+    y.grad = [1, 1]
+    dr.backward_to(x)
+    assert dr.all(x.grad == [0, 8, 0, 0, 0, 0])
 
 
 @pytest.mark.parametrize("enabled", [True, False])


### PR DESCRIPTION
The gradient of a product should be the product of the other entries, but we
computed it as `result / value`, which breaks when an entry is zero. 
`dr.prod` caught the divide by zero and returned 0, which is the wrong answer: for
`[2, 0, 4]` the gradient should be `[0, 8, 0]` and previous result was `[0, 0, 0]`. 

The axis/block version didn't check at all and returned NaN.

The cost is two extra reductions in the backward pass, so a product backward is about 3x slower:

| backend | op | N | before | after |
|---------|----------------|-----|----------|----------|
| LLVM    | `prod`         | 16M | 3.8 ms   | 13.0 ms  |
| LLVM    | `block_reduce` | 16M | 6.0 ms   | 13.0 ms  |
| CUDA    | `prod`         | 16M | 0.044 ms | 0.135 ms |
| CUDA    | `block_reduce` | 16M | 0.090 ms | 0.314 ms |

That could be brought back to a single pass by combining the two reductions, but
it needs a new reduction primitive in drjit-core, which felt like too much for
this one fix. I am happy to add that if needed.

If the slowdown isn't worth it I am happy to leave the gradient approximate and
just guard the block version so it returns 0 instead of NaN.