### PR TITLE
Keep AD variables whose derivative evaluates to zero

### DIFF
--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -1111,12 +1111,16 @@ DRJIT_NOINLINE Index ad_var_new_impl(const char *label, JitVar &&result,
     }
 
     EdgeIndex edge_index = 0;
+    bool has_diff_input = false;
 
     for (size_t i = 0; i < N; ++i) {
         ADIndex source = args[i].ad_index;
 
         if (!source)
             continue;
+
+        // At least one operand is attached to the AD graph
+        has_diff_input = true;
 
         if constexpr (!std::is_same_v<ArgType, SpecialArg>) {
             if (jit_var_is_zero_literal(args[i].weight.index())) {
@@ -1146,10 +1150,16 @@ DRJIT_NOINLINE Index ad_var_new_impl(const char *label, JitVar &&result,
         v_source->next_fwd = edge_index_new;
     }
 
+    /* An operation can have differentiable operands and still end up without
+       any edges, namely when every weight turned out to be a zero literal.
+       Keep the variable in that case: a derivative of zero is not the same
+       thing as not being tracked. Dropping it would make the result look like
+       a variable that was never attached to the AD graph, and drjit.backward()
+       would then wrongly report that its argument does not depend on the
+       input being differentiated. */
     if constexpr (N > 0) {
-        if (!edge_index) {
-            // All edges were pruned, don't create the node after all
-            ad_trace("ad_var_new(a%u): all edges pruned, removing variable.", ad_index);
+        if (!edge_index && !has_diff_input) {
+            ad_trace("ad_var_new(a%u): no differentiable input, removing variable.", ad_index);
             ad_free(ad_index, var);
             return result.release();
         }

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -2175,3 +2175,16 @@ def test138_relative_grad(t):
     assert dr.allclose(y_replaced, dr.ones_like(y))
     dr.backward(y_replaced)
     assert dr.allclose(dr.grad(x), 2 * x / dr.square(x))
+
+@pytest.test_arrays('is_diff,float,shape=(*)')
+def test139_zero_derivative_stays_attached(t):
+    # A derivative that works out to zero should still stay in the AD graph.
+    # Otherwise it looks like a variable that was never attached, and
+    # dr.backward() wrongly complains about its argument.
+    with dr.scoped_set_flag(dr.JitFlag.SymbolicCalls, True):
+        a, b = t(1.0), t(1.0)
+        dr.enable_grad(a)
+        loss = dr.square(a - b)  # d/da is 2*(a-b), which is 0 here
+        assert dr.grad_enabled(loss)
+        dr.backward(loss)
+        assert dr.allclose(dr.grad(a), 0.0)


### PR DESCRIPTION
Follow-up to my NEON PR #531.

I was looking at #517. The error turned out to have nothing to do with `dr.square`, and nothing to do with symbolic calls. It comes from the AD layer.

### What happens

`ad_var_new()` skips an edge when its weight is a zero literal. If all the edges of an operation get skipped, the AD variable is thrown away:

```cpp
if constexpr (N > 0) {
    if (!edge_index) {
        // All edges were pruned, don't create the node after all
        ad_free(ad_index, var);
        return result.release();
    }
}
```

After that the result has no AD index at all, so it looks the same as a variable where nobody called `dr.enable_grad()`. `check_grad_enabled()` then sees `grad_enabled() == false` and raises "the argument does not depend on the input variable(s) being differentiated", even though the program is fine and the gradient is simply zero.

The annoying part is that this depends on the values at runtime, so the same code fails for one input and works for another:

```python
import drjit as dr
from drjit.llvm.ad import Float

dr.set_flag(dr.JitFlag.SymbolicCalls, True)
a, b = Float(1.0), Float(1.0)
dr.enable_grad(a)
loss = dr.square(a - b)   # a - b becomes a literal 0, so the weight 2*(a-b) is a zero literal
dr.backward(loss)         # RuntimeError, even though d(loss)/da really is 0
```

With `Float(1.0), Float(3.0)` the same code runs fine.

This also explains the `SymbolicCalls` part of the issue. That flag only decides whether the check inside `check_grad_enabled()` runs at all (it was added in 4fbd8d0d). It does not change the AD graph. `grad_enabled(loss)` is `False` either way.

### The change

Throw the variable away only if the operation had no differentiable input to begin with. I did not touch the edge pruning itself, so an operation whose derivative is zero stays in the graph and just does not propagate anything.

### What I tested

Rebased on current master and re-checked everything on macOS arm64 (LLVM and Metal backends):

- Full test suite: 14258 passed, 0 failed.
- The new test fails on master and passes with this change. On this machine that is `Float`, `Float16` and `Float64` for LLVM and Metal. I also checked CUDA separately on a T4, where the unpatched build fails all three `drjit.cuda.ad` variants.
- Normal AD code is not affected. The number of live AD variables is the same with and without the change: 601 and 6001 for chains of 200 and 2000 operations.
- The extra nodes only show up in the literal zero case. A loop of `dr.square(a - b)` with literal operands keeps 2 AD variables per iteration where master keeps none.

### One open question

I am not sure this is the trade off you want. Keeping these nodes costs memory in exactly the places the pruning was written for. The other option is to leave the AD layer alone and make the check in `check_grad_enabled()` less strict instead. I am happy to redo it that way if you prefer, or to add a changelog entry.

I mostly work on C++ and SIMD performance and I am still learning the JIT and autodiff internals, so I may be missing something here.

