### PR TITLE
Rewrite of the `@dr.freeze` frontend

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ def _class_members(name):
         else:
             continue
         # Keep ``__init__`` and operator dunders (``__add__`` etc.), but drop
-        # private helpers such as ``_traverse_1_cb_ro``.
+        # private helpers such as ``_traverse_cb``.
         if member.startswith("_") and not (
             member.startswith("__") and member.endswith("__")
         ):

--- a/docs/freeze.rst
+++ b/docs/freeze.rst
@@ -885,18 +885,11 @@ traversable.
          "x": Float
       }
 
-Finally, C++ classes may additionally implement the ``TraversableBase`` class
-to make them traversable. Python classes, inheriting from these classes through
-trampolines are automatically traversed. This is useful when implementing your
-own subclasses with indirect function calls.
-
-.. code-block:: python
-
-   # If BSDF is a traversable trampoline class,
-   # then member variables of MyClass will also be traversed.
-   class MyClass(mi.BSDF):
-      x: Float
-
+Finally, C++ classes may additionally inherit from ``drjit::TraversableBase``
+and list their members using the ``DR_TRAVERSE_CB`` macro to make them
+traversable. For C++ types subclassed in Python, Dr.Jit will explore both
+members listed via ``DR_TRAVERSE_CB`` and members in the Python instance
+dictionary.
 
 Output construction
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/freeze.rst
+++ b/docs/freeze.rst
@@ -284,9 +284,18 @@ Watch out for following pitfalls when using :py:func:`@dr.freeze <freeze>` decor
 Implicit inputs
 ~~~~~~~~~~~~~~~
 
-A class can hold JIT arrays as members, and its methods can use them. Likewise,
-a function can access variables of the outer scope (closures). These types of
-implicit inputs to a frozen function are generally not supported:
+A frozen function may read more than its arguments: global variables,
+variables of an enclosing scope (closures), and the members of an object whose
+method is frozen. The values of the global and closure variables that the
+function itself reads are captured on every call and become part of the
+input, so that a change of such a variable is detected. This includes the
+bodies written inside the function, such as comprehensions, generator
+expressions, lambdas and nested functions. The members of the object of a
+frozen method are visible when the object is a valid :ref:`PyTree <pytrees>`
+(a dataclass, a class with a ``DRJIT_STRUCT`` annotation, or a traversable C++
+object), since ``self`` is an ordinary argument in that case.
+
+Other implicit inputs are not visible to the freezing mechanism:
 
 .. code-block:: python
 
@@ -296,27 +305,24 @@ implicit inputs to a frozen function are generally not supported:
 
       @dr.freeze
       def method(self, a: Float):
-         # The `self.state` variable is an implicit input to the frozen function.
-         # Attempting to record this function will raise an exception!
+         # ``MyClass`` is not a PyTree, so `self.state` is an implicit input
+         # that the frozen function cannot see. Attempting to record this
+         # function will raise an exception!
          return self.state + a
 
    ...
 
    local_var = Float([1, 2, 3])
    def func(a: Float):
-      # `local_var` is an implicit input to the frozen function (closure variable).
       return local_var + a
 
    @dr.freeze
    def func2(b: Float):
+      # `local_var` is read by `func`, not by the frozen function itself, so
+      # it is not captured.
       return func(b) + b
 
-   # This will raise an exception. Closure variables are not supported except
-   # in the most straightforward cases.
-   func2(Float([4, 5, 6]))
-
-When freezing such a method or function, these implicit inputs need to be made
-visible to the freezing mechanism. There are two recommended ways to do so:
+There are two recommended ways to make such inputs visible:
 
 1. Turn the class into a valid :ref:`PyTree <pytrees>`, e.g., a dataclass
    (:py:class:`@dataclass`) or a  ``DRJIT_STRUCT``.
@@ -534,22 +540,19 @@ literals and their "paths" in the input arguments if they are detected:
       l = [Float(1), Float(i)]
       c = MyClass(Float(i))
 
-      # The function can be called with arguments and keyword arguments. They will
-      # show up as a tuple in the path.
+      # Arguments and keyword arguments are both referred to by their name
       frozen(x, y, l, c = c)
 
 The above code will print the following message, when the function is called the second time:
 
 .. code-block:: text
 
-   While traversing the frozen function input, new literal variables have
-   been discovered which changed from one call to another. These will be made
-   opaque, and the input will be traversed again. This will incur some
-   overhead. To prevent this, make those variables opaque in beforehand. Below,
-   a list of variables that changed will be shown.
-   args[1][0]: The literal value of this variable changed from 0x0 to 0x3f800000
-   args[2][1][0]: The literal value of this variable changed from 0x0 to 0x3f800000
-   kwargs["c"].z[0]: The literal value of this variable changed from 0x0 to 0x3f800000
+   drjit.freeze(): the literal values below changed between calls and are made
+   opaque, which requires a new recording. Making them opaque beforehand avoids
+   this overhead.
+    - y
+    - l[1]
+    - c.z
 
 This output can be used to determine which literal where made opaque.
 As stated above, it can be beneficial to make these literals opaque beforehand.
@@ -836,20 +839,38 @@ can occur when using custom BSDFs in Mitsuba 3.
 Implementation details
 ----------------------
 
-Every time the annotated function is called, its inputs are analyzed. All JIT
-variables are extracted into a flattened and de-duplicated array. Additionally,
-a key describing the "layout" of the inputs is generated. This key will be used
-to distinguish between different recordings of the same frozen function, in case
-some of its inputs qualitatively change in subsequent calls.
+When the annotated function is called for the first time, its inputs are
+analyzed: the PyTree is traversed, its JIT variables are extracted into a
+flattened and de-duplicated array, and a *layout* describing the structure and
+types of the input, its literal values, and the sizes of its variables is
+built. The layout serves as a key that distinguishes different recordings of
+the same frozen function, in case some of its inputs qualitatively change in
+subsequent calls.
 
-If no recording is found for the current key, Dr.Jit enters a "kernel recording"
-mode (:py:obj:`drjit.JitFlag.FreezingScope`) and the actual function code is
-executed. In this mode, all device level operations, such as kernel launches are
-recorded as well as executed normally.
+If no recording exists for the current layout, Dr.Jit enters a "kernel
+recording" mode (:py:obj:`drjit.JitFlag.FreezingScope`) and the actual
+function code is executed. In this mode, all device level operations, such as
+kernel launches are recorded as well as executed normally. After the call, the
+result and the inputs are analyzed once more, so that the recording knows
+which variables it must produce when it is replayed: the ones making up the
+result, and inputs that the function modified. A frozen function may assign
+new arrays to its inputs (e.g., ``x += 1`` on an argument, or an updated
+member of an object), but it must not change anything else about them: the
+entries of containers, dictionary keys and their order, tensor shapes and the
+Python values held by the input must stay as they are, since the replay could
+not reproduce such a change. Recording a function that does so raises an
+exception naming the changed entry. A common case is state that is
+initialized lazily, such as a generator ``dr.rng()`` seeded with an
+integer, which converts its seed to an array when it is first used. Seed
+it with an array (``dr.rng(UInt64(0))``) or use it once before the frozen
+call.
 
-The next time the function is called, the newly-provided inputs are traversed,
-and the layout is used to look up compatible recordings. If such a recording is
-found, any tracing is skipped: the various recorded operations and kernels are
+The next time the function is called, the inputs are verified against the
+layout of the recording used by the previous call. The verification walks the
+input alongside the layout, and on success replays the recording right away.
+Otherwise the input is analyzed again and the resulting layout is compared
+against all recordings of the function. If a compatible recording is found,
+any tracing is skipped: the various recorded operations and kernels are
 directly replayed.
 
 Traversal

--- a/docs/freeze.rst
+++ b/docs/freeze.rst
@@ -1,3 +1,4 @@
+
 .. py:currentmodule:: drjit
 
 .. _freeze:
@@ -5,148 +6,444 @@
 Function Freezing
 =================
 
-.. warning:: This feature is still considered experimental, please refer to the
-   sections on :ref:`pitfalls <pitfalls>` and :ref:`unsupported operations
-   <unsupported_operations>` section. If you encounter any issues please open
-   an issue `here <https://github.com/mitsuba-renderer/drjit/issues>`__ with
-   a minimal reproducer.
+In typical usage, Dr.Jit traces a computation, compiles it into executable
+machine code, and then launches the resulting kernels on the target device. Of
+these three steps, only the kernel launch is truly desired, whereas tracing and
+compilation represent *overheads*.
 
-Introduction
-------------
+Compilation tends to be the most costly, but can normally be avoided thanks to a
+cache of previously compiled kernels. This leaves tracing as the remaining
+source of overhead. Although tracing is generally fast, it can dominate when a
+program processes a small amount of data using relatively complex expressions.
+This is especially problematic when the same code runs repeatedly, for example,
+inside an optimization loop.
 
-Dr.Jit traces code to obtain computation graphs that are later compiled into
-into executable machine code. Compilation can be very costly due to a number of
-sophisticated optimizations performed by LLVM/CUDA backends. Fortunately,
-compilation is often avoidable thanks to a cache of previously compiled
-kernels, which leaves tracing as the main source of overheads.
+Function freezing addresses this problem by eliminating the cost of tracing and
+compilation on repeated calls. The first call to a function
+decorated with :py:func:`@dr.freeze <freeze>` executes the Python function and
+creates a recording. Subsequent calls with compatible inputs can replay the
+recording directly without executing the function body again. Dr.Jit can
+maintain multiple recordings when a function is called with different input
+configurations.
 
-While tracing costs are often negligible, there are situations where this part
-actually ends up dominating. This can happen when the program evaluates complex
-expressions with relatively little data so that tracing takes longer than the
-actual kernel runtime. This can be especially problematic when the code runs
-repeatedly, e.g., as part of an optimization loop.
+Freezing works best for functions that are expensive to trace and whose input
+structure remains stable across calls. It provides little benefit when tracing
+is inexpensive or when most calls require a new recording.
 
-Dr.Jit's *function freezing* feature addresses this performance bottleneck
-using the :py:func:`@dr.freeze <freeze>` decorator. Calls to functions using
-this decorator query a cache and potentially avoid tracing altogether. The
-first time such a function is called, Dr.Jit will analyze the inputs and then
-trace its body, taking note of all kernel launches. On subsequent calls, Dr.Jit
-only checks that the new inputs are still compatible with the previously
-recorded kernels. In that case, it skips tracing and assembly and launches the
-kernels directly.
+Basic use
+---------
 
-Usage
------
-
-Using this feature is as simple as annotating the function with the
+To use this feature, place the computation in a function and apply the
 :py:func:`@dr.freeze <freeze>` decorator:
 
 .. code-block:: python
-   :emphasize-lines: 11
+   :emphasize-lines: 4
 
    import drjit as dr
-   from drjit.cuda import Float, UInt32
+   from drjit.cuda import Float
 
-   # Without freezing - traces every time
-   def func(x):
-       y = seriously_complicated_code(x)
-       dr.eval(y) # ..intermediate evaluations..
-       return huge_function(y, x)
-
-   # With freezing - traces only once
    @dr.freeze
-   def frozen(x):
-       y = seriously_complicated_code(x)
+   def f(x: Float):
+       y = seriously_complicated_function(x)
        dr.eval(y) # ..intermediate evaluations..
-       return huge_function(y, x)
+       return another_huge_function(y, x)
 
-Calls to :py:func:`@dr.freeze <freeze>`-decorated functions still involves
-small overheads related to examining their inputs, mapping them to function
-outputs, and performing checks to ensure correctness. However, these costs are
-proportional to the number of function inputs/outputs rather than the
-complexity of the computation.
+   value_1 = f(Float(...)) # 🔴 record
+   value_2 = f(Float(...)) # ▶️ replay
 
-For debugging purposes, the freezing feature can easily be disabled by setting
-the :py:attr:`drjit.JitFlag.KernelFreezing` to ``False``.
+Methods can be frozen in the same way using :py:func:`@dr.freeze <freeze>`.
+Here, ``self`` is treated like any other argument. Dr.Jit only tracks its
+attributes when the object is a :ref:`PyTree <pytrees>`. With an ordinary Python
+class, changes to these attributes may be missed, causing a recording to replay
+with stale values.
+
+Make the class a dataclass or list its traversable members using a
+:ref:`DRJIT_STRUCT annotation <custom_types_py>`:
 
 .. code-block:: python
 
-   @dr.freeze
-   def func(x):
-      ...
+   class Scaler:
+       DRJIT_STRUCT = { "scale": Float }
 
-   # By default the function is recorded and replayed on subsequent calls.
-   func(x)
+       def __init__(self, scale: Float):
+           self.scale = scale
 
-   # Function freezing can be disabled by setting a flag to False. Subsequent
-   # calls will not use the recording and run the function as if it was not
-   # annotated.
+       @dr.freeze
+       def apply(self, x: Float):
+           return self.scale * x
+
+   scaler = Scaler(Float(2))
+   scaler.apply(Float(1))  # returns [2]
+
+   scaler.scale = Float(3)
+   scaler.apply(Float(1))  # returns [3]
+
+The frozen function ``f`` behaves like the wrapped Python callable and also
+provides the following attributes and methods:
+
+- ``f.enabled``: set this to ``False`` to disable function freezing
+  so that calls directly reach the wrapped function.
+
+- ``f.n_recordings``: reports the total number of recordings created.
+
+- ``f.n_cached_recordings``: reports the number of stored recordings,
+  which may differ from ``n_recordings`` when cache entries are evicted.
+
+- ``f.clear()``: clears the cache and resets both counters.
+
+The :py:attr:`drjit.JitFlag.KernelFreezing` flag can be used to disable
+function freezing globally:
+
+.. code-block:: python
+
    dr.set_flag(dr.JitFlag.KernelFreezing, False)
-   func(x)
 
-To re-enable function freezing, the flag can simply be set to ``True`` again.
-Previous recordings made while the flag was set will still be available and
-can be used when replaying the function.
+Structural compatibility
+------------------------
 
-Additional arguments can be specified when using the decorator. These are
-documented in the API-level documentation :py:func:`@dr.freeze <freeze>`.
+Inputs and return values of frozen functions may be arbitrary
+:ref:`PyTrees <pytrees>`, including Dr.Jit arrays, tuples and lists,
+dictionaries, dataclasses, or :ref:`custom classes <custom_types_py>` with a
+``DRJIT_STRUCT`` annotation.
+Custom classes returned by a frozen function must be default-constructible so
+that Dr.Jit can recreate them during replay.
 
-More implementation details are given :ref:`below
-<freezing_implementation_details>`.
+Dr.Jit can only replay a recording when the new input is *structurally
+equivalent* to the input that produced it. The following examples illustrate
+what this means:
 
-.. _unsupported_operations:
+The contents and size of a Dr.Jit array may change between calls without
+triggering a new recording:
 
-Unsupported operations
-----------------------
+.. code-block:: python
 
-Frozen functions only support operations that can be replayed seamlessly
-with new inputs. We describe *unsupported* operations below.
+   f(Float(1, 2))     # 🔴 record
+   f(Float(3, 4, 5))  # ▶️ replay
 
-Array access
-~~~~~~~~~~~~
+When a function has multiple inputs, inputs of the same size form a group. A
+recording made with one set of input sizes generalizes to other sizes, as long
+as the inputs within each group continue to have the same size.
 
-Frozen functions can accept arbitrary :ref:`PyTrees <pytrees>` as input, which
-ultimately consist of the following leaf elements:
+.. code-block:: python
 
-- Scalar Python variables (``int``, ``str``, etc.). The freezing feature makes a
-  note of their value and detects changes in subsequent calls. Because they can
-  influence the generated kernel code, any changes here trigger re-tracing of
-  the function body.
+   f(Float(1, 2),    Float(3, 4))    # 🔴 record
+   f(Float(1, 2, 3), Float(4, 5, 6)) # ▶️ replay
+   f(Float(1, 2, 3), Float(4, 5))    # ⚠️ miss, record again
 
-- Dr.Jit arrays. The contents of evaluated JIT array arguments may change
-  between calls without requiring re-tracing.
+All of the following changes will also trigger a new recording:
 
-The contents of Dr.Jit array variables will generally change when a frozen
-function is later replayed. Operations that extract scalar array elements,
-(e.g, to influence control flow) are not legal, since the freezing would bake
-the observed constants and decisions into the generated kernels instead of
-responding to changes in subsequent replays. Dr.Jit detects such attempts and
-raises an exception.
+- Changing the type of an argument or the value of a Python scalar.
+  The following snippet does both:
+
+  .. code-block:: python
+
+     f(x, 1)    # 🔴 record
+     f(x, 3.0)  # ⚠️ miss, record again
+
+- Replacing a Python object that is not a PyTree with an unequal object.
+  Equality is determined using ``__eq__``:
+
+  .. code-block:: python
+
+     f(x, BigInt(1)) # 🔴 record
+     f(x, BigInt(2)) # ⚠️ miss, record again
+
+- Changing the length of a Python container or the key set of a dictionary:
+
+  .. code-block:: python
+
+     f(x, [1],    {'y' : 'h'}) # 🔴 record
+     f(x, [1, 2], {'_y': 'y'}) # ⚠️ miss, record again
+
+- Changing any Dr.Jit compiler flag:
+
+  .. code-block:: python
+
+     f(x) # 🔴 record
+     dr.set_flag(...)
+     f(x) # ⚠️ miss, record again
+
+- Changing a tensor's rank or any dimension other than its leading dimension:
+
+  .. code-block:: python
+
+     f(dr.zeros(TensorXf, (10, 20, 30))) # 🔴 record
+     f(dr.zeros(TensorXf, (15, 20, 30))) # ▶️ replay
+     f(dr.zeros(TensorXf, (18, 24)))     # ⚠️ miss, record again
+
+Repeated recordings
+-------------------
+
+By default, a frozen function warns after it has created more than ten
+recordings. The ``warn_after`` parameter changes this threshold. Setting it to
+``1`` can be useful when diagnosing a function:
+
+.. code-block:: pycon
+
+   >>> @dr.freeze(warn_after=1)
+   ... def f(x, iteration):
+   ...     return x + iteration
+   ...
+   >>> f(Float(1, 2), 0)
+   >>> f(Float(1, 2), 1)
+   This frozen function was traced 2 times. Repeated tracing defeats the purpose
+   of function freezing and is caused by structural changes of the function's
+   inputs. The change that triggered this recording was: 'iteration' (the value
+   changed from 0 to 1).
+
+Here, ``iteration`` is a Python ``int``, whose value forms part of the
+recording's configuration. If a value is expected to change between calls,
+pass it as an opaque Dr.Jit array to avoid another recording:
+
+.. code-block:: python
+
+   for i in range(n):
+       f(x, dr.opaque(UInt32(i)))
+
+Dr.Jit normally detects changing literal arrays such as ``UInt32(i)`` and makes
+them opaque automatically. This requires one additional recording. Making a
+value that is known to change opaque from the start avoids that cost.
+
+Captured state
+--------------
+
+Not every value used by a function appears in its argument list:
+
+.. code-block:: python
+
+   scale = 2
+
+   @dr.freeze
+   def f(x):
+       return x * scale
+
+   f(Float(1, 2))  # 🔴 record
+
+   scale = 3
+   f(Float(1, 2))  # ⚠️ miss, record again
+
+Although ``scale`` is not an argument of ``f``, Dr.Jit detects that the
+function reads it and includes its value when selecting a recording. The same
+applies to variables defined in an enclosing function, which Python calls
+*closure variables*. Dr.Jit also detects such reads inside comprehensions,
+generator expressions, lambdas, and nested functions.
+
+Dr.Jit does not automatically detect state accessed through a helper function
+or stored in an object that is not a :ref:`PyTree <pytrees>`. Pass such state
+as an argument or expose it using the ``state_fn`` argument. The
+:py:func:`dr.freeze <freeze>` API reference includes an example of the latter
+approach.
+
+Mutable inputs
+--------------
+
+A frozen function may update Dr.Jit arrays stored in a mutable
+:ref:`PyTree <pytrees>`. Dr.Jit writes the updated values back after replay:
 
 .. code-block:: python
 
    @dr.freeze
-   def func(x: Float, y: Float):
-      # Depending on the content of x, one of two possible kernels could be generated.
-      # This cannot be replayed. Accessing elements of x is therefore prohibited.
-      if x[1] > 0:
-         return y + 1
-      else:
-         return y - 1
+   def increment(state: dict):
+       state["value"] = state["value"] + 1
 
-   func(Float(0, 1), Float(0, 1, 2))
+   state = { "value": Float(1, 2) }
 
-.. _non_recordable_operations:
+   increment(state)  # 🔴 record
+   increment(state)  # ▶️ replay
+
+   assert dr.all(state["value"] == Float(3, 4))
+
+A replay assigns new arrays to the leaves of the input, but it cannot reproduce
+a change of the input's *structure*, such as adding or removing container
+entries or changing Python values stored in the input. The next section covers
+the case where such a change happens only once.
+
+Inputs initialized on first use
+-------------------------------
+
+A callable often builds part of its input the first time it runs: a dictionary
+gains a key, a tensor is reshaped, or an object populates a member on first
+use. Such an initialization typically happens once, and the frozen function
+recovers from it by recording the callable a second time. The call has already
+happened at that point, so the input now holds the initialized state that every
+later call sees as well, and the second recording describes the callable in its
+steady state.
+
+.. code-block:: python
+
+   @dr.freeze
+   def func(d):
+      d["y"] = d["x"] + 1
+
+   d = {"x": UInt32(1, 2, 3)}
+   func(d)                      # Adds the key, hence two recordings
+   assert func.n_recordings == 2
+
+   func(d)                      # ▶️ replay, since the key now exists
+   assert func.n_recordings == 2
+
+The callable therefore runs **twice** on the call that triggers this, which is
+observable when it advances a random number generator or writes to a file. A
+callable that keeps changing the structure of its input on every call cannot be
+frozen and raises instead.
+
+Automatic differentiation
+--------------------------
+
+Frozen functions can be differentiated as usual:
+
+.. code-block:: python
+
+   @dr.freeze
+   def loss(x: Float):
+       return dr.mean(dr.square(x))
+
+   x = dr.arange(Float, 4)
+   dr.enable_grad(x)
+
+   value = loss(x)
+   dr.backward(value)
+
+The first call records the primal computation. The first derivative pass in
+each mode records the corresponding derivative computation. Later passes in
+that mode can replay it.
+
+A frozen function can also propagate gradients internally. This is useful when
+the function computes a loss and the caller only needs the accumulated
+gradients:
+
+.. code-block:: python
+
+   @dr.freeze
+   def accumulate_gradient(y: Float):
+       dr.backward(dr.mean(y))
+
+   x = dr.arange(Float, 4)
+   dr.enable_grad(x)
+
+   accumulate_gradient(dr.square(x))
+
+Gradients produced this way propagate through the function's inputs to the
+variables on which they depend. The backward pass becomes part of the recording
+and is replayed together with the primal computation.
+
+The two forms have different performance characteristics. When
+``dr.backward()`` is applied to a frozen function's return value, the
+reverse-mode pass evaluates the primal computation again. The primal therefore
+runs twice, once when the frozen function is called and once during the
+reverse-mode pass. Calling ``dr.backward()`` inside the frozen function records
+the primal and reverse computations together and avoids this duplicated work.
+Prefer the latter form when the loss can be computed inside the function and
+the caller only needs the resulting gradients.
+
+🔪 The sharp bits 🔪
+--------------------
+
+Most users will not encounter the limitations below. They become relevant when
+a frozen function reads values back to Python, derives array sizes in unusual
+ways, or relies on low-level operations outside Dr.Jit's regular kernel
+launches.
+
+Reading array values in Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Function freezing rejects operations that transfer the contents of an evaluated
+Dr.Jit array from the device to the host and read them into Python. Such a read
+can influence Python control flow and therefore change the recorded
+computation. In the example below, the value of ``x[0]`` would determine which
+of two kernels is generated:
+
+.. code-block:: pycon
+
+   >>> @dr.freeze
+   ... def func(x: Float):
+   ...    if x[0] > 0:
+   ...       return x
+   ...    else:
+   ...       return -x
+
+   >>> func(Float(0, 1))
+   RuntimeError: drjit.cuda.Float.__getitem__(): jit_var_read(): reading the contents of an↵
+   evaluated variable while recording a frozen function is not permitted, as this operation↵
+   cannot be recorded. See https://drjit.readthedocs.io/en/latest/freeze.html for details.
+
+Array sizes
+~~~~~~~~~~~
+
+A recording can usually be replayed with inputs of different widths. When a
+function creates an array whose width depends on an input, Dr.Jit must be able
+to recover that relationship. Simple integer multiples and fractions are
+supported:
+
+.. code-block:: python
+
+   @dr.freeze
+   def return_even(x: Float):
+       indices = 2 * dr.arange(UInt32, dr.width(x) // 2)
+       return dr.gather(Float, x, indices)
+
+Other relationships, such as ``dr.width(x) - 1``, cannot be inferred reliably.
+The size observed while recording may then be reused during replay, potentially
+causing incorrect results or out-of-bounds accesses. Avoid such relationships
+when a frozen function will receive inputs of different widths.
+
+Size inference can also become ambiguous when a kernel reads multiple inputs
+of different widths:
+
+.. code-block:: python
+
+   @dr.freeze
+   def combine(x: Float, y: Float):
+       indices = dr.arange(UInt32, dr.width(x) // 2)
+       return (dr.gather(Float, x, indices) +
+               dr.gather(Float, y, indices))
+
+   combine(dr.arange(Float, 8),
+           dr.arange(Float, 16))  # 🔴 record, returns 4 elements
+
+   combine(dr.arange(Float, 16),
+           dr.arange(Float, 16))  # incorrect: still returns 4 elements
+
+During the first call, the output width of four could be described as either
+half the width of ``x`` or one quarter the width of ``y``. Dr.Jit may record
+the latter relationship. The second call then returns four elements even
+though the function derives its indices from ``x`` and should return eight.
+
+Avoid this ambiguity by keeping the relative input sizes fixed across calls.
+Otherwise, do not freeze a computation whose output size could be inferred
+from more than one input.
+
+Advanced tensor indexing
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tensor indexing is generally supported, but combining an array index with a
+slice requires care. Dr.Jit lowers such an expression to a flat index
+calculation while tracing the Python function. This calculation uses the
+current length of the index array as a Python integer, which becomes fixed in
+the recording:
+
+.. code-block:: python
+
+   @dr.freeze
+   def select_rows(t: TensorXf, rows: UInt32):
+       return t[rows, :]
+
+   select_rows(t, UInt32(0, 1))     # 🔴 record with two rows
+   select_rows(t, UInt32(0, 1, 2))  # incorrect: still assumes two rows
+
+Avoid this pattern when the index array may change size. Computing flat indices
+and using :py:func:`dr.gather <gather>` directly avoids the problem.
 
 Unsupported low-level operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The freezing feature captures regular Dr.Jit kernel launches, reductions, and
-various data movement operations. It does not track operations that fall
-outside of this pattern, such as custom CUDA kernel launches.
+Function freezing captures regular Dr.Jit operations, including kernel
+launches, reductions, and data movement. It cannot capture low-level operations
+such as custom CUDA kernel launches.
 
-Some parts of Dr.Jit itself currently remain unsupported. For example,
-constructing a new texture as in
+Existing textures can be passed to frozen functions and used for lookups and
+gradient calculations. Creating or updating a texture inside a frozen function
+is not supported on the CUDA and Metal backends:
 
 .. code-block:: python
 
@@ -156,799 +453,7 @@ constructing a new texture as in
       tex.set_value(data)  # <--- unsupported!
       return tex.eval(pos)
 
-does not produce correct results. This is because initialization of device
-textures requires a call to a CUDA texture-specific operation
-(``cuMemcpy2DAsync``), which is essentially a custom (non-Dr.Jit) kernel.
-Another unsupported case is building acceleration data structures for GPU ray
-tracing. Such steps must be performed outside of the frozen function.
-
-Note: Dr.Jit provides basic abstractions to capture even such steps in principle,
-so it possible that these limitations will be lifted in the future.
-
-Gradient propagation
-~~~~~~~~~~~~~~~~~~~~
-
-Tracing the backward pass of differentiable computation is often at least as
-complex as the forward pass. Freezing derivatives is therefore desirable. The
-:py:func:`@dr.freeze <freeze>` decorator supports propagating gradients within
-the function and can propagate gradients to variables that the function's
-inputs depend on.
-
-However, propagating gradients from the result of a frozen function *through*
-the function is not supported. All gradient backpropagation has to start
-within the recorded function.
-
-In terms of automatic differentiation, annotating a function with the
-:py:func:`dr.freeze` decorator is equivalent to wrapping the content with an
-isolated gradient scope.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(y):
-      # Some differentiable operation...
-      z = dr.mean(y)
-      # Propagate the gradients to the input of the function...
-      dr.backward(z)
-
-   x = dr.arange(Float, 3)
-   dr.enable_grad(x)
-
-   y = dr.square(x)
-
-   # The first time the function is called, it will be recorded and the correct
-   # gradients will be accumulated into x.
-   func(y)
-
-   y = x * 2
-
-   # On subsequent calls the function will be replayed, and gradients will
-   # be accumulated in x.
-   func(y)
-
-The :py:func:`@dr.freeze <freeze>` decorator adds an implicit
-:py:func:`drjit.isolate_grad` context to the function. The above function is
-then equivalent to the following function.
-
-.. code-block:: python
-
-   def func(y):
-      # The isolate grad scope is added implicitly by the freezing decorator
-      with dr.isolate_grad():
-         # Some differentiable operation...
-         z = dr.mean(y)
-         # Propagate the gradients to the input of the function...
-         dr.backward(z)
-
-
-Compress
-~~~~~~~~
-
-Compress operations (:py:func:`drjit.compress`) generate results, whose size
-(number of entries) depends on the content of the input. Therefore the output
-size cannot be determined ahead of time. Using :py:func:`drjit.compress` with
-any other function that needs to know array sizes in advance will cause the
-function to be re-traced on every call, effectively rendering the freezing
-mechanism useless.
-
-Examples of such functions include :py:func:`drjit.block_reduce`,
-:py:func:`drjit.block_prefix_reduce`, and :py:func:`drjit.scatter_reduce` when
-using the LLVM backend.
-
-.. code-block:: python
-
-   @dr.freeze
-   func(x):
-      y = dr.block_reduce(dr.ReduceOp.Add, x, 2)
-      return dr.compress(y > 2)
-
-   # Calling the function the first time, will cause it to be traced.
-   x = dr.arange(Float, 4)
-   func(x)
-
-   # Successive calls will also re-trace the function, even when called with the
-   # same input. A warning will also be printed, to notify of such cases.
-   x = dr.arange(Float, 4)
-   func(x)
-
-
-Pointers with offsets
-~~~~~~~~~~~~~~~~~~~~~
-
-The following comment mainly applies to custom C++ code using Dr.Jit.
-
-Internally, new inputs to pre-recorded kernels are passed using the variables'
-data pointer. This is also how variables are identified and disambiguated
-in the function freezing implementation.
-
-However, this identification mechanism will not work for addresses pointing
-*inside* of a memory region. Therefore, such pointers are not supported inside
-of frozen functions.
-
-.. code-block:: cpp
-
-   // This pattern is not supported inside of frozen functions.
-   UInt32::load_(x.data() + 4)
-
-Note that this pattern might be used in existing C++ code which is called inside
-of the frozen function, which would result in an exception.
-
-
-.. _pitfalls:
-
-Pitfalls
---------
-
-Watch out for following pitfalls when using :py:func:`@dr.freeze <freeze>` decorator.
-
-Implicit inputs
-~~~~~~~~~~~~~~~
-
-A frozen function may read more than its arguments: global variables,
-variables of an enclosing scope (closures), and the members of an object whose
-method is frozen. The values of the global and closure variables that the
-function itself reads are captured on every call and become part of the
-input, so that a change of such a variable is detected. This includes the
-bodies written inside the function, such as comprehensions, generator
-expressions, lambdas and nested functions. The members of the object of a
-frozen method are visible when the object is a valid :ref:`PyTree <pytrees>`
-(a dataclass, a class with a ``DRJIT_STRUCT`` annotation, or a traversable C++
-object), since ``self`` is an ordinary argument in that case.
-
-Other implicit inputs are not visible to the freezing mechanism:
-
-.. code-block:: python
-
-   class MyClass:
-      def __init__(self, state: Float):
-         self.state = state
-
-      @dr.freeze
-      def method(self, a: Float):
-         # ``MyClass`` is not a PyTree, so `self.state` is an implicit input
-         # that the frozen function cannot see. Attempting to record this
-         # function will raise an exception!
-         return self.state + a
-
-   ...
-
-   local_var = Float([1, 2, 3])
-   def func(a: Float):
-      return local_var + a
-
-   @dr.freeze
-   def func2(b: Float):
-      # `local_var` is read by `func`, not by the frozen function itself, so
-      # it is not captured.
-      return func(b) + b
-
-There are two recommended ways to make such inputs visible:
-
-1. Turn the class into a valid :ref:`PyTree <pytrees>`, e.g., a dataclass
-   (:py:class:`@dataclass`) or a  ``DRJIT_STRUCT``.
-
-2. Or, use the ``state_fn`` argument of the :py:func:`@dr.freeze <freeze>` decorator to
-   manually specify the implicit inputs. ``state_fn`` will be called as a
-   function with the same arguments as the annotated function, and should return
-   a tuple of all extra inputs to be considered when recording and replaying.
-
-The following snippet illustrates correct usage:
-
-.. code-block:: python
-
-   @dataclass
-   class MyDataClass:
-      # Dataclasses are valid PyTrees, which make these fields visible to Dr.Jit
-      # and the freezing mechanism.
-      x: Float
-      y: Float
-
-      @dr.freeze
-      def func(self, z: Float):
-         return self.y + z
-
-   def other_func(obj: MyDataClass, z: Float):
-      return obj.x + obj.y + x
-
-   ...
-
-   class OpaqueClass:
-      def __init__(self, x: Float):
-         # This field is not visible to Dr.Jit.
-         self.x = x
-
-   # The ``state_fn`` argument can be used to make implicit inputs visible
-   # without modifying the class.
-   @dr.freeze(state_fn=(lambda obj, **_: obj.x))
-   def func(obj: OpaqueClass):
-      return obj.x + 1
-
-
-
-Kernel size inference
-~~~~~~~~~~~~~~~~~~~~~
-
-As explained above, frozen functions can in general be called many times with
-JIT inputs of varying sizes (number of elements) without requiring re-tracing.
-
-In some situations, the size of an input may be used to determine the size of
-another variable:
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(x):
-      indices = dr.arange(UInt32, dr.width(x) // 2)
-      # The size of the result depends on the size of input `x`.
-      return dr.gather(type(x), x, indices)
-
-The freezing mechanism uses a simple heuristic to detect variables whose size
-is a direct multiple or fraction of the input size.
-
-.. code-block:: python
-
-   # When calling the function, Dr.Jit will notice that the size of the output
-   # is a whole fraction of the input. This fact will be recorded by the frozen
-   # function.
-   x = dr.arange(Float, 8)
-   y1 = func(x)
-   assert dr.width(y1) == 4
-
-   # When replaying the function with a differently sized input, the size of
-   # the resulting variable will be derived according to this fraction.
-   x = dr.arange(Float, 16)
-   y2 = func(x)
-   assert dr.width(y2) == 8
-
-Unfortunately, if this heuristic does not succeed (e.g., creating a variable with 3
-more entries than the input), the size of the new variable will be assumed to be
-a constant, and will always be set to the size observed during the first recording,
-even in subsequent calls.
-
-.. warning::
-
-   Because there is no way for Dr.Jit to reliably detect it, freezing a function
-   containing this pattern can result in unsafe code or undefined behavior! In
-   particular, there may be out-of-bounds accesses due to the incorrect variable
-   size.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(x):
-      # The size of `indices` is not a simple multiple or fraction of the size
-      # of input `x`.
-      indices = dr.arange(UInt32, dr.width(x) - 1)
-      return dr.gather(type(x), x, indices)
-
-   # When first calling the function with an input of size 8, the constant size
-   # of (8 - 1) = 7 is baked into the frozen function.
-   x = dr.arange(Float, 8)
-   y1 = func(x)
-
-   # When replaying the function, a kernel of the hardcoded size 7 be replayed,
-   # resulting in an incorrect output. This is unsafe!
-   x = dr.arange(Float, 16)
-   y2 = func(x)
-
-When more than one variable are accessed using :py:func:`drjit.gather` or
-:py:func:`drjit.scatter`, and the kernel size has to be inferred, it is
-possible that Dr.Jit picks the wrong variable to base the kernel size on.
-Such cases might also lead to undefined behavior and may cause out-of-bounds
-memory accesses. In general, Dr.Jit will try to use the largest variable that
-is either a fraction or multiple of the kernel input size.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(x, y):
-      # The size of `indices` is not a simple multiple or fraction of the size
-      # of input `x`.
-      indices = dr.arange(UInt32, dr.width(x) // 2)
-      return dr.gather(type(x), x, indices) + dr.gather(type(y), y, indices)
-
-   # When calling the function, Dr.Jit will notice, that the size of the output
-   # is a whole fraction of the size of ``x`` as well as ``y``.
-   x = dr.arange(Float, 8)
-   y = dr.arange(Float, 16)
-   z1 = func(x, y)
-   assert dr.width(z1) == 4
-
-   # When replaying the function, Dr.Jit will use the larger of the two inputs
-   # to determine the size of the output.
-   x = dr.arange(Float, 16)
-   y = dr.arange(Float, 32)
-   z2 = func(x, y)
-   assert dr.width(z2) == 8
-
-Excessive recordings
-~~~~~~~~~~~~~~~~~~~~
-
-A common pattern when rendering scenes or running an optimization loop is to use
-the iteration index, e.g., as a seed to initialize a random number generator.
-This is also supported in a frozen function, however passing the iteration count
-as a plain Python integer will cause the function to be re-recorded each time,
-resulting in lower performance than not using frozen functions.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(scene, it):
-      return render(scene, seed = it)
-
-   for i in range(n):
-      # When this function is called with different int-typed seed values, the
-      # frozen function will be re-traced for each new value of ``i``!
-      func(scene, i)
-
-   for i in range(n):
-      # Re-tracing can be prevented by using an opaque JIT variable instead.
-      i = dr.opaque(UInt32(i))
-      func(scene, i)
-
-
-Auto-opaque
-~~~~~~~~~~~
-
-There is one more subtlety when using a *literal* JIT variable (:py:obj:`UInt32(i)`)
-instead of an opaque one (:py:obj:`dr.opaque(UInt32(i))`). The "auto-opaque"
-feature, which is enabled by default, will detect literal JIT inputs that
-change between calls and make them opaque. However, this means that the function
-has to be traced at least twice, which incurs additional overhead at the start.
-
-.. code-block:: python
-
-   for i in range(n):
-      # By default, this literal JIT variable (non-opaque) will be made opaque
-      # when passed to the frozen function at the second call only.
-      # This means the function is traced twice instead of once.
-      i = UInt32(i)
-      func(scene, i)
-
-Disabling auto-opaque (:py:obj:`drjit.freeze(auto_opaque=False)`) will result
-in a single recording, but all literal inputs will be made opaque regardless of
-whether they would later remain constant or not. This will lead to higher memory
-usage and may also worsen performance of the kernel itself.
-
-When possible, it is therefore recommended to **use opaque JIT variables for
-inputs that are known to change across calls**.
-
-To help track changing inputs, Dr.Jit can provide a list of such changing
-literals and their "paths" in the input arguments if they are detected:
-
-.. code-block:: python
-
-   # For the literal "paths" to be printed the log level has to be set to ``Info``
-   dr.set_log_level(dr.LogLevel.Info)
-
-   @dr.freeze
-   def frozen(x, y, l, c):
-      return x +  1
-      ...
-
-   # Members of classes will be printed
-   @dataclass
-   class MyClass:
-      z: Float
-
-   # We call the function twice. The first call will leave all literals untouched.
-   # In the second call, changing literals will be detected and their paths will
-   # be printed.
-   for i in range(2):
-      x = dr.arange(Float, i+2)
-      y = Float(i)
-      l = [Float(1), Float(i)]
-      c = MyClass(Float(i))
-
-      # Arguments and keyword arguments are both referred to by their name
-      frozen(x, y, l, c = c)
-
-The above code will print the following message, when the function is called the second time:
-
-.. code-block:: text
-
-   drjit.freeze(): the literal values below changed between calls and are made
-   opaque, which requires a new recording. Making them opaque beforehand avoids
-   this overhead.
-    - y
-    - l[1]
-    - c.z
-
-This output can be used to determine which literal where made opaque.
-As stated above, it can be beneficial to make these literals opaque beforehand.
-In this case, the second argument of the function, the second argument of the
-list and the member ``z`` of the class have been detected as changing literals.
-
-
-Dry-run replay
-~~~~~~~~~~~~~~
-
-Some operations, such as block reductions, require the recording to be replayed
-in a dry-run mode before executing it. This calculates the size of variables and
-ensures that it will be possible to replay the recording later. If such a
-dry-run fails, the function will have to be re-traced, however instead of adding
-a new recording to the function, the old one will be overwritten. It is not
-possible to add another recording, to the cache, since the condition that
-causes a dry-run to fail can be dependent on the size (number of elements) of
-JIT input variables, which is allowed to change.
-
-.. code-block:: python
-
-   dr.freeze
-   def func(x):
-      return dr.block_reduce(dr.ReduceOp.Add, x, 2)
-
-   # The first time the function is called, a new recording is made
-   x = dr.arange(Float, 4)
-   y = func(x)
-
-   # The block reduction will require a dry-run before launching kernels. In
-   # this case, it is detected that the size of x is not divisible by 2. The
-   # function will be re-traced, however this will overwrite the old recording.
-   x = dr.arange(Float, 5)
-   y = func(x)
-
-   # Calling the function in a loop with changing input sizes can cause all
-   # dry-runs to fail, rendering the freezing mechanism useless.
-   for i in range(5, 10):
-      x = dr.arange(Float, i)
-      y = func(x)
-
-A warning will be printed after more than 10 iterations have been re-traced.
-This limit can be changed using the ``warn_after`` argument of the decorator.
-
-Such functions should therefore be used with caution and only called with
-inputs that do not lead to a dry-run failure.
-
-Tensor shapes
-~~~~~~~~~~~~~
-
-When a frozen function is called with a tensor, the first dimension of the
-tensor is assumed to be dynamic. It can change from one call to another without
-triggering re-tracing of the function. However, changes in any other dimension
-will cause it to be re-traced.
-
-This is due to the way tensors are indexed: computing indices to access tensor
-entries does not involve the first (outermost) dimension, which makes it
-possible to reuse the same code as long as trailing dimensions do not change.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(t: TensorXf, i: UInt, j: UInt, k: UInt):
-      # Indexes into the tensor array, getting the entry at (row, col)
-      index = i * dr.shape(t)[1] * dr.shape(t)[2] + j * dr.shape(t)[2] + k
-      return dr.gather(Float, t.array, index)
-
-   # The first call will record the function
-   t = TensorXf(dr.arange(Float, 10*7*3), shape=(10, 7, 3))
-   func(t, UInt(1), UInt(1), UInt(1))
-
-   # Subsequent calls with the same trailing dimensions will be replayed
-   t = TensorXf(dr.arange(Float, 25*7*3), shape=(25, 7, 3))
-   func(t, UInt(1), UInt(1), UInt(1))
-
-   # Changes in trailing dimensions will cause the function to be re-traced
-   t = TensorXf(dr.arange(Float, 10*3*7), shape=(10, 3, 7))
-   func(t, UInt(1), UInt(1), UInt(1))
-
-Dr.Jit also supports advanced tensor indexing, allowing you to use arrays to
-index into a tensor e.g. ``t[UInt(1, 2, 3), :]``. When multiple array indices
-are used, they select element-wise following NumPy/PyTorch semantics (all
-arrays must have the same length or length 1 for broadcasting). This syntax
-can also be used inside of frozen functions, however it might lead to kernels
-with baked-in kernel sizes, and therefore incorrect outputs. If tensor indexing
-with indices of changing sizes is required, calculating the array index
-manually with the formula in the above example is recommended.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(t: TensorXf, i: UInt, j: UInt, k: UInt):
-      # Indexes into the tensor array, getting the entry at (i, j, k)
-      return t[i, j, k]
-
-   t = TensorXf(dr.arange(Float, 10*7*3), shape=(10, 7, 3))
-
-   # The first call will record the function, and will return a tensor of shape
-   # (3,)
-   func(t, UInt(1, 2, 3), UInt(1, 2, 3), UInt(1, 2, 3))
-
-   # Calling the function with a different number of index elements will be
-   # correct, as long as only array indices are used (no slices).
-   func(t, UInt(1, 2, 3, 4), UInt(1, 2, 3, 4), UInt(1, 2, 3, 4))
-
-   # Mixing array indices with slice dimensions can lead to incorrect outputs
-   # when the tensor data size happens to be a multiple of the kernel launch
-   # size. The heuristic will infer the kernel size from the tensor data
-   # pointer instead of the array indices.
-
-   @dr.freeze
-   def func2(t: TensorXf, row: UInt):
-      return t[row, :]
-
-   t2 = TensorXf(dr.arange(Float, 10*10*3), shape=(10, 10, 3))
-
-   # This call records the kernel with array size 2 (launch size 2*30=60,
-   # and tensor size 300 is a multiple of 60)
-   func2(t2, UInt(0, 1))
-
-   # This call will (incorrectly) replay with the old kernel size
-   func2(t2, UInt(0, 1, 2))
-
-
-.. warning::
-   Using indexing or slicing inside of a frozen function can easily lead to
-   baked-in kernel sizes and as a result to incorrect outputs without any
-   warning. This should be used with caution when replaying frozen functions
-   with JIT inputs of varying sizes (number of elements).
-
-Textures
-~~~~~~~~
-
-:ref:`Textures <textures>` can be used inside of frozen functions for lookups,
-as well as for gradient calculations. However because they require special
-memory operations on the CUDA backend, it is not possible to update or
-initialize CUDA textures inside of frozen functions.
-This is a special case of :ref:`non-recordable operation <non_recordable_operations>`.
-
-.. code-block:: python
-
-   @dr.freeze
-   def func(tex: Texture1f, pos: Float):
-     return tex.eval(pos)
-
-   tex = Texture1f([2], 1)
-   tex.set_value(t(0, 1))
-
-   pos = dr.arange(Float, 4) / 4
-
-   # The texture can be evaluated inside the frozen function.
-   func(tex, pos)
-
-
-Indirect function calls
-~~~~~~~~~~~~~~~~~~~~~~~
-
-As symbolic indirect function calls are generally supported by frozen functions.
-However, some limitations apply. The following example shows a supported use of
-indirect function calls in frozen functions.
-
-.. code-block:: python
-
-   # `A` and `B` derive from `Base`
-   a, b = A(), B()
-
-   @dr.freeze
-   def func(base: BasePtr, x: Float):
-      return base.f(x)
-
-   base = BasePtr(a, a, None, b, b)
-   x = Float(1, 2, 3, 4, 5)
-   func(base, x)
-
-When a frozen function is called with a variable that can point to a virtual
-base class, Dr.Jit's pointer registry is traversed to find all variables used
-in the frozen function call. Since some objects can be registered, but not
-referenced by the pointer, member JIT variables of these objects are traversed
-**and evaluated**, even though they are not used in the function.
-This side-effect can be unexpected.
-
-.. code-block:: python
-
-   # `A` and `B` derive from `Base`
-   # These objects are registered with Dr.Jit's pointer registry
-   a, b = A(), B()
-
-   @dr.freeze
-   def func(base: BasePtr, x: Float):
-      return base.f(x)
-
-   # Even though only `a` is referenced, we have to traverse member variables
-   # of `b`. These can be evaluated by the frozen function call.
-   base = BasePtr(a, a, None)
-   x = Float(1, 2, 3, 4, 5)
-   func(base, x)
-
-Nested indirect function calls are supported when the inner base class pointer
-is passed as an argument to the outer function. However, due to implementation
-details nested calls are not supported when the outer function retrieves the
-callee pointer from class member variables
-
-.. code-block:: python
-
-   # Even though `A` is traversable, a frozen function with a call to
-   # ``nested_member`` will fail.
-   class A(Base):
-      DRJIT_STRUCT = {
-         "s": BasePtr,
-      }
-
-      s: BasePtr
-
-      def nested(self, s, x):
-         s.f(x)
-
-      def nested_member(self, x):
-         self.s.f(x)
-
-   a, b = A(), B()
-
-   # This nested vcall is supported because the nested base pointer is an
-   # argument to the nested function.
-   @dr.freeze
-   def supported(base: BasePtr, nested_base: BasePtr, x: Float):
-      return base.nested(nested_base, x)
-
-   a.s = BasePtr(b)
-   dr.make_opaque(a.s)
-
-   # This nested vcall is unsupported because the nested base pointer is an
-   # opaque member of the class `A`.
-   @dr.freeze
-   def unsupported(base: BasePtr, x: Float):
-      return base.nested_member(x)
-
-Runaway recursion
-~~~~~~~~~~~~~~~~~
-
-Passing inputs to a frozen function that contain basic reference cycles is
-supported. However, reference cycles going through C++ classes can lead to a
-runaway recursion when traversing the function inputs, and raise an exception.
-
-.. code-block:: python
-
-   @dr.freeze
-   def frozen(l):
-      return l[0] + 1
-
-   # This constructs a list with a reference cycle.
-   l = [Float(1)]
-   l.append(l)
-
-   # Passing an object with a simple reference cycle is supported.
-   frozen(l)
-
-However, this more complex example shows an *unsupported* case of reference cycles that
-can occur when using custom BSDFs in Mitsuba 3.
-
-.. code-block:: python
-
-   # A class inheriting from a trampoline class is automatically traversed.
-   class MyBSDF(mi.BSDF):
-      def set_scene(self, scene):
-         self.scene = scene
-      ...
-
-   @dr.freeze
-   def frozen(scene):
-      ...
-
-   # Construct a scene that includes ``MyBSDF`` as an element.
-   scene = ...
-   # Setting the scene reference in the BSDF completes the reference cycle.
-   mybsdf.set_scene(scene)
-
-   # Calling the function with such an object, will lead to a runaway
-   # recursion, and the frozen function will raise an exception.
-   frozen(scene)
-
-
-.. _freezing_implementation_details:
-
-Implementation details
-----------------------
-
-When the annotated function is called for the first time, its inputs are
-analyzed: the PyTree is traversed, its JIT variables are extracted into a
-flattened and de-duplicated array, and a *layout* describing the structure and
-types of the input, its literal values, and the sizes of its variables is
-built. The layout serves as a key that distinguishes different recordings of
-the same frozen function, in case some of its inputs qualitatively change in
-subsequent calls.
-
-If no recording exists for the current layout, Dr.Jit enters a "kernel
-recording" mode (:py:obj:`drjit.JitFlag.FreezingScope`) and the actual
-function code is executed. In this mode, all device level operations, such as
-kernel launches are recorded as well as executed normally. After the call, the
-result and the inputs are analyzed once more, so that the recording knows
-which variables it must produce when it is replayed: the ones making up the
-result, and inputs that the function modified. A frozen function may assign
-new arrays to its inputs (e.g., ``x += 1`` on an argument, or an updated
-member of an object), but it must not change anything else about them: the
-entries of containers, dictionary keys and their order, tensor shapes and the
-Python values held by the input must stay as they are, since the replay could
-not reproduce such a change. Recording a function that does so raises an
-exception naming the changed entry. A common case is state that is
-initialized lazily, such as a generator ``dr.rng()`` seeded with an
-integer, which converts its seed to an array when it is first used. Seed
-it with an array (``dr.rng(UInt64(0))``) or use it once before the frozen
-call.
-
-The next time the function is called, the inputs are verified against the
-layout of the recording used by the previous call. The verification walks the
-input alongside the layout, and on success replays the recording right away.
-Otherwise the input is analyzed again and the resulting layout is compared
-against all recordings of the function. If a compatible recording is found,
-any tracing is skipped: the various recorded operations and kernels are
-directly replayed.
-
-Traversal
-~~~~~~~~~
-
-In order to map the variables provided to a frozen function as arguments to the
-actual kernel inputs (slots), Dr.Jit must be able to traverse these arguments.
-In addition to basic Python containers such as lists, tuples and dictionaries,
-the following :ref:`PyTrees <pytrees>` are traversable and can be part of the
-input of a frozen function.
-
-*Dataclasses* are traversable by Dr.Jit and their fields are automatically made
-visible to the traversal algorithm.
-
-.. code-block:: python
-
-   # Fields of dataclasses are traversable
-   @dataclass
-   class MyClass:
-      x: Float
-
-Classes can be annotated with a static ``DRJIT_STRUCT`` field to make classes
-traversable.
-
-.. code-block:: python
-
-   class MyClass:
-      x: Float
-
-      # Annotating the class with DRJIT_STRUCT will make the members listed
-      # available to traversal.
-      DRJIT_STRUCT = {
-         "x": Float
-      }
-
-Finally, C++ classes may additionally inherit from ``drjit::TraversableBase``
-and list their members using the ``DR_TRAVERSE_CB`` macro to make them
-traversable. For C++ types subclassed in Python, Dr.Jit will explore both
-members listed via ``DR_TRAVERSE_CB`` and members in the Python instance
-dictionary.
-
-Output construction
-~~~~~~~~~~~~~~~~~~~
-
-After a frozen function has been replayed, the outputs of the replayed operation
-(kernel launches, reductions, etc) have to be mapped back to outputs of the
-frozen function, respecting the layout observed in the first launch.
-
-Since this output must be constructible at replay time, only a subset of
-traversable types can be returned from frozen functions. This includes:
-
-- JIT and AD variables,
-- Dr.Jit Tensors and Arrays,
-- Python lists, tuples and dictionaries,
-- Dataclasses,
-- ``DRJIT_STRUCT`` annotated classes with a default constructor.
-
-The following example shows an *unsupported* return type: because the constructor
-of ``MyClass`` expects a variable, an object of type ``MyClass`` cannot be
-created at replay time.
-
-.. code-block:: python
-
-   class MyClass:
-      x: Float
-
-      DRJIT_STRUCT = {
-         "x": Float,
-      }
-
-      # Non-default constructor (requires argument `x`)
-      def __init__(self, x: Float):
-         self.x = x
-
-   @dr.freeze
-   def func(x):
-      return MyClass(x + 1)
-
-   # Calling the function will fail, as the output of the frozen function
-   # cannot be constructed without a default constructor.
-   func(Float(1, 2, 3))
+Texture initialization uses backend-specific memory operations that are not
+captured by function freezing, such as ``cuMemcpy2DAsync`` on CUDA.
+Building acceleration data structures for GPU ray tracing is likewise
+unsupported and must be done outside the frozen function.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -214,6 +214,7 @@ Function freezing
 -----------------
 
 .. autofunction:: freeze
+.. autoclass:: FrozenFunction
 
 Type traits
 -----------

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -3797,7 +3797,7 @@ def freeze(
     *,
     state_fn: Optional[Callable],
     limit: Optional[int] = None,
-    warn_after: int = 10,
+    warn_after: Optional[int] = 10,
     backend: Optional[JitBackend] = None,
     auto_opaque: bool = True,
     enabled: bool = True,
@@ -3811,7 +3811,7 @@ def freeze(
     *,
     state_fn: Optional[Callable] = None,
     limit: Optional[int] = None,
-    warn_after: int = 10,
+    warn_after: Optional[int] = 10,
     backend: Optional[JitBackend] = None,
     auto_opaque: bool = True,
     enabled: bool = True,
@@ -3824,7 +3824,7 @@ def freeze(
     *,
     state_fn: Optional[Callable] = None,
     limit: Optional[int] = None,
-    warn_after: int = 10,
+    warn_after: Optional[int] = 10,
     backend: Optional[JitBackend] = None,
     auto_opaque: bool = True,
     enabled: bool = True,
@@ -3961,9 +3961,10 @@ def freeze(
           stored configurations. Once this limit is reached, incompatible calls
           requiring re-tracing will cause the last used configuration to be dropped.
 
-        warn_after (int): When the number of re-tracing steps exceeds this value,
-          Dr.Jit will generate a warning that explains which variables changed
-          between calls to the function.
+        warn_after (Optional[int]): When the number of re-tracing steps exceeds
+          this value, Dr.Jit will generate a warning that explains which
+          variables changed between calls to the function. Pass ``None`` to
+          disable the warning, e.g. when re-tracing is expected.
 
         state_fn (Optional[Callable]): An optional callable that specifies additional
           state used to identify the configuration. It receives the same arguments as
@@ -3985,6 +3986,7 @@ def freeze(
     """
 
     limit = limit if limit is not None else -1
+    warn_after = warn_after if warn_after is not None else 0xffffffff
     backend = backend if backend is not None else JitBackend.Invalid
 
     def decorator(f):

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-# Annotations below spell cross-module names fully qualified, as in
-# 'drjit.detail.X'. The stub generator only recognizes that form, which it
-# rewrites into a stub-local reference plus a matching import. This import
-# keeps the spelling valid at runtime.
 import drjit
 from . import detail
 
@@ -3874,8 +3870,9 @@ def freeze(
     - Changes in the **length** of a container (``list``, ``tuple``, ``dict``).
     - Changes of **dictionary keys**  or **field names** of dataclasses.
     - Changes in the AD status (:py:func:`dr.grad_enabled() <drjit.grad_enabled>`) of a variable.
-    - Changes of (non-PyTree) **Python objects**, as detected by mismatching ``hash()``
-      or ``id()`` if they are not hashable.
+    - Changes of (non-PyTree) **Python objects**, as detected by an equality
+      comparison with the value seen when recording (a comparison that raises
+      counts as unequal).
 
     The following more technical conditions also trigger re-tracing:
 
@@ -3972,137 +3969,8 @@ def freeze(
     backend = backend if backend is not None else JitBackend.Invalid
 
     def decorator(f):
-        """
-        Internal decorator, returned in ``dr.freeze`` was used with arguments.
-        """
-        import functools
-        import inspect
-
-        # Capturing closure variables lets the frozen function detect when
-        # nonlocal/global symbols change.
-        _cv = inspect.getclosurevars(f)
-        _global_names = tuple(frozenset(_cv.globals) | frozenset(_cv.unbound))
-        _free_vars = f.__code__.co_freevars
-
-        def capture_closure():
-            g = f.__globals__
-            globals_ = {n: g[n] for n in _global_names if n in g}
-            cells = f.__closure__
-            nonlocals_ = {} if cells is None else {
-                n: c.cell_contents for n, c in zip(_free_vars, cells)
-            }
-            return globals_, nonlocals_
-
-        def inner(input: dict):
-            """
-            This inner function is the one that is actually frozen, and it calls
-            the wrapped function. It receives the input such as args, kwargs and
-            any additional input such as closures or state specified with the ``state``
-            lambda, and makes its traversal possible.
-            """
-            args = input["args"]
-            kwargs = input["kwargs"]
-            return f(*args, **kwargs)
-
-        class FrozenFunction:
-            # If this bool is true, the function will be frozen, otherwise the
-            # call will be forwarded to the inner function.
-            enabled: bool
-
-            def __init__(self, f) -> None:
-                self.f = f
-                self.frozen = detail.FrozenFunction(
-                    inner, limit, warn_after, backend, auto_opaque
-                )
-                self.enabled = enabled
-
-            def __call__(self, *args, **kwargs):
-                if not self.enabled:
-                    return self.f(*args, **kwargs)
-
-                globals_, nonlocals_ = capture_closure()
-                input = {
-                    "globals": globals_,
-                    "nonlocals": nonlocals_,
-                    "args": args,
-                    "kwargs": kwargs,
-                }
-                if state_fn is not None:
-                    input["state_fn"] = state_fn(*args, **kwargs)
-
-                return self.frozen(input)
-
-            @property
-            def n_recordings(self):
-                """
-                Represents the number of times the function was recorded. This
-                includes occasions where it was recorded due to a dry-run failing.
-                It does not necessarily correspond to the number of recordings
-                currently cached see ``n_cached_recordings`` for that.
-                """
-                return self.frozen.n_recordings
-
-            @property
-            def n_cached_recordings(self):
-                """
-                Represents the number of recordings currently cached of the frozen
-                function. If a recording fails in dry-run mode, it will not create
-                a new recording, but replace the recording that was attemted to be
-                replayed. The number of recordings can also be limited with
-                the ``max_cache_size`` argument.
-                """
-                return self.frozen.n_cached_recordings
-
-            def clear(self):
-                """
-                Clears the recordings of the frozen function, and resets the
-                ``n_recordings`` counter. The reference to the function is still
-                kept, and the frozen function can be called again to re-trace
-                new recordings.
-                """
-                return self.frozen.clear()
-
-            def __get__(self, obj, type=None):
-                if obj is None:
-                    return self
-                else:
-                    return FrozenMethod(self.f, self.frozen, obj)
-
-        class FrozenMethod(FrozenFunction):
-            """
-            A FrozenMethod currying the object into the __call__ method.
-
-            If the ``freeze`` decorator is applied to a method of some class, it has
-            to call the internal frozen function with the ``self`` argument. To this
-            end we implement the ``__get__`` method of the frozen function, to
-            return a ``FrozenMethod``, which holds a reference to the object.
-            The ``__call__`` method of the ``FrozenMethod`` then supplies the object
-            in addition to the arguments to the internal function.
-            """
-            def __init__(self, f, frozen, obj) -> None:
-                self.f = f
-                self.obj = obj
-                self.frozen = frozen
-                self.enabled = enabled
-
-            def __call__(self, *args, **kwargs):
-                if not self.enabled:
-                    return self.f(self.obj, *args, **kwargs)
-
-                # self.f is the same function object captured by capture_closure
-                # above (its __globals__/__closure__ are identical).
-                globals_, nonlocals_ = capture_closure()
-                input = {
-                        "globals": globals_,
-                        "nonlocals": nonlocals_,
-                        "args": [self.obj, *args],
-                        "kwargs": kwargs,
-                    }
-                if state_fn is not None:
-                    input["state_fn"] = state_fn(self.obj, *args, **kwargs)
-                return self.frozen(input)
-
-        return functools.wraps(f)(FrozenFunction(f))
+        return wraps(f)(FrozenFunction(f, state_fn, limit, warn_after,
+                                       backend, auto_opaque, enabled))
 
     if f is not None:
         return decorator(f)
@@ -4649,4 +4517,4 @@ newaxis = None
 from . import hashgrid as hashgrid
 from . import nn as nn
 
-del overload, Optional, F, F2
+del F, F2

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -3909,6 +3909,26 @@ def freeze(
     **Advanced features**. The :py:func:`@dr.freeze <drjit.freeze>` decorator takes
     several optional parameters that are helpful in certain situations.
 
+    - **Additional state**: The ``state_fn`` parameter identifies values that
+      Dr.Jit cannot discover on its own. It receives the same arguments as the
+      frozen function and returns a :ref:`PyTree <pytrees>` that is treated as an
+      additional input. For example, it can expose attributes of an ordinary
+      Python class:
+
+      .. code-block:: python
+
+         class Scaler:
+             def __init__(self, scale: Float):
+                 self.scale = scale
+
+             @dr.freeze(state_fn=lambda self, x: self.scale)
+             def apply(self, x: Float):
+                 return self.scale * x
+
+      Alternatively, adding a :ref:`DRJIT_STRUCT annotation <custom_types_py>`
+      to ``Scaler`` would make it a PyTree and let Dr.Jit discover ``scale``
+      without a ``state_fn``.
+
     - **Warning when re-tracing happens too often**: Incompatible arguments trigger
       re-tracing, which can mask issues where *accidentally* incompatible arguments
       keep :py:func:`@dr.freeze <drjit.freeze>` from producing the expected
@@ -3945,11 +3965,10 @@ def freeze(
           Dr.Jit will generate a warning that explains which variables changed
           between calls to the function.
 
-        state_fn (Optional[Callable]): This optional callable can specify additional
-          state to identifies the configuration. ``state_fn`` will be called with
-          the same arguments as that of the decorated function. It should return a
-          traversable object (e.g., a list or tuple) that is conceptually treated
-          as if it was another input of the function.
+        state_fn (Optional[Callable]): An optional callable that specifies additional
+          state used to identify the configuration. It receives the same arguments as
+          the decorated function and should return a traversable object, such as a list
+          or tuple, that is treated as an additional input.
 
         backend (Optional[JitBackend]): If no inputs are given when calling the
           frozen function, the backend used has to be specified using this argument.

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1139,7 +1139,7 @@ def suspend_grad(*args: object, when: bool = True) -> drjit.detail.ADContextMana
     if not when:
         return detail.NullContextManager()
 
-    array_indices = detail.collect_indices(args)
+    array_indices = detail.collect_indices(args, detail.TraverseRole.Gradient)
 
     if len(args) > 0 and len(array_indices) == 0:
         array_indices.append(0)
@@ -1192,7 +1192,7 @@ def resume_grad(*args: object, when: bool = True) -> drjit.detail.ADContextManag
         return detail.NullContextManager()
 
     array_indices = []
-    array_indices = detail.collect_indices(args)
+    array_indices = detail.collect_indices(args, detail.TraverseRole.Gradient)
 
     if len(args) > 0 and len(array_indices) == 0:
         array_indices.append(0)

--- a/drjit/random.py
+++ b/drjit/random.py
@@ -277,11 +277,6 @@ class Philox4x32Generator(Generator):
             if type(seed) is not seed_tp:
                 if symbolic:
                     raise RuntimeError('To generate random numbers within a symbolic loop, you must initialize the Generator with a seed of the underlying JIT backend, e.g.: rng = dr.rng(seed=dr.cuda.UInt32(0))')
-                # When we record a frozen function, this will result in a
-                # change of a type in the input of the function. The recording
-                # were this change occurred cannot be replayed and has to be
-                # discarded.
-                dr.detail.freeze_discard(dr.backend_v(seed_tp), "Philox4x32Generator allocated seed")
 
                 seed = seed_tp(seed)
                 counter = counter_tp(counter)

--- a/include/drjit/array_traverse.h
+++ b/include/drjit/array_traverse.h
@@ -60,6 +60,70 @@ DRJIT_INLINE void traverse_3(T1 &&v1, T2 &&v2, T3 &&v3, F &&f) {
     }
 }
 
+struct TraversableBase;
+
+/**
+ * \brief Purpose of a traversal
+ *
+ * This enumeration characterizes the different roles of an object traversal
+ * conducted through the \ref TraversableBase interface. An object may then choose
+ * to expose or withhold certain attributes based on the role.
+ */
+enum class TraverseRole : uint32_t {
+    /// Catch-all for generic operations like: ``dr.width()``, ``dr.copy()``, etc.
+    Generic,
+
+    /// Scheduling and evaluation
+    Eval,
+
+    /// Automatic differentiation
+    Gradient,
+
+    /// Symbolic loop state tracking (``dr.while_loop()``)
+    Loop,
+
+    /// Symbolic conditional state tracking (``dr.if_stmt()``)
+    Conditional,
+
+    /// Symbolic call state tracking (``dr.switch()``, ``dr.dispatch()``)
+    Call,
+
+    /// Inputs and outputs of a frozen function (``dr.freeze()``)
+    Freeze
+};
+
+/**
+ * \brief Callbacks invoked by the traversal of a C++ object (see \ref
+ * TraversableBase::traverse_cb)
+ *
+ * ``var`` receives the index of each JIT array held by the object and returns
+ * the index that the object holds from now on. A read-only traversal should
+ * simply return the index it was given. A traversal that replaces arrays must
+ * return a borrowed index. This means a callback that callbacks creates a new
+ * variable must keep it alive until the traversal has returns.
+ * When the array is a class pointer array, ``variant`` and ``domain`` identify
+ * its ``CallSupport``, otherwise both are "".
+ *
+ * ``child`` receives each directly held child object (a member deriving from
+ * \ref TraversableBase, whether held by value, pointer, or smart pointer). A
+ * null ``child`` callback requests a deep traversal that descends into every
+ * child object in place.
+ *
+ * Both callbacks receive the ``name`` of the member that the array or child
+ * object was reached through, which \ref DR_TRAVERSE_CB obtains by
+ * stringifying its arguments. It is a compile-time string that the callback
+ * may store without copying it, or an empty string when the traversal does not
+ * name its members. A member expanding into several arrays or child objects
+ * (a container, a nested array, a ``DRJIT_STRUCT``) reports the same name for
+ * each of them.
+ */
+struct TraverseVisitor {
+    TraverseRole role;
+    uint64_t (*var)(void *payload, uint64_t index, const char *name,
+                    const char *variant, const char *domain);
+    void (*child)(void *payload, TraversableBase *obj, const char *name);
+};
+
 namespace detail {
     // Traversal helper for objects that cannot be traversed
     template <typename T, typename SFINAE = int> struct traversable {
@@ -134,18 +198,22 @@ namespace detail {
     };
 
     template <typename T>
-    using det_traverse_1_cb_ro =
-        decltype(T(nullptr)->traverse_1_cb_ro(nullptr, nullptr));
+    static constexpr bool is_traversable_object_v =
+        std::is_base_of_v<TraversableBase, std::remove_cv_t<T>>;
 
+    /// Report a \ref TraversableBase instance to ``cb.child``, or descend
+    /// into it when the callback requests a deep traversal
     template <typename T>
-    using det_traverse_1_cb_rw =
-        decltype(T(nullptr)->traverse_1_cb_rw(nullptr, nullptr));
+    void traverse_child(T *obj, void *payload, const TraverseVisitor &cb,
+                         const char *name) {
+        if (cb.child)
+            cb.child(payload, obj, name);
+        else
+            obj->traverse_cb(payload, cb);
+    }
 
     template <typename T>
     using det_get = decltype(std::declval<T&>().get());
-
-    template <typename T>
-    using det_const_get = decltype(std::declval<const T &>().get());
 
     template<typename T>
     using det_begin = decltype(std::declval<T &>().begin());
@@ -193,117 +261,97 @@ template <typename T> auto labels(const T &v) {
 }
 
 /**
- * This function traverses C++ objects, that have one of the following features:
+ * \brief Traverse the JIT arrays and child objects of a C++ value
  *
- * 1. They represent Jit arrays, in which case the callback is called with
+ * The function handles values with one of the following features:
+ *
+ * 1. They represent Jit arrays, in which case ``cb.var`` is called with
  *    optional domain and variant arguments.
  * 2. They fall under the \c traversable trait (see above), for example
- *    DRJIT_STRUCTs or tuples
+ *    DRJIT_STRUCTs or tuples, whether held by value or by pointer.
  * 3. They represent dynamic arrays.
- * 4. They themselves implement the function \c traverse_1_cb_ro, in which case
- *    this function is called.
+ * 4. They derive from \ref TraversableBase, whether held by value, by
+ *    pointer, or by a smart pointer.
  * 5. They represent iterables with a \c begin and \c end function, such as
  *    \c std::vector or \c drjit::vector.
- * 6. They represent unique pointers, with a constant get method, such as
- *    \c std::unique_ptr.
+ * 6. They represent smart pointers with a \c get method, such as
+ *    \c std::unique_ptr or \c nb::ref.
+ *
+ * Objects deriving from \ref TraversableBase are not descended into. They are
+ * reported through ``cb.child`` instead, and the caller decides whether to
+ * descend into them. This is what lets the caller deduplicate shared objects
+ * and handle reference cycles. A null ``cb.child`` descends in place, which
+ * is a deep traversal that visits shared objects once per reference. Every
+ * other class is a transparent aggregate: it adds no object of its own, and
+ * exposes its members through \ref DRJIT_TRAVERSE.
+ *
+ * The index returned by ``cb.var`` replaces the traversed array if it differs
+ * from the current one. A const value is traversed read-only: the returned
+ * indices are ignored, and child objects are reached through a const cast
+ * with the understanding that the callback returns their indices unchanged.
+ *
+ * ``name`` is the compile-time name of the member holding ``value``, which the
+ * function passes on to every array and child object it finds below it.
  */
-template <typename Value>
-void traverse_1_fn_ro(const Value &value, void *payload,
-                      void (*fn)(void *, uint64_t, const char *,
-                                 const char *)) {
+template <typename Value_>
+void traverse_fn(Value_ &&value, void *payload, const TraverseVisitor &cb,
+                 const char *name = "") {
+    using Value   = std::remove_reference_t<Value_>;
+    using ValueNC = std::remove_cv_t<Value>;
+    using Pointee = std::remove_cv_t<std::remove_pointer_t<ValueNC>>;
+    constexpr bool Write = !std::is_const_v<Value>;
+
     DRJIT_MARK_USED(payload);
-    DRJIT_MARK_USED(fn);
-    if constexpr (is_jit_v<Value> && depth_v<Value> == 1) {
-        if constexpr(Value::IsClass)
-            fn(payload, value.index_combined(), Value::CallSupport::Variant,
-               Value::CallSupport::Domain);
+    DRJIT_MARK_USED(cb);
+    DRJIT_MARK_USED(name);
+
+    if constexpr (is_jit_v<ValueNC> && depth_v<ValueNC> == 1) {
+        uint64_t index = value.index_combined(), index_new;
+        if constexpr (ValueNC::IsClass)
+            index_new = cb.var(payload, index, name,
+                               ValueNC::CallSupport::Variant,
+                               ValueNC::CallSupport::Domain);
         else
-            fn(payload, value.index_combined(), "", "");
-    } else if constexpr (is_traversable_v<Value>) {
-        traverse_1(fields(value), [payload, fn](auto &x) {
-            traverse_1_fn_ro(x, payload, fn);
+            index_new = cb.var(payload, index, name, "", "");
+
+        if constexpr (Write) {
+            if (index_new != index)
+                value = ValueNC::borrow((typename ValueNC::Index) index_new);
+        } else {
+            (void) index_new;
+        }
+    } else if constexpr (is_traversable_v<ValueNC>) {
+        traverse_1(fields(value), [payload, &cb, name](auto &x) {
+            traverse_fn(x, payload, cb, name);
         });
-    } else if constexpr (is_dynamic_traversable_v<Value>) {
+    } else if constexpr (is_dynamic_traversable_v<ValueNC>) {
         for (size_t i = 0; i < value.size(); ++i) {
-            traverse_1(drjit::tie(value.entry(i)), [payload, fn](auto &x) {
-                traverse_1_fn_ro(x, payload, fn);
+            traverse_1(drjit::tie(value.entry(i)), [payload, &cb, name](auto &x) {
+                traverse_fn(x, payload, cb, name);
             });
         }
     } else if constexpr (std::is_array_v<Value>) {
         for (size_t i = 0; i < std::extent_v<Value>; ++i)
-            traverse_1_fn_ro(value[i], payload, fn);
-    } else if constexpr (std::is_pointer_v<Value> &&
-                         is_detected_v<detail::det_traverse_1_cb_ro, Value>) {
+            traverse_fn(value[i], payload, cb, name);
+    } else if constexpr (std::is_pointer_v<ValueNC> &&
+                         detail::is_traversable_object_v<Pointee>) {
         if (value)
-            value->traverse_1_cb_ro(payload, fn);
-
+            detail::traverse_child(const_cast<Pointee *>(value), payload, cb,
+                                    name);
+    } else if constexpr (std::is_pointer_v<ValueNC> &&
+                         is_traversable_v<Pointee>) {
+        if (value)
+            traverse_fn(*value, payload, cb, name);
     } else if constexpr (is_detected_v<detail::det_begin, Value> &&
                          is_detected_v<detail::det_end, Value>) {
-        for (auto elem : value)
-            traverse_1_fn_ro(elem, payload, fn);
-    } else if constexpr (is_detected_v<detail::det_const_get, Value>) {
-        const auto *tmp = value.get();
-        traverse_1_fn_ro(tmp, payload, fn);
-    } else if constexpr (is_detected_v<detail::det_traverse_1_cb_ro, Value *>) {
-        value.traverse_1_cb_ro(payload, fn);
-    }
-}
-
-/**
- * This function traverses C++ objects, that have one of the following features:
- *
- * 1. They represent Jit arrays, in which case the callback is called with
- *    optional domain and variant arguments.
- * 2. They fall under the \c traversable trait (see above), for example
- *    DRJIT_STRUCTs or tuples
- * 3. They represent dynamic arrays.
- * 4. They themselves implement the function \c traverse_1_cb_rw, in which case
- *    this function is called.
- * 5. They represent iterables with a \c begin and \c end function, such as
- *    \c std::vector or \c drjit::vector.
- * 6. They represent unique pointers, with a get method, such as
- *    \c std::unique_ptr.
- */
-template <typename Value>
-void traverse_1_fn_rw(Value &value, void *payload,
-                      uint64_t (*fn)(void *, uint64_t, const char *,
-                                     const char *)) {
-    DRJIT_MARK_USED(payload);
-    DRJIT_MARK_USED(fn);
-    if constexpr (is_jit_v<Value> && depth_v<Value> == 1) {
-        if constexpr(Value::IsClass)
-            value = Value::borrow((typename Value::Index) fn(
-                payload, value.index_combined(), Value::CallSupport::Variant,
-                Value::CallSupport::Domain));
-        else
-            value = Value::borrow((typename Value::Index) fn(
-                payload, value.index_combined(), "", ""));
-    } else if constexpr (is_traversable_v<Value>) {
-        traverse_1(fields(value), [payload, fn](auto &x) {
-            traverse_1_fn_rw(x, payload, fn);
-        });
-    } else if constexpr (is_dynamic_traversable_v<Value>) {
-        for (size_t i = 0; i < value.size(); ++i) {
-            traverse_1(drjit::tie(value.entry(i)), [payload, fn](auto &x) {
-                traverse_1_fn_rw(x, payload, fn);
-            });
-        }
-    } else if constexpr (std::is_array_v<Value>) {
-        for (size_t i = 0; i < std::extent_v<Value>; ++i)
-            traverse_1_fn_rw(value[i], payload, fn);
-    } else if constexpr (std::is_pointer_v<Value> &&
-                         is_detected_v<detail::det_traverse_1_cb_rw, Value>) {
-        if (value)
-            value->traverse_1_cb_rw(payload, fn);
-    } else if constexpr (is_detected_v<detail::det_begin, Value> &&
-                         is_detected_v<detail::det_end, Value>) {
-        for (auto elem : value)
-            traverse_1_fn_rw(elem, payload, fn);
+        for (auto &elem : value)
+            traverse_fn(elem, payload, cb, name);
     } else if constexpr (is_detected_v<detail::det_get, Value>) {
         auto *tmp = value.get();
-        traverse_1_fn_rw(tmp, payload, fn);
-    } else if constexpr (is_detected_v<detail::det_traverse_1_cb_rw, Value *>) {
-        value.traverse_1_cb_rw(payload, fn);
+        traverse_fn(tmp, payload, cb, name);
+    } else if constexpr (detail::is_traversable_object_v<ValueNC>) {
+        detail::traverse_child(const_cast<ValueNC *>(&value), payload, cb,
+                                name);
     }
 }
 

--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -922,7 +922,8 @@ void traverse(ADMode mode, uint32_t flags = (uint32_t) ADFlag::Default) {
 
 namespace detail {
     template <bool IncRef, typename T>
-    void collect_indices(const T &value, vector<uint64_t> &indices);
+    void collect_indices(const T &value, vector<uint64_t> &indices,
+                         TraverseRole role);
 }
 
 template <typename T> struct suspend_grad {
@@ -937,7 +938,8 @@ template <typename T> struct suspend_grad {
         if constexpr (Enabled) {
             if (condition) {
                 vector<uint64_t> indices;
-                (detail::collect_indices<false>(args, indices), ...);
+                (detail::collect_indices<false>(args, indices,
+                                                TraverseRole::Gradient), ...);
                 ad_scope_enter(
                     ADScope::Suspend, indices.size(), indices.data(), -1);
             }
@@ -969,7 +971,8 @@ template <typename T> struct resume_grad {
         if constexpr (Enabled) {
             if (condition) {
                 vector<uint64_t> indices;
-                (detail::collect_indices<false>(args, indices), ...);
+                (detail::collect_indices<false>(args, indices,
+                                                TraverseRole::Gradient), ...);
                 ad_scope_enter(
                     ADScope::Resume, indices.size(), indices.data(), -1);
             }
@@ -1066,15 +1069,15 @@ void forward(T &value, uint32_t flags = (uint32_t) ADFlag::Default) {
 NAMESPACE_BEGIN(detail)
 
 /// Internal operations for traversing nested data structures and fetching or
-/// storing indices. Used in ``call.h`` and ``loop.h``.
+/// storing indices. Used in ``call.h``, ``while_loop.h`` and ``if_stmt.h``.
 
 template <bool IncRef>
-void collect_indices_fn(void *p, uint64_t index, const char * /*variant*/,
-                        const char * /*domain*/) {
+uint64_t collect_indices_fn(void *p, uint64_t index, const char * /*name*/,
+                            const char * /*variant*/,
+                            const char * /*domain*/) {
     vector<uint64_t> &indices = *(vector<uint64_t> *) p;
-    if constexpr (IncRef)
-        index = ad_var_inc_ref(index);
-    indices.push_back(index);
+    indices.push_back(IncRef ? ad_var_inc_ref(index) : index);
+    return index;
 }
 
 struct update_indices_payload {
@@ -1082,26 +1085,32 @@ struct update_indices_payload {
     size_t &pos;
 };
 
-inline uint64_t update_indices_fn(void *p, uint64_t, const char * /*variant*/,
+inline uint64_t update_indices_fn(void *p, uint64_t, const char * /*name*/,
+                                  const char * /*variant*/,
                                   const char * /*domain*/) {
     update_indices_payload &payload = *(update_indices_payload *) p;
     return payload.indices[payload.pos++];
 }
 
 template <bool IncRef, typename Value>
-void collect_indices(const Value &value, vector<uint64_t> &indices) {
-    traverse_1_fn_ro(value, (void *) &indices, collect_indices_fn<IncRef>);
+void collect_indices(const Value &value, vector<uint64_t> &indices,
+                     TraverseRole role) {
+    traverse_fn(value, (void *) &indices,
+                TraverseVisitor { role, collect_indices_fn<IncRef>, nullptr });
 }
 
 template <typename Value>
-void update_indices(Value &value, const vector<uint64_t> &indices, size_t &pos) {
+void update_indices(Value &value, const vector<uint64_t> &indices, size_t &pos,
+                    TraverseRole role) {
     update_indices_payload payload { indices, pos };
-    traverse_1_fn_rw(value, (void *) &payload, update_indices_fn);
+    traverse_fn(value, (void *) &payload,
+                TraverseVisitor { role, update_indices_fn, nullptr });
 }
 
-template <typename T> void update_indices(T &value, const vector<uint64_t> &indices) {
+template <typename T>
+void update_indices(T &value, const vector<uint64_t> &indices, TraverseRole role) {
     size_t pos = 0;
-    update_indices(value, indices, pos);
+    update_indices(value, indices, pos, role);
 #if !defined(NDEBUG)
     if (pos != indices.size())
         drjit_fail("update_indices(): did not consume the expected number of indices!");

--- a/include/drjit/call.h
+++ b/include/drjit/call.h
@@ -187,11 +187,11 @@ template <typename Ret, typename... Args> struct CallState {
     }
 
     void update_args(const vector<uint64_t> &indices) {
-        update_indices(args, indices);
+        update_indices(args, indices, TraverseRole::Call);
     }
 
     void collect_rv(vector<uint64_t> &indices) const {
-        collect_indices<false>(rv, indices);
+        collect_indices<false>(rv, indices, TraverseRole::Call);
     }
 };
 
@@ -206,7 +206,7 @@ Ret call(const Self &self, const char *variant, const char *domain,
     Mask mask = extract_mask<Mask>(state->args);
 
     index64_vector args_i, rv_i;
-    collect_indices<true>(state->args, args_i);
+    collect_indices<true>(state->args, args_i, TraverseRole::Call);
     bool done = ad_call(Self::Backend, variant, domain, -1, 0, name, is_getter,
                         self.index(), mask.index(), args_i, rv_i, state,
                         callback, &CallStateT::cleanup, true);
@@ -214,7 +214,7 @@ Ret call(const Self &self, const char *variant, const char *domain,
     if constexpr (!std::is_same_v<Ret, void>) {
         Ret2 result(std::move(state->rv));
         if (!rv_i.empty())
-            update_indices(result, rv_i);
+            update_indices(result, rv_i, TraverseRole::Call);
         else
             result = zeros<Ret2>();
 

--- a/include/drjit/custom.h
+++ b/include/drjit/custom.h
@@ -12,7 +12,9 @@
 
 #pragma once
 
-#define NB_INTRUSIVE_EXPORT DRJIT_EXTRA_EXPORT
+#if !defined(NB_INTRUSIVE_EXPORT)
+#  define NB_INTRUSIVE_EXPORT DRJIT_EXTRA_EXPORT
+#endif
 
 #include <drjit/autodiff.h>
 #include <drjit/extra.h>

--- a/include/drjit/if_stmt.h
+++ b/include/drjit/if_stmt.h
@@ -67,14 +67,14 @@ auto if_stmt_impl(std::index_sequence<Is...>, Args &&args, const Mask &cond,
                                   vector<uint64_t> &rv_i) {
             IfStmtData *isd = (IfStmtData *) p;
 
-            update_indices(isd->args, args_i);
+            update_indices(isd->args, args_i, TraverseRole::Conditional);
 
             if (value)
                 isd->rv = isd->true_fn(get<Is>(isd->args)...);
             else
                 isd->rv = isd->false_fn(get<Is>(isd->args)...);
 
-            collect_indices<true>(isd->rv, rv_i);
+            collect_indices<true>(isd->rv, rv_i, TraverseRole::Conditional);
         };
 
         ad_cond_delete delete_cb = [](void *p) { delete (IfStmtData *) p; };
@@ -86,7 +86,8 @@ auto if_stmt_impl(std::index_sequence<Is...>, Args &&args, const Mask &cond,
                             Return() });
 
         detail::index64_vector args_i, rv_i;
-        detail::collect_indices<true>(isd->args, args_i);
+        detail::collect_indices<true>(isd->args, args_i,
+                                      TraverseRole::Conditional);
 
         bool all_done = ad_cond(Mask::Backend, -1, name, isd.get(), cond.index(),
                                 args_i, rv_i, body_cb, delete_cb, true);
@@ -96,7 +97,7 @@ auto if_stmt_impl(std::index_sequence<Is...>, Args &&args, const Mask &cond,
         if (!all_done)
             isd.release();
 
-        detail::update_indices(rv, rv_i);
+        detail::update_indices(rv, rv_i, TraverseRole::Conditional);
 
         return rv;
     }

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -1123,93 +1123,27 @@ template <typename T> void bind_all(ArrayBinding &b) {
     bind_array<Tensor<float64_array_t<T2>>>(b);
 }
 
-// Expose already existing object tree traversal callbacks (T::traverse_1_..) in Python.
-// This functionality is needed to traverse custom/opaque C++ classes and correctly
-// update their members when they are used in vectorized loops, function calls, etc.
-template <typename T, typename... Args> auto &bind_traverse(nanobind::class_<T, Args...> &cls)
-{
+// Expose deep object tree traversal as ``_traverse_cb(role, callback)``
+template <typename T, typename... Args> auto &bind_traverse(nanobind::class_<T, Args...> &cls) {
     namespace nb = nanobind;
-    struct Payload {
-        nb::callable c;
-    };
+    struct Payload { nb::callable c; };
 
     static_assert(std::is_base_of_v<TraversableBase, T>);
 
-    cls.def("_traverse_1_cb_ro", [](const T *self, nb::callable c) {
+    cls.def("_traverse_cb", [](T *self, TraverseRole role, nb::callable c) {
         Payload payload{ std::move(c) };
-        self->traverse_1_cb_ro((void *) &payload,
-            [](void *p, uint64_t index, const char *variant, const char *domain) {
-                ((Payload *) p)->c(index, variant, domain);
-            });
-    });
-
-    cls.def("_traverse_1_cb_rw", [](T *self, nb::callable c) {
-        Payload payload{ std::move(c) };
-        self->traverse_1_cb_rw((void *) &payload, [](void *p, uint64_t index,
-                                                     const char *variant,
-                                                     const char *domain) {
-            return nb::cast<uint64_t>(
-                ((Payload *) p)->c(index, variant, domain));
-        });
+        traverse_fn(self, (void *) &payload,
+            TraverseVisitor {
+                role,
+                [](void *p, uint64_t index, const char *name,
+                   const char *variant, const char *domain) {
+                    return nb::cast<uint64_t>(
+                        ((Payload *) p)->c(index, name, variant, domain));
+                },
+                nullptr });
     });
 
     return cls;
-}
-
-/**
- * \brief This function traverses a python object, that inherits from a
- * trampoline class.
- *
- * Internally, this function calls the ``traverse_py_cb_ro_impl`` function,
- * exposed through ``drjit.detail``, with the object and the callback.
- */
-inline void traverse_py_cb_ro(const TraversableBase *base, void *payload,
-                              void (*fn)(void *, uint64_t, const char *variant,
-                                         const char *domain)) {
-    namespace nb    = nanobind;
-    nb::gil_scoped_acquire guard;
-
-    nb::handle self = base->self_py();
-    if (!self)
-        return;
-
-    // Resolved once; non-owning reference, kept alive by drjit.detail's module dict.
-    static nb::handle traverse_py_cb_ro_fn =
-        nb::module_::import_("drjit.detail").attr("traverse_py_cb_ro");
-
-    traverse_py_cb_ro_fn(self,
-        nb::cpp_function([&](uint64_t index, const char *variant,
-                           const char *domain) {
-            fn(payload, index, variant, domain);
-        }));
-}
-
-/**
- * \brief This function traverses a python object, that inherits from a
- * trampoline class.
- *
- * Internally, this function calls the ``traverse_py_cb_rw_impl`` function,
- * exposed through ``drjit.detail``, with the object and the callback.
- */
-inline void traverse_py_cb_rw(TraversableBase *base, void *payload,
-                              uint64_t (*fn)(void *, uint64_t, const char *,
-                                             const char *)) {
-    namespace nb    = nanobind;
-    nb::gil_scoped_acquire guard;
-
-    nb::handle self = base->self_py();
-    if (!self)
-        return;
-
-    // Resolved once; non-owning reference, kept alive by drjit.detail's module dict.
-    static nb::handle traverse_py_cb_rw_fn =
-        nb::module_::import_("drjit.detail").attr("traverse_py_cb_rw");
-
-    traverse_py_cb_rw_fn(self,
-    nb::cpp_function([&](uint64_t index, const char *variant,
-                       const char *domain) {
-        return fn(payload, index, variant, domain);
-    }));
 }
 
 NAMESPACE_END(drjit)

--- a/include/drjit/texture.h
+++ b/include/drjit/texture.h
@@ -30,7 +30,7 @@
 
 NAMESPACE_BEGIN(drjit)
 
-template <typename Storage_, size_t Dimension> class Texture : TraversableBase {
+template <typename Storage_, size_t Dimension> class Texture : public TraversableBase {
 public:
     static constexpr bool IsCUDA = is_cuda_v<Storage_>;
     static constexpr bool IsMetal = is_metal_v<Storage_>;
@@ -1951,35 +1951,14 @@ private:
     vector<TensorXf> m_levels;
 
 public:
-    void
-    traverse_1_cb_ro(void *payload,
-                     drjit ::detail ::traverse_callback_ro fn) const override {
-        // Traverse the function to react to changes when freezing code via
-        // @dr.freeze. In all other contexts, the texture is read-only and does
-        // not require traversal
-        if (!jit_flag(JitFlag::EnableObjectTraversal))
+    void traverse_cb(void *payload, const drjit::TraverseVisitor &cb) override {
+        // The texture data only takes part in frozen functions, which must
+        // react to changes of the underlying arrays. In every other context
+        // (loops, calls, evaluation) the texture is a read-only resource.
+        if (cb.role != TraverseRole::Freeze)
             return;
 
-        DRJIT_MAP(DR_TRAVERSE_MEMBER_RO, m_padded_tensor, m_tensor,
-                  m_resolution_opaque, m_inv_resolution, m_mip, m_mip_table,
-                  m_levels);
-        if constexpr (HasGPUTexture) {
-            uint32_t n_indices = tex_n_indices();
-            uint32_t *indices = (uint32_t *) alloca(sizeof(uint32_t) * n_indices);
-            jit_tex_get_indices(m_handle, indices);
-            for (uint32_t i = 0; i < n_indices; i++)
-                fn(payload, indices[i], "", "");
-        }
-    }
-    void traverse_1_cb_rw(void *payload,
-                          drjit ::detail ::traverse_callback_rw fn) override {
-        // Only traverse the scene for frozen functions, since accidentally
-        // traversing the scene in loops or vcalls can cause errors with
-        // variable size mismatches, and backpropagation of gradients.
-        if (!jit_flag(JitFlag::EnableObjectTraversal))
-            return;
-
-        DRJIT_MAP(DR_TRAVERSE_MEMBER_RW, m_padded_tensor, m_tensor,
+        DRJIT_MAP(DR_TRAVERSE_MEMBER, m_padded_tensor, m_tensor,
                   m_resolution_opaque, m_inv_resolution, m_mip, m_mip_table,
                   m_levels);
 
@@ -1988,7 +1967,8 @@ public:
             uint32_t *indices = (uint32_t *) alloca(sizeof(uint32_t) * n_indices);
             jit_tex_get_indices(m_handle, indices);
             for (uint32_t i = 0; i < n_indices; i++) {
-                uint64_t new_index = fn(payload, indices[i], "", "");
+                uint64_t new_index =
+                    cb.var(payload, indices[i], "m_handle", "", "");
                 if (new_index != indices[i])
                     jit_raise("A texture was changed by traversing it. This is "
                               "not supported!");

--- a/include/drjit/texture_impl.h
+++ b/include/drjit/texture_impl.h
@@ -114,6 +114,13 @@ private:
     size_t m_size;
 };
 
+/// Reduce a texel-space coordinate to the range that \c Int can represent, so
+/// that ``pos_f - to_float(floor2int(pos_f))`` cannot blow up to inf or NaN
+template <typename Ops>
+typename Ops::Float tex_clamp_pos(const Ops &ops, const typename Ops::Float &pos_f) {
+    return clip(pos_f, ops.lit(-0x1p30), ops.lit(0x1p30));
+}
+
 /// Apply the wrapping mode to one integer coordinate along dimension \c k
 template <typename Ops>
 typename Ops::Int tex_wrap(const Ops &ops, const typename Ops::Int &pos, uint32_t k) {
@@ -327,8 +334,9 @@ void tex_eval(const Ops &ops, const typename Ops::Float *pos,
     Float pos_f[MaxDim];
     Int pos_i[MaxDim];
     for (uint32_t k = 0; k < dim; ++k) {
-        pos_f[k] = nearest ? pos[k] * ops.res_f(k)
-                           : fmadd(pos[k], ops.res_f(k), ops.lit(-0.5));
+        pos_f[k] = tex_clamp_pos(ops, nearest
+                                     ? pos[k] * ops.res_f(k)
+                                     : fmadd(pos[k], ops.res_f(k), ops.lit(-0.5)));
         pos_i[k] = floor2int<Int>(pos_f[k]);
     }
 
@@ -594,7 +602,8 @@ void tex_eval_cubic(const Ops &ops, const typename Ops::Float *pos,
     Int pos_i[MaxDim];
     Float w[MaxDim][4];
     for (uint32_t k = 0; k < dim; ++k) {
-        Float pos_f = fmadd(pos[k], ops.res_f(k), ops.lit(-0.5));
+        Float pos_f = tex_clamp_pos(
+            ops, fmadd(pos[k], ops.res_f(k), ops.lit(-0.5)));
         pos_i[k] = floor2int<Int>(pos_f);
         tex_cubic_weights(ops, pos_f - ops.to_float(pos_i[k]), w[k]);
     }
@@ -634,7 +643,8 @@ void tex_eval_cubic_deriv(const Ops &ops, const typename Ops::Float *pos,
     Int pos_i[MaxDim];
     Float wv[MaxDim][4], wg[MaxDim][4], wh[MaxDim][4];
     for (uint32_t k = 0; k < dim; ++k) {
-        Float pos_f = fmadd(pos[k], ops.res_f(k), ops.lit(-0.5));
+        Float pos_f = tex_clamp_pos(
+            ops, fmadd(pos[k], ops.res_f(k), ops.lit(-0.5)));
         pos_i[k] = floor2int<Int>(pos_f);
         Float alpha = pos_f - ops.to_float(pos_i[k]);
         tex_cubic_weights(ops, alpha, wv[k]);
@@ -727,7 +737,8 @@ void tex_fetch(const Ops &ops,
 
     Int pos_i[MaxDim];
     for (uint32_t k = 0; k < dim; ++k) {
-        Float pos_f = fmadd(pos[k], ops.res_f(k), ops.lit(-0.5));
+        Float pos_f = tex_clamp_pos(
+            ops, fmadd(pos[k], ops.res_f(k), ops.lit(-0.5)));
         pos_i[k] = floor2int<Int>(pos_f);
     }
 

--- a/include/drjit/traversable_base.h
+++ b/include/drjit/traversable_base.h
@@ -4,75 +4,20 @@
 #include <drjit-core/jit.h>
 #include <drjit-core/macros.h>
 #include <drjit/array_traverse.h>
+#include <drjit/extra.h>
 #include <drjit/map.h>
+
+// The intrusive reference counting implementation lives in drjit-extra
+#if !defined(NB_INTRUSIVE_EXPORT)
+#  define NB_INTRUSIVE_EXPORT DRJIT_EXTRA_EXPORT
+#endif
+
 #include <nanobind/intrusive/counter.h>
 #include <nanobind/intrusive/ref.h>
 
 NAMESPACE_BEGIN(drjit)
 
 NAMESPACE_BEGIN(detail)
-/**
- * \brief The callback used to traverse all JIT arrays of a C++ object.
- *
- * \param payload:
- *     To wrap closures, a payload can be provided to the ``traverse_1_cb_ro``
- *     function, that is passed to the callback.
- *
- * \param index:
- *     A non-owning index of the traversed JIT array.
- *
- * \param variant:
- *     If a ``JitArray`` has the attribute ``IsClass`` it is referring to a
- *     drjit class. When such a variable is traversed, the ``variant`` and
- *     ``domain`` string of its ``CallSupport`` is provided to the callback
- *     using this argument. Otherwise the string is equal to "".
- *
- * \param domain:
- *     The domain of the ``CallSupport`` when traversing a class variable.
- */
-using traverse_callback_ro = void (*)(void *payload, uint64_t index,
-                                      const char *variant, const char *domain);
-/**
- * \brief The callback used to traverse and modify all JIT arrays of a C++ object.
- *
- * \param payload:
- *     To wrap closures, a payload can be provided to the ``traverse_1_cb_ro``
- *     function, that is passed to the callback.
- *
- * \param index:
- *     A non-owning index of the traversed JIT array.
- *
- * \param variant:
- *     If a ``JitArray`` has the attribute ``IsClass`` it is referring to a
- *     drjit class. When such a variable is traversed, the ``variant`` and
- *     ``domain`` string of its ``CallSupport`` is provided to the callback
- *     using this argument. Otherwise the string is equal to "".
- *
- * \param domain:
- *     The domain of the ``CallSupport`` when traversing a class variable.
- *
- * \return
- *     The new index of the traversed variable. This index is borrowed, and
- *     should therefore be non-owning.
- */
-using traverse_callback_rw = uint64_t (*)(void *payload, uint64_t index,
-                                          const char *variant,
-                                          const char *domain);
-
-inline void log_member_open(bool rw, const char *member) {
-    DRJIT_MARK_USED(rw);
-    DRJIT_MARK_USED(member);
-#ifndef NDEBUG
-    jit_log(LogLevel::Debug, "%s%s{", rw ? "rw " : "ro ", member);
-#endif
-}
-
-inline void log_member_close() {
-#ifndef NDEBUG
-    jit_log(LogLevel::Debug, "}");
-#endif
-}
-
 NAMESPACE_END(detail)
 
 #if defined(_MSC_VER)
@@ -83,155 +28,50 @@ NAMESPACE_END(detail)
 /**
  * \brief Interface for traversing C++ objects.
  *
- * This interface should be inherited by any class that can be added to the
- * registry. We try to ensure this by wrapping the function ``jit_registry_put``
- * in the function ``drjit::registry_put`` that takes a ``TraversableBase`` for
- * the pointer argument.
+ * This interface exposes members (Dr.Jit arrays, child objects) of classes
+ * using a callback for recursive traversal. The function freezing feature
+ * (``@dr.freeze``) requires this functionality to peek into otherwise opaque
+ * C++ instances and observe how their contents change.
  */
 struct DRJIT_EXTRA_EXPORT TraversableBase : public nanobind::intrusive_base {
     /**
-     * \brief Traverse all JIT arrays in this c++ object. For every jit
-     *     variable, the callback should be called, with the provided payload
-     *     pointer.
+     * \brief Invoke the provided \ref TraverseVisitor callback for all tracked
+     * Dr.Jit arrays and TraversableBase-derived instances reachable from
+     * \c this.
      *
-     * \param payload:
-     *    A pointer to a payload struct. The callback ``cb`` is called with this
-     *    pointer.
-     *
-     * \param cb:
-     *    A function pointer, that is called with the ``payload`` pointer, the
-     *    index of the jit variable, and optionally the domain and variant of a
-     *    ``Class`` variable.
+     * See the \ref TraverseVisitor class for details on the protocol.
      */
-    virtual void traverse_1_cb_ro(void *payload,
-                                  detail::traverse_callback_ro cb) const = 0;
-
-    /**
-     * \brief Traverse all JIT arrays in this c++ object, and assign the output of the
-     *     callback to them. For every jit variable, the callback should be called,
-     *     with the provided payload pointer.
-     *
-     * \param payload:
-     *    A pointer to a payload struct. The callback ``cb`` is called with this
-     *    pointer.
-     *
-     * \param cb:
-     *    A function pointer, that is called with the ``payload`` pointer, the
-     *    index of the jit variable, and optionally the domain and variant of a
-     *    ``Class`` variable. The resulting index of calling this function
-     *    pointer will be assigned to the traversed variable. The return value
-     *    of the is borrowed from when overwriting assigning the traversed
-     *    variable.
-     */
-    virtual void traverse_1_cb_rw(void *payload,
-                                  detail::traverse_callback_rw cb) = 0;
+    virtual void traverse_cb(void *payload, const TraverseVisitor &cb) = 0;
 };
 
 #if defined(_MSC_VER)
 #  pragma warning(pop)
 #endif
 
-/**
- * \brief Macro for generating call to \c traverse_1_fn_ro for a class member.
- *
- * This is only a utility macro, for the DR_TRAVERSE_CB_RO macro. It can only be
- * used in a context, where the ``payload`` and ``fn`` variables are present.
- */
-#define DR_TRAVERSE_MEMBER_RO(member)                                          \
-    drjit::detail::log_member_open(false, #member);                            \
-    drjit::traverse_1_fn_ro(member, payload, fn);                              \
-    drjit::detail::log_member_close();
+/// Helper macro for DR_TRAVERSE_CB, which names the member it traverses
+#define DR_TRAVERSE_MEMBER(member)                                             \
+    drjit::traverse_fn(member, payload, cb, #member);
 
 /**
- * \brief Macro for generating call to \c traverse_1_fn_rw for a class member.
+ * \brief Macro generating the implementation of the ``traverse_cb`` method
  *
- * This is only a utility macro, for the DR_TRAVERSE_CB_RW macro. It can only be
- * used in a context, where the ``payload`` and ``fn`` variables are present.
- */
-#define DR_TRAVERSE_MEMBER_RW(member)                                          \
-    drjit::detail::log_member_open(true, #member);                             \
-    drjit::traverse_1_fn_rw(member, payload, fn);                              \
-    drjit::detail::log_member_close();
-
-/**
- * \brief Macro, generating the implementation of the ``traverse_1_cb_ro``
- *     method.
- *
- * The first argument should be the base class, from which the current class
- * inherits. The other arguments should list all members of that class, which
- * are supposed to be read only traversable.
- */
-#define DR_TRAVERSE_CB_RO(Base, ...)                                           \
-    void traverse_1_cb_ro(void *payload,                                       \
-                          drjit::detail::traverse_callback_ro fn)              \
-        const override {                                                       \
-        static_assert(                                                         \
-            std::is_base_of<drjit::TraversableBase,                            \
-                            std::remove_pointer_t<decltype(this)>>::value);    \
-        DRJIT_MARK_USED(payload);                                              \
-        DRJIT_MARK_USED(fn);                                                   \
-        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
-            Base::traverse_1_cb_ro(payload, fn);                               \
-        DRJIT_MAP(DR_TRAVERSE_MEMBER_RO, __VA_ARGS__)                          \
-    }
-
-/**
- * \breif Macro, generating the implementation of the ``traverse_1_cb_rw``
- *     method.
- *
- * The first argument should be the base class, from which the current class
- * inherits. The other arguments should list all members of that class, which
- * are supposed to be read and write traversable.
- */
-#define DR_TRAVERSE_CB_RW(Base, ...)                                           \
-    void traverse_1_cb_rw(void *payload,                                       \
-                          drjit::detail::traverse_callback_rw fn) override {   \
-        static_assert(                                                         \
-            std::is_base_of<drjit::TraversableBase,                            \
-                            std::remove_pointer_t<decltype(this)>>::value);    \
-        DRJIT_MARK_USED(payload);                                              \
-        DRJIT_MARK_USED(fn);                                                   \
-        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
-            Base::traverse_1_cb_rw(payload, fn);                               \
-        DRJIT_MAP(DR_TRAVERSE_MEMBER_RW, __VA_ARGS__)                          \
-    }
-
-/**
- * \brief Macro, generating the both the implementations of the
- *     ``traverse_1_cb_ro`` and ``traverse_1_cb_rw`` methods.
- *
- * The first argument should be the base class, from which the current class
- * inherits. The other arguments should list all members of that class, which
- * are supposed to be read and write traversable.
+ * The first argument is the base class of the current class. The remaining
+ * arguments list the members to traverse. Trampoline classes of nanobind
+ * bindings list no members: the Dr.Jit arrays stored in the ``__dict__`` of a
+ * derived Python object are discovered by the Python-side traversal.
  */
 #define DR_TRAVERSE_CB(Base, ...)                                              \
 public:                                                                        \
-    DR_TRAVERSE_CB_RO(Base, __VA_ARGS__)                                       \
-    DR_TRAVERSE_CB_RW(Base, __VA_ARGS__)
-
-/**
- * \brief Macro, generating the implementations of ``traverse_1_cb_ro`` and
- *     ``traverse_1_cb_rw`` of a nanobind trampoline class.
- *
- * This macro should only be instantiated on trampoline classes, that serve as
- * the base class for derived types in Python. Adding this macro to a trampoline
- * class, allows for the automatic traversal of all python members in any
- * derived python class.
- */
-#define DR_TRAMPOLINE_TRAVERSE_CB(Base)                                        \
-public:                                                                        \
-    void traverse_1_cb_ro(void *payload,                                       \
-                          drjit::detail::traverse_callback_ro fn)              \
-        const override {                                                       \
+    void traverse_cb(void *payload, const drjit::TraverseVisitor &cb)          \
+        override {                                                             \
+        static_assert(                                                         \
+            std::is_base_of<drjit::TraversableBase,                            \
+                            std::remove_pointer_t<decltype(this)>>::value);    \
+        DRJIT_MARK_USED(payload);                                              \
+        DRJIT_MARK_USED(cb);                                                   \
         if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
-            Base::traverse_1_cb_ro(payload, fn);                               \
-        drjit::traverse_py_cb_ro(this, payload, fn);                           \
-    }                                                                          \
-    void traverse_1_cb_rw(void *payload,                                       \
-                          drjit::detail::traverse_callback_rw fn) override {   \
-        if constexpr (!std::is_same_v<Base, drjit::TraversableBase>)           \
-            Base::traverse_1_cb_rw(payload, fn);                               \
-        drjit::traverse_py_cb_rw(this, payload, fn);                           \
+            Base::traverse_cb(payload, cb);                                    \
+        DRJIT_MAP(DR_TRAVERSE_MEMBER, __VA_ARGS__)                             \
     }
 
 /**

--- a/include/drjit/while_loop.h
+++ b/include/drjit/while_loop.h
@@ -60,11 +60,13 @@ StateD while_loop_impl(std::index_sequence<Is...>, State &&state_, Cond &&cond,
         };
 
         ad_loop_read read_cb = [](void *p, vector<uint64_t> &indices) {
-            detail::collect_indices<true>(((Payload *) p)->state, indices);
+            detail::collect_indices<true>(((Payload *) p)->state, indices,
+                                          TraverseRole::Loop);
         };
 
         ad_loop_write write_cb = [](void *p, const vector<uint64_t> &indices, bool) {
-            detail::update_indices(((Payload *) p)->state, indices);
+            detail::update_indices(((Payload *) p)->state, indices,
+                                   TraverseRole::Loop);
         };
 
         ad_loop_cond cond_cb = [](void *p) -> uint32_t {

--- a/src/extra/texture.cpp
+++ b/src/extra/texture.cpp
@@ -223,7 +223,7 @@ struct JitOps {
         ad_loop_write write_cb = [](void *q, const dr::vector<uint64_t> &indices,
                                     bool) {
             Payload *pl = (Payload *) q;
-            pl->i = Int::borrow(indices[0]);
+            pl->i = Int::borrow((uint32_t) indices[0]);
             for (uint32_t j = 0; j < pl->n_state; ++j)
                 pl->state[j] = Float::borrow(indices[j + 1]);
         };

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -74,6 +74,7 @@ nanobind_add_module(
   reduce.h      reduce.cpp
   apply.h       apply.cpp
   eval.h        eval.cpp
+  funcenv.h     funcenv.cpp
   freeze.h      freeze.cpp
   memop.h       memop.cpp
   slice.h       slice.cpp

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -76,6 +76,9 @@ nanobind_add_module(
   eval.h        eval.cpp
   funcenv.h     funcenv.cpp
   freeze.h      freeze.cpp
+  freeze_layout.h freeze_layout.cpp
+  freeze_output.cpp
+  freeze_verify.cpp
   memop.h       memop.cpp
   slice.h       slice.cpp
   dlpack.h      dlpack.cpp

--- a/src/python/apply.cpp
+++ b/src/python/apply.cpp
@@ -17,6 +17,8 @@
 #include "shape.h"
 #include "init.h"
 #include <algorithm>
+#include <tsl/robin_set.h>
+#include <drjit-core/hash.h>
 
 static const char *op_names[] = {
     // Unary operations
@@ -630,8 +632,39 @@ struct recursion_guard {
 uint64_t TraverseCallback::operator()(uint64_t, const char *, const char *) { return 0; }
 void TraverseCallback::traverse_unknown(nb::handle) { }
 
+/// C++ objects entered by a traversal (see traverse_object() in apply.h)
+using VisitedSet = tsl::robin_set<dr::TraversableBase *, PointerHasher>;
+
+/// Parameters of a traversal, shared by its recursive steps
+struct TraverseState {
+    const char *op;
+    TraverseCallback &tc;
+    dr::TraverseRole role;
+    bool rw;
+    VisitedSet &visited;
+
+    uint64_t var(uint64_t index, const char *variant, const char *domain) {
+        uint64_t result = tc(index, variant, domain);
+        return rw ? result : index;
+    }
+
+    void py(nb::dict d) {
+        for (nb::handle value : d.values())
+            traverse_impl(value);
+    }
+
+    void traverse_impl(nb::handle h);
+};
+
 /// Invoke the given callback on leaf elements of the pytree 'h'
-void traverse(const char *op, TraverseCallback &tc, nb::handle h, bool rw) {
+void traverse(const char *op, TraverseCallback &tc, nb::handle h,
+              dr::TraverseRole role, bool rw) {
+    VisitedSet visited;
+    TraverseState st { op, tc, role, rw, visited };
+    st.traverse_impl(h);
+}
+
+void TraverseState::traverse_impl(nb::handle h) {
     recursion_guard guard;
 
     nb::handle tp = h.type();
@@ -649,60 +682,30 @@ void traverse(const char *op, TraverseCallback &tc, nb::handle h, bool rw) {
                     len = s.len(inst_ptr(h));
 
                 for (Py_ssize_t i = 0; i < len; ++i)
-                    traverse(op, tc, nb::steal(s.item(h.ptr(), i)), rw);
+                    traverse_impl(nb::steal(s.item(h.ptr(), i)));
             } else  {
                 tc(h);
             }
         } else if (tp.is(&PyTuple_Type)) {
             for (nb::handle h2 : nb::borrow<nb::tuple>(h))
-                traverse(op, tc, h2, rw);
+                traverse_impl(h2);
         } else if (tp.is(&PyList_Type)) {
             for (nb::handle h2 : nb::borrow<nb::list>(h))
-                traverse(op, tc, h2, rw);
+                traverse_impl(h2);
         } else if (tp.is(&PyDict_Type)) {
             for (nb::handle h2 : nb::borrow<nb::dict>(h).values())
-                traverse(op, tc, h2, rw);
+                traverse_impl(h2);
+        } else if (auto traversable = traversable_ptr(h); traversable) {
+            traverse_object(*this, traversable);
         } else if (nb::dict ds = get_drjit_struct(tp); ds.is_valid()) {
             for (auto [k, v] : ds)
-                traverse(op, tc, nb::getattr(h, k), rw);
-        } else if (nb::dict df = get_dataclass_field_dict(tp); df.is_valid()) {
+                traverse_impl(nb::getattr(h, k));
+        } else if (nb::dict df = dataclass_field_dict(tp); df.is_valid()) {
             for (auto [k, field] : df)
                 if (is_dataclass_field(field))
-                    traverse(op, tc, nb::getattr(h, k), rw);
-        } else if (auto traversable = get_traversable_base(h); traversable) {
-            struct Payload {
-                TraverseCallback &tc;
-            };
-            Payload p{ tc };
-            if (rw) {
-                traversable->traverse_1_cb_rw(
-                    (void *) &p,
-                    [](void *p, uint64_t index, const char *variant,
-                       const char *domain) -> uint64_t {
-                        Payload *payload = (Payload *) p;
-                        uint64_t new_index =
-                            payload->tc(index, variant, domain);
-                        return new_index;
-                    });
-            } else {
-                traversable->traverse_1_cb_ro(
-                    (void *) &p, [](void *p, uint64_t index,
-                                    const char *variant, const char *domain) {
-                        Payload *payload = (Payload *) p;
-                        payload->tc(index, variant, domain);
-                    });
-            }
-        } else if (auto cb = get_traverse_cb_ro(tp); cb.is_valid() && !rw) {
-            cb(h, nb::cpp_function(
-                      [&](uint64_t index, const char *variant,
-                          const char *domain) { tc(index, variant, domain); }));
-        } else if (nb::object cb_rw = get_traverse_cb_rw(tp);
-                   cb_rw.is_valid() && rw) {
-            cb_rw(h, nb::cpp_function([&](uint64_t index, const char *variant,
-                                       const char *domain) {
-                   return tc(index, variant, domain);
-               }));
+                    traverse_impl(nb::getattr(h, k));
         } else {
+            raise_if_unbound_traversable(tp);
             tc.traverse_unknown(h);
         }
     } catch (nb::python_error &e) {
@@ -836,7 +839,7 @@ void traverse_pair_impl(const char *op, TraversePairCallback &tc, nb::handle h1,
                                    report_inconsistencies, width_consistency);
                 name.resize(name_size);
             }
-        } else if (!scalar && (df = get_dataclass_field_dict(tp1)).is_valid()) {
+        } else if (!scalar && (df = dataclass_field_dict(tp1)).is_valid()) {
             for (auto [k, field] : df) {
                 if (!is_dataclass_field(field))
                     continue;
@@ -883,8 +886,52 @@ nb::object TransformCallback::transform_unknown(nb::handle h) const {
     return nb::borrow(h);
 }
 
+/// Parameters of a transformation, shared by its recursive steps
+struct TransformState {
+    const char *op;
+    TransformCallback &tc;
+    dr::TraverseRole role;
+    VisitedSet visited;
+
+    /// C++ objects are transformed in place through the index overload of
+    /// the callback, including the arrays held by their Python attributes
+    uint64_t var(uint64_t index, const char *, const char *) {
+        return tc(index);
+    }
+
+    void py(nb::dict d) {
+        struct Adapter final : TraverseCallback {
+            TransformCallback &tc;
+            Adapter(TransformCallback &tc) : tc(tc) { }
+
+            void operator()(nb::handle h) override {
+                const ArraySupplement &s = supp(h.type());
+                if (s.index)
+                    s.reset_index(tc(s.index(inst_ptr(h))), inst_ptr(h));
+            }
+
+            uint64_t operator()(uint64_t index, const char *,
+                                const char *) override {
+                return tc(index);
+            }
+        } adapter { tc };
+
+        TraverseState ts { op, adapter, role, true, visited };
+        for (nb::handle value : d.values())
+            ts.traverse_impl(value);
+    }
+
+    nb::object transform_impl(nb::handle h);
+};
+
 /// Transform an input pytree 'h' into an output pytree, potentially of a different type
-nb::object transform(const char *op, TransformCallback &tc, nb::handle h) {
+nb::object transform(const char *op, TransformCallback &tc, nb::handle h,
+                     dr::TraverseRole role) {
+    TransformState st { op, tc, role, {} };
+    return st.transform_impl(h);
+}
+
+nb::object TransformState::transform_impl(nb::handle h) {
     recursion_guard guard;
     nb::handle tp = h.type();
 
@@ -903,7 +950,7 @@ nb::object transform(const char *op, TransformCallback &tc, nb::handle h) {
 
             if (s1.is_tensor) {
                 nb::object array = nb::steal(s1.tensor_array(h.ptr())),
-                           array_t = transform(op, tc, array);
+                           array_t = transform_impl(array);
 
                 nb::object s = shape(h);
                 if (nb::len(array) == nb::len(array_t))
@@ -922,7 +969,7 @@ nb::object transform(const char *op, TransformCallback &tc, nb::handle h) {
                 }
 
                 for (size_t i = 0; i < size; ++i)
-                    result[i] = transform(op, tc, h[i]);
+                    result[i] = transform_impl(h[i]);
             } else {
                 result = nb::inst_alloc_zero(tp2);
                 tc(h, result);
@@ -932,34 +979,33 @@ nb::object transform(const char *op, TransformCallback &tc, nb::handle h) {
             size_t size = nb::len(t);
             nb::tuple_builder tb(size);
             for (size_t i = 0; i < size; ++i)
-                tb.put(transform(op, tc, t[i]));
+                tb.put(transform_impl(t[i]));
             result = tb.commit();
         } else if (tp.is(&PyList_Type)) {
             nb::list l = nb::borrow<nb::list>(h);
             nb::list_builder lb(nb::len(l));
             for (nb::handle item : l)
-                lb.put(transform(op, tc, item));
+                lb.put(transform_impl(item));
             result = lb.commit();
         } else if (tp.is(&PyDict_Type)) {
             nb::dict tmp;
             for (auto [k, v] : nb::borrow<nb::dict>(h))
-                tmp[k] = transform(op, tc, v);
+                tmp[k] = transform_impl(v);
             result = std::move(tmp);
+        } else if (auto traversable = traversable_ptr(h); traversable) {
+            traverse_object(*this, traversable);
+            result = nb::borrow(h);
         } else if (nb::dict ds = get_drjit_struct(tp); ds.is_valid()) {
             nb::object tmp = tp();
             for (auto [k, v] : ds)
-                nb::setattr(tmp, k, transform(op, tc, nb::getattr(h, k)));
+                nb::setattr(tmp, k, transform_impl(nb::getattr(h, k)));
             result = std::move(tmp);
-        } else if (nb::dict df = get_dataclass_field_dict(tp); df.is_valid()) {
+        } else if (nb::dict df = dataclass_field_dict(tp); df.is_valid()) {
             nb::dict tmp;
             for (auto [k, field] : df)
                 if (is_dataclass_field(field))
-                    tmp[k] = transform(op, tc, nb::getattr(h, k));
+                    tmp[k] = transform_impl(nb::getattr(h, k));
             result = tp(**tmp);
-        } else if (nb::object cb = get_traverse_cb_rw(tp); cb.is_valid()) {
-            cb(h, nb::cpp_function([&](uint64_t index, const char *,
-                                       const char *) { return tc(index); }));
-            result = nb::borrow(h);
         } else if (!result.is_valid()) {
             result = tc.transform_unknown(h);
         }
@@ -1094,7 +1140,7 @@ nb::object transform_pair(const char *op, TransformPairCallback &tc,
                                 transform_pair(op, tc, nb::getattr(h1, k),
                                                nb::getattr(h2, k)));
                 return result;
-            } else if (nb::dict df = get_dataclass_field_dict(tp1); df.is_valid()) {
+            } else if (nb::dict df = dataclass_field_dict(tp1); df.is_valid()) {
                 nb::dict result;
                 for (auto [k, field] : df)
                     if (is_dataclass_field(field))

--- a/src/python/apply.h
+++ b/src/python/apply.h
@@ -131,6 +131,10 @@ struct TransformPairCallback {
  * \param callback:
  *     The \c TraverseCallback, called for every Jit variable in the pytree.
  *
+ * \param role:
+ *     Purpose of the traversal, passed on to C++ objects so that they can
+ *     decide which of their members take part (see \c drjit::TraverseRole).
+ *
  * \param rw:
  *     Boolean, indicating if C++ objects should be traversed in read-write
  *     mode. If this is set to \c true, the result from the method
@@ -139,7 +143,40 @@ struct TransformPairCallback {
  *     traversed.
  */
 extern void traverse(const char *op, TraverseCallback &callback, nb::handle h,
+                     dr::TraverseRole role = dr::TraverseRole::Generic,
                      bool rw = false);
+
+/**
+ * \brief Traverse the graph of C++ objects below ``obj``
+ *
+ * This is the one place that defines how Dr.Jit walks objects deriving from
+ * \c drjit::TraversableBase outside of frozen functions. The state type must
+ * provide:
+ *
+ * - ``role``: the \c drjit::TraverseRole reported to the objects
+ * - ``visited``: a set of ``drjit::TraversableBase *``; every object is
+ *   entered once, which deduplicates shared objects and terminates cycles
+ * - ``var(index, variant, domain)``: receives each JIT array and returns the
+ *   index that the object holds from now on
+ * - ``py(dict)``: receives the attribute dictionary of the Python side of an
+ *   object (see \c traversable_dict())
+ */
+template <typename State>
+void traverse_object(State &st, dr::TraversableBase *obj) {
+    if (!st.visited.insert(obj).second)
+        return;
+
+    for_each_member(
+        obj, st.role,
+        [&st](uint64_t index, const char *, const char *variant,
+              const char *domain) { return st.var(index, variant, domain); },
+        [&st](dr::TraversableBase *child, const char *) {
+            traverse_object(st, child);
+        });
+
+    if (nb::dict d = traversable_dict(obj); d.is_valid())
+        st.py(d);
+}
 
 /// Parallel traversal of two compatible pytrees 'h1' and 'h2'
 extern void traverse_pair(const char *op, TraversePairCallback &callback,
@@ -147,8 +184,12 @@ extern void traverse_pair(const char *op, TraversePairCallback &callback,
                           bool report_inconsistencies = true,
                           bool width_consistency = true);
 
-/// Transform an input pytree 'h' into an output pytree, potentially of a different type
-extern nb::object transform(const char *op, TransformCallback &callback, nb::handle h);
+/// Transform an input pytree 'h' into an output pytree, potentially of a
+/// different type. C++ objects are transformed in place; ``role`` is the
+/// purpose reported to them (see \c drjit::TraverseRole).
+extern nb::object transform(const char *op, TransformCallback &callback,
+                            nb::handle h,
+                            dr::TraverseRole role = dr::TraverseRole::Generic);
 
 /// Transform a pair of input pytrees 'h1' and 'h2' into an output pytree, potentially of a different type
 extern nb::object transform_pair(const char *op, TransformPairCallback &callback, nb::handle h1, nb::handle h2);

--- a/src/python/autodiff.cpp
+++ b/src/python/autodiff.cpp
@@ -65,7 +65,7 @@ static void set_grad_enabled(nb::handle h, bool enable_) {
     };
 
     SetGradEnabled sge(enable_);
-    traverse("drjit.set_grad_enabled", sge, h);
+    traverse("drjit.set_grad_enabled", sge, h, dr::TraverseRole::Gradient);
 }
 
 static nb::object new_grad(nb::handle h) {
@@ -90,7 +90,7 @@ static nb::object new_grad(nb::handle h) {
         }
     } ng;
 
-    return transform("drjit.detail.new_grad", ng, h);
+    return transform("drjit.detail.new_grad", ng, h, dr::TraverseRole::Gradient);
 }
 
 static void enable_grad(nb::handle h) { set_grad_enabled(h, true); }
@@ -115,7 +115,7 @@ bool grad_enabled(nb::handle h) {
     };
 
     GradEnabled ge;
-    traverse("drjit.grad_enabled", ge, h);
+    traverse("drjit.grad_enabled", ge, h, dr::TraverseRole::Gradient);
     return ge.result;
 }
 
@@ -131,7 +131,7 @@ static bool has_grad(nb::handle h) {
     };
 
     HasGrad ge;
-    traverse("drjit.has_grad", ge, h);
+    traverse("drjit.has_grad", ge, h, dr::TraverseRole::Gradient);
     return ge.result;
 }
 
@@ -178,7 +178,7 @@ static nb::object detach(nb::handle h, bool preserve_type_ = true) {
         return nb::borrow(h);
 
     Detach d(preserve_type_);
-    return transform("drjit.detach", d, h);
+    return transform("drjit.detach", d, h, dr::TraverseRole::Gradient);
 }
 
 nb::object grad(nb::handle h, bool preserve_type_) {
@@ -229,7 +229,7 @@ nb::object grad(nb::handle h, bool preserve_type_) {
     };
 
     Grad g(preserve_type_);
-    return transform("drjit.grad", g, h);
+    return transform("drjit.grad", g, h, dr::TraverseRole::Gradient);
 }
 
 static void clear_grad(nb::handle dst) {
@@ -241,7 +241,7 @@ static void clear_grad(nb::handle dst) {
         }
     } cg;
 
-    traverse("drjit.clear_grad", cg, dst);
+    traverse("drjit.clear_grad", cg, dst, dr::TraverseRole::Gradient);
 }
 
 static void accum_grad(nb::handle target, nb::handle source) {
@@ -337,7 +337,7 @@ static void enqueue_impl(dr::ADMode mode_, nb::handle h_) {
     };
 
     Enqueue e(mode_);
-    traverse("drjit.enqueue", e, h_);
+    traverse("drjit.enqueue", e, h_, dr::TraverseRole::Gradient);
 }
 
 static bool check_grad_enabled(const char *name, nb::handle h, uint32_t flags) {
@@ -520,7 +520,7 @@ public:
         };
 
         AddInOut aio(*this, input_);
-        return transform(name, aio, h);
+        return transform(name, aio, h, dr::TraverseRole::Gradient);
     }
 
     nb::object grad_in(nb::handle key) {

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -1386,6 +1386,8 @@ nb::handle lazy_import(LazyImport value) {
                 module_name = "typing"; attr_name = "get_type_hints"; break;
             case LazyImport::TypingGetArgs:
                 module_name = "typing"; attr_name = "get_args"; break;
+            case LazyImport::TypesMethodType:
+                module_name = "types"; attr_name = "MethodType"; break;
             case LazyImport::DataclassesField:
                 module_name = "dataclasses"; attr_name = "_FIELD"; break;
             default:

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -1369,10 +1369,6 @@ nb::handle DR_STR(DRJIT_STRUCT);
 nb::handle DR_STR(__dataclass_fields__);
 nb::handle DR_STR(name);
 nb::handle DR_STR(type);
-nb::handle DR_STR(_traverse_write);
-nb::handle DR_STR(_traverse_read);
-nb::handle DR_STR(_traverse_1_cb_rw);
-nb::handle DR_STR(_traverse_1_cb_ro);
 
 /// Cache backing lazy_import(), indexed by LazyImport. Populated on demand and
 /// released by lazy_import_shutdown().
@@ -1411,10 +1407,6 @@ void export_base(nb::module_ &m) {
     DR_STR(__dataclass_fields__) = PyUnicode_InternFromString("__dataclass_fields__");
     DR_STR(name) = PyUnicode_InternFromString("name");
     DR_STR(type) = PyUnicode_InternFromString("type");
-    DR_STR(_traverse_write) = PyUnicode_InternFromString("_traverse_write");
-    DR_STR(_traverse_read) = PyUnicode_InternFromString("_traverse_read");
-    DR_STR(_traverse_1_cb_rw) = PyUnicode_InternFromString("_traverse_1_cb_rw");
-    DR_STR(_traverse_1_cb_ro) = PyUnicode_InternFromString("_traverse_1_cb_ro");
 
     // Generic type variable used in many places
     for (const char *name :

--- a/src/python/base.cpp
+++ b/src/python/base.cpp
@@ -1369,6 +1369,7 @@ nb::handle DR_STR(DRJIT_STRUCT);
 nb::handle DR_STR(__dataclass_fields__);
 nb::handle DR_STR(name);
 nb::handle DR_STR(type);
+nb::handle DR_STR(cell_contents);
 
 /// Cache backing lazy_import(), indexed by LazyImport. Populated on demand and
 /// released by lazy_import_shutdown().
@@ -1407,6 +1408,7 @@ void export_base(nb::module_ &m) {
     DR_STR(__dataclass_fields__) = PyUnicode_InternFromString("__dataclass_fields__");
     DR_STR(name) = PyUnicode_InternFromString("name");
     DR_STR(type) = PyUnicode_InternFromString("type");
+    DR_STR(cell_contents) = PyUnicode_InternFromString("cell_contents");
 
     // Generic type variable used in many places
     for (const char *name :

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -63,6 +63,7 @@ extern nb::handle DR_STR(DRJIT_STRUCT);
 extern nb::handle DR_STR(__dataclass_fields__);
 extern nb::handle DR_STR(name);
 extern nb::handle DR_STR(type);
+extern nb::handle DR_STR(cell_contents);
 
 /// Dr.Jit can lazily import and then cache the following objects to avoid
 /// costly nb::module_::import() calls.

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -72,6 +72,7 @@ enum class LazyImport {
     TypingGetTypeHints,  // typing.get_type_hints
     TypingGetArgs,       // typing.get_args
     DataclassesField,    // dataclasses._FIELD (marker of ordinary fields)
+    TypesMethodType,     // types.MethodType
     Count
 };
 

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -63,10 +63,6 @@ extern nb::handle DR_STR(DRJIT_STRUCT);
 extern nb::handle DR_STR(__dataclass_fields__);
 extern nb::handle DR_STR(name);
 extern nb::handle DR_STR(type);
-extern nb::handle DR_STR(_traverse_write);
-extern nb::handle DR_STR(_traverse_read);
-extern nb::handle DR_STR(_traverse_1_cb_rw);
-extern nb::handle DR_STR(_traverse_1_cb_ro);
 
 /// Dr.Jit can lazily import and then cache the following objects to avoid
 /// costly nb::module_::import() calls.
@@ -93,7 +89,7 @@ inline nb::dict get_drjit_struct(nb::handle tp) {
 }
 
 /// Extract the dataclass fields element of a custom data structure type, if available
-inline nb::object get_dataclass_fields(nb::handle tp) {
+inline nb::object dataclass_fields(nb::handle tp) {
     nb::object result = nb::getattr(tp, DR_STR(__dataclass_fields__), nb::handle());
     if (result.is_valid()) {
         result = lazy_import(LazyImport::DataclassesFields)(tp);
@@ -120,14 +116,14 @@ inline nb::object get_dataclass_fields(nb::handle tp) {
 }
 
 /// Retrieve the ``__dataclass_fields__`` of a dataclass type.
-inline nb::dict get_dataclass_field_dict(nb::handle tp) {
+inline nb::dict dataclass_field_dict(nb::handle tp) {
     nb::object result = nb::getattr(tp, DR_STR(__dataclass_fields__), nb::handle());
     if (result.is_valid() && !result.type().is(&PyDict_Type))
         result = nb::object();
     return nb::borrow<nb::dict>(result);
 }
 
-/// Use this function to skip non-field entries returned by \ref get_dataclass_field_dict
+/// Use this function to skip non-field entries returned by \ref dataclass_field_dict
 inline bool is_dataclass_field(nb::handle field) {
     return nb::getattr(field, "_field_type", nb::handle())
         .is(lazy_import(LazyImport::DataclassesField));
@@ -154,20 +150,63 @@ inline bool py_equal(nb::handle a, nb::handle b) {
     return rv == 1;
 }
 
+/// Python type object of ``drjit::TraversableBase``, set by ``export_detail()``
+extern nb::handle traversable_base_type;
+
 /// Return a pointer to the underlying C++ class if the Python object inherits
 /// from TraversableBase or null otherwise
-inline drjit::TraversableBase *get_traversable_base(nb::handle h) {
-    drjit::TraversableBase *result = nullptr;
-    nb::try_cast(h, result);
-    return result;
+inline drjit::TraversableBase *traversable_ptr(nb::handle h) {
+    if (!PyType_IsSubtype(Py_TYPE(h.ptr()),
+                          (PyTypeObject *) traversable_base_type.ptr()) ||
+        !nb::inst_ready(h))
+        return nullptr;
+    return nb::inst_ptr<drjit::TraversableBase>(h);
 }
 
-/// Extract a read-only callback to traverse custom data structures
-inline nb::object get_traverse_cb_ro(nb::handle tp) {
-    return nb::getattr(tp, DR_STR(_traverse_1_cb_ro), nb::handle());
+/**
+ * \brief Return the instance dictionary of a traversable object, if available.
+ *
+ * Given a ``drjit::TraversableBase``-derived instance, this function checks
+ * if the type has been subclassed in Python. In that case, it returns the
+ * instance's dictionary. Otherwise, it returns an invalid handle.
+ */
+inline nb::dict traversable_dict(const drjit::TraversableBase *obj) {
+    nb::handle self = obj->self_py();
+    if (!self.is_valid() || !NB_CALL(nb_inst_python_derived)(self.ptr()))
+        return nb::steal<nb::dict>(nb::handle());
+    return nb::inst_dict(self);
 }
 
-/// Extract a read-write callback to traverse custom data structures
-inline nb::object get_traverse_cb_rw(nb::handle tp) {
-    return nb::getattr(tp, DR_STR(_traverse_1_cb_rw), nb::handle());
+/**
+ * \brief Run the traversal callback of a C++ object
+ *
+ * Calls ``var(index, name, variant, domain)`` for every JIT array held by
+ * ``obj`` (the return value is the index that the object holds from now on,
+ * see \ref drjit::TraverseVisitor) and ``child(obj, name)`` for every directly
+ * held child object. This is the one place that turns the C callback interface
+ * of ``traverse_cb()`` into lambdas; all drivers build on it.
+ */
+template <typename Var, typename Child>
+void for_each_member(drjit::TraversableBase *obj, drjit::TraverseRole role,
+                     Var &&var, Child &&child) {
+    struct Payload {
+        Var &var;
+        Child &child;
+    } p { var, child };
+
+    obj->traverse_cb(
+        &p,
+        drjit::TraverseVisitor {
+            role,
+            [](void *p, uint64_t index, const char *name, const char *variant,
+               const char *domain) -> uint64_t {
+                return ((Payload *) p)->var(index, name, variant, domain);
+            },
+            [](void *p, drjit::TraversableBase *child, const char *name) {
+                ((Payload *) p)->child(child, name);
+            } });
 }
+
+/// Raise if the nanobind binding of type ``tp`` implements the traversal
+/// interface without declaring drjit::TraversableBase as a base class
+extern void raise_if_unbound_traversable(nb::handle tp);

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -211,3 +211,25 @@ void for_each_member(drjit::TraversableBase *obj, drjit::TraverseRole role,
 /// Raise if the nanobind binding of type ``tp`` implements the traversal
 /// interface without declaring drjit::TraversableBase as a base class
 extern void raise_if_unbound_traversable(nb::handle tp);
+
+/// Cheap check that skips the construction of log messages in hot paths
+inline bool log_enabled(LogLevel level) {
+    return level <= jit_log_level_callback() || level <= jit_log_level_stderr();
+}
+
+/// RAII helpers to acquire/release the Dr.Jit state lock
+struct state_lock_guard {
+    state_lock_guard() { jit_state_lock(); }
+    ~state_lock_guard() { jit_state_unlock(); }
+};
+
+struct state_unlock_guard {
+    state_unlock_guard() { jit_state_unlock(); }
+    ~state_unlock_guard() { jit_state_lock(); }
+};
+
+/// Reports the enclosing scope as a range to an attached profiler
+struct ProfilerPhase {
+    ProfilerPhase(const char *name) { jit_profile_range_push(name); }
+    ~ProfilerPhase() { jit_profile_range_pop(); }
+};

--- a/src/python/coop_vec.cpp
+++ b/src/python/coop_vec.cpp
@@ -459,7 +459,7 @@ static nb::object repack_impl(const char *name, MatrixLayout layout,
         for (auto [k, v] : ds)
             nb::setattr(tmp, k, repack_impl(name, layout, nb::getattr(arg, k), offset, items));
         return tmp;
-    } else if (nb::dict df = get_dataclass_field_dict(arg_tp); df.is_valid()) {
+    } else if (nb::dict df = dataclass_field_dict(arg_tp); df.is_valid()) {
         nb::dict tmp;
         for (auto [k, field] : df)
             if (is_dataclass_field(field))

--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -385,7 +385,6 @@ void export_detail(nb::module_ &m) {
 
     d.def("leak_warnings", &leak_warnings, doc_leak_warnings);
     d.def("set_leak_warnings", &set_leak_warnings, doc_set_leak_warnings);
-    d.def("freeze_discard", jit_freeze_discard);
 
     d.def("block_mkperm",
           [](nb::handle_t<dr::ArrayBase> values, uint32_t block_size,

--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -97,7 +97,8 @@ bool can_scatter_reduce(nb::type_object_t<dr::ArrayBase> tp, ReduceOp op) {
  * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
 */
-void collect_indices(nb::handle h, dr::vector<uint64_t> &indices, bool inc_ref) {
+void collect_indices(nb::handle h, dr::vector<uint64_t> &indices,
+                     dr::TraverseRole role, bool inc_ref) {
     struct CollectIndices final : TraverseCallback {
         dr::vector<uint64_t> &result;
         bool inc_ref;
@@ -124,7 +125,7 @@ void collect_indices(nb::handle h, dr::vector<uint64_t> &indices, bool inc_ref) 
         return;
 
     CollectIndices ci { indices, inc_ref };
-    traverse("drjit.detail.collect_indices", ci, h);
+    traverse("drjit.detail.collect_indices", ci, h, role);
 }
 
 /**
@@ -147,7 +148,8 @@ void collect_indices(nb::handle h, dr::vector<uint64_t> &indices, bool inc_ref) 
  * (Note: this explanation is also part of src/python/docstr.rst -- please keep
  * them in sync in case you make a change here)
  */
-nb::object update_indices(nb::handle h, const dr::vector<uint64_t> &indices) {
+nb::object update_indices(nb::handle h, const dr::vector<uint64_t> &indices,
+                          dr::TraverseRole role) {
     struct UpdateIndicesOp final : TransformCallback {
         const dr::vector<uint64_t> &indices;
         size_t counter;
@@ -173,7 +175,7 @@ nb::object update_indices(nb::handle h, const dr::vector<uint64_t> &indices) {
         return nb::object();
 
     UpdateIndicesOp uio { indices };
-    nb::object result = transform("drjit.detail.update_indices", uio, h);
+    nb::object result = transform("drjit.detail.update_indices", uio, h, role);
 
     if (uio.counter != indices.size())
         nb::raise("drjit.detail.update_indices(): too many indices "
@@ -286,133 +288,47 @@ bool leak_warnings() {
     return nb::leak_warnings() || jit_leak_warnings() || ad_leak_warnings();
 }
 
-// Have to wrap this in an unnamed namespace to prevent collisions with the
-// other declaration of ``recursion_guard``.
-namespace {
-static int recursion_level = 0;
+nb::handle traversable_base_type;
 
-// PyTrees could theoretically include cycles. Catch infinite recursion below
-struct recursion_guard {
-    recursion_guard() {
-        if (recursion_level >= 50) {
-            PyErr_SetString(PyExc_RecursionError, "runaway recursion detected");
-            nb::raise_python_error();
-        }
-        // NOTE: the recursion_level has to be incremented after potentially
-        // throwing an exception, as throwing an exception in the constructor
-        // prevents the destructor from being called.
-        recursion_level++;
-    }
-    ~recursion_guard() { recursion_level--; }
-};
-} // namespace
-
-/**
- * \brief Traverses all variables of a python object.
- *
- * This function is used to traverse variables of python objects, inheriting
- * from trampoline classes. This allows the user to freeze a custom python
- * version of a C++ class, without having to declare its variables.
- */
-void traverse_py_cb_ro_impl(nb::handle self, nb::callable c) {
-    recursion_guard guard;
-
-    struct PyTraverseCallback : TraverseCallback {
-        void operator()(nb::handle h) override {
-            const ArraySupplement &s = supp(h.type());
-            auto index_fn = s.index;
-            if (index_fn){
-                if (s.is_class){
-                    nb::str variant =
-                        nb::borrow<nb::str>(nb::getattr(h, "Variant"));
-                    nb::str domain =
-                        nb::borrow<nb::str>(nb::getattr(h, "Domain"));
-                    operator()(index_fn(inst_ptr(h)), variant.c_str(),
-                               domain.c_str());
-                }
-                else
-                    operator()(index_fn(inst_ptr(h)), "", "");
-            }
-        }
-        uint64_t operator()(uint64_t index, const char *variant,
-                            const char *domain) override {
-            m_callback(index, variant, domain);
-            return 0;
-        }
-        nb::callable m_callback;
-
-        PyTraverseCallback(nb::callable c) : m_callback(c) {}
-    };
-
-    PyTraverseCallback traverse_cb(std::move(c));
-
-    if (nb::hasattr(self, "__dict__")) {
-        auto dict = nb::borrow<nb::dict>(nb::getattr(self, "__dict__"));
-        for (auto value : dict.values())
-            traverse("traverse_py_cb_ro", traverse_cb, value);
-    }
-}
-
-/**
- * \brief Traverses all variables of a python object.
- *
- * This function is used to traverse variables of python objects, inheriting
- * from trampoline classes. This allows the user to freeze a custom python
- * version of a C++ class, without having to declare its variables.
- */
-void traverse_py_cb_rw_impl(nb::handle self, nb::callable c) {
-    recursion_guard guard;
-
-    struct PyTraverseCallback : TraverseCallback {
-        void operator()(nb::handle h) override {
-            const ArraySupplement &s = supp(h.type());
-            auto index_fn            = s.index;
-            if (index_fn){
-                uint64_t new_index;
-                if (s.is_class) {
-                    nb::str variant =
-                        nb::borrow<nb::str>(nb::getattr(h, "Variant"));
-                    nb::str domain = nb::borrow<nb::str>(nb::getattr(h, "Domain"));
-                    new_index   = operator()(index_fn(inst_ptr(h)),
-                                           variant.c_str(), domain.c_str());
-                } else
-                    new_index = operator()(index_fn(inst_ptr(h)), "", "");
-                s.reset_index(new_index, inst_ptr(h));
-            }
-        }
-        uint64_t operator()(uint64_t index, const char *variant, const char *domain) override {
-            return nb::cast<uint64_t>(m_callback(index, variant, domain));
-        }
-        nb::callable m_callback;
-
-        PyTraverseCallback(nb::callable c) : m_callback(c) {}
-    };
-
-    PyTraverseCallback traverse_cb(std::move(c));
-
-    if (nb::hasattr(self, "__dict__")) {
-        auto dict = nb::borrow<nb::dict>(nb::getattr(self, "__dict__"));
-        for (auto value : dict.values())
-            traverse("traverse_py_cb_rw", traverse_cb, value, true);
-    }
+void raise_if_unbound_traversable(nb::handle tp) {
+    if (nb::type_check(tp) && nb::hasattr(tp, "_traverse_cb"))
+        nb::raise("the type '%s' derives from drjit::TraversableBase, but its "
+                  "nanobind binding does not declare drjit::TraversableBase "
+                  "as a base class. Dr.Jit cannot traverse its variables. Bind "
+                  "it as nb::class_<T, drjit::TraversableBase>(...).",
+                  nb::type_name(tp).c_str());
 }
 
 void export_detail(nb::module_ &m) {
     nb::module_ d = nb::module_::import_("drjit.detail");
 
+    traversable_base_type =
+        nb::class_<drjit::TraversableBase, nb::intrusive_base>(d, "TraversableBase")
+            .freeze();
+
     m.def("copy", &copy, "arg"_a, doc_copy,
           nb::sig("def copy(arg: T, /) -> T"));
 
+    nb::enum_<dr::TraverseRole>(d, "TraverseRole", doc_detail_TraverseRole)
+        .value("Generic", dr::TraverseRole::Generic)
+        .value("Eval", dr::TraverseRole::Eval)
+        .value("Gradient", dr::TraverseRole::Gradient)
+        .value("Loop", dr::TraverseRole::Loop)
+        .value("Conditional", dr::TraverseRole::Conditional)
+        .value("Call", dr::TraverseRole::Call)
+        .value("Freeze", dr::TraverseRole::Freeze);
+
     d.def("collect_indices",
-          [](nb::handle h) {
+          [](nb::handle h, dr::TraverseRole role) {
               dr::vector<uint64_t> result;
-              collect_indices(h, result);
+              collect_indices(h, result, role);
               return result;
           },
+          "value"_a, "role"_a = dr::TraverseRole::Generic,
           doc_detail_collect_indices)
 
      .def("update_indices", &update_indices, "value"_a, "indices"_a,
-          doc_detail_update_indices)
+          "role"_a = dr::TraverseRole::Generic, doc_detail_update_indices)
 
      .def("check_compatibility", &check_compatibility,
           doc_detail_check_compatibility)
@@ -469,8 +385,6 @@ void export_detail(nb::module_ &m) {
 
     d.def("leak_warnings", &leak_warnings, doc_leak_warnings);
     d.def("set_leak_warnings", &set_leak_warnings, doc_set_leak_warnings);
-    d.def("traverse_py_cb_ro", &traverse_py_cb_ro_impl);
-    d.def("traverse_py_cb_rw", &traverse_py_cb_rw_impl);
     d.def("freeze_discard", jit_freeze_discard);
 
     d.def("block_mkperm",

--- a/src/python/detail.h
+++ b/src/python/detail.h
@@ -23,8 +23,10 @@ struct StashRef {
 
 // See misc.cpp for documentation of these functions
 extern void collect_indices(nb::handle, dr::vector<uint64_t> &,
+                            dr::TraverseRole role = dr::TraverseRole::Generic,
                             bool inc_ref = false);
-extern nb::object update_indices(nb::handle, const dr::vector<uint64_t> &);
+extern nb::object update_indices(nb::handle, const dr::vector<uint64_t> &,
+                                 dr::TraverseRole role = dr::TraverseRole::Generic);
 extern void check_compatibility(nb::handle, nb::handle, bool, const char *);
 extern void stash_ref(nb::handle h, dr::vector<StashRef> &);
 

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -5811,6 +5811,16 @@
     raised if there is a mismatch of the vectorization widths of any Dr.Jit type
     in the pytrees.
 
+.. topic:: detail_TraverseRole
+
+    Purpose of a traversal of a :ref:`PyTree <pytrees>`.
+
+    Dr.Jit traverses PyTrees and C++ objects for many reasons: to evaluate
+    their arrays, to gather the state of a symbolic loop, to describe the
+    input of a frozen function, and so on. The role is reported to C++ objects
+    deriving from ``drjit::TraversableBase`` so that they can decide which of
+    their members take part in a particular traversal.
+
 .. topic:: detail_collect_indices
 
     Return Dr.Jit variable indices associated with the provided data structure.
@@ -5820,7 +5830,8 @@
     variables (in the order of traversal, may contain duplicates). The index
     information is returned as a list of encoded 64 bit integers, where each
     contains the AD variable index in the upper 32 bits and the JIT variable
-    index in the lower 32 bit.
+    index in the lower 32 bit. The ``role`` parameter is reported to C++
+    objects (see :py:class:`drjit.detail.TraverseRole`).
 
     This function exists for Dr.Jit-internal use. You probably should not
     call it in your own application code.
@@ -6435,15 +6446,6 @@
 
     User code may query this flag to conditionally optimize kernels for frozen
     function recording, such as re-seeding the sampler, used for rendering.
-
-.. topic:: JitFlag_EnableObjectTraversal
-
-    This flag is set to ``True`` when Dr.Jit is currently traversing
-    inputs and outputs of a frozen function. The flag is automatically managed
-    and should not be updated by application code.
-
-    When enabled, traversal of complex objects, that usually are opaque to
-    loops and conditionals, is enabled.
 
 .. topic:: JitFlag_SpillToSharedMemory
 
@@ -8977,7 +8979,11 @@
 
    Create a new variable tracker.
 
-   The constructor accepts two parameters:
+   The constructor accepts three parameters:
+
+   - ``role``: The purpose of the traversal that is reported to C++ objects
+     (see :py:class:`drjit.detail.TraverseRole`), for example ``Loop`` when
+     tracking the state of a symbolic loop.
 
    - ``strict``: Certain types of Python objects (e.g. custom Python classes
      without ``DRJIT_STRUCT`` field, scalar Python numeric types) are not

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -9221,6 +9221,20 @@
 
    Query whether leak warnings are enabled. See :py:func:`drjit.detail.set_leak_warnings()`.
 
+.. topic:: FrozenFunction
+
+   Callable returned by :py:func:`drjit.freeze`.
+
+   Besides being callable like the decorated function, it exposes the
+   following members:
+
+   - ``enabled``: when set to ``False``, calls are forwarded to the decorated
+     function without freezing.
+   - ``n_recordings``: the number of times the function was recorded,
+     including re-recordings after a failed dry run.
+   - ``n_cached_recordings``: the number of recordings currently cached.
+   - ``clear()``: drops all recordings and resets the counters.
+
 .. topic:: step
 
    Step function.

--- a/src/python/eval.cpp
+++ b/src/python/eval.cpp
@@ -38,7 +38,7 @@ bool schedule(nb::handle h) {
     };
 
     ScheduleCallback sc{ result_ };
-    traverse("drjit.schedule", sc, h);
+    traverse("drjit.schedule", sc, h, dr::TraverseRole::Eval);
     return result_;
 }
 
@@ -81,7 +81,7 @@ static void make_opaque(nb::handle h) {
     };
 
     ScheduleForceCallback sfc;
-    traverse("drjit.make_opaque", sfc, h);
+    traverse("drjit.make_opaque", sfc, h, dr::TraverseRole::Eval);
     if (sfc.result) {
         nb::gil_scoped_release guard;
         jit_eval();
@@ -128,7 +128,7 @@ nb::object opaque(nb::handle h) {
     eval(h);
 
     OpaqueOp op;
-    return transform("drjit.opaque", op, h);
+    return transform("drjit.opaque", op, h, dr::TraverseRole::Eval);
 }
 
 bool eval(nb::handle h) {

--- a/src/python/freeze.cpp
+++ b/src/python/freeze.cpp
@@ -148,48 +148,6 @@
 
 using Buffer = nanobind::detail::Buffer;
 
-/// Cheap check, used to skip construction of expensive log messages in hot
-/// paths when they would be discarded anyway.
-static bool log_enabled(LogLevel level) {
-    return level <= jit_log_level_callback() || level <= jit_log_level_stderr();
-}
-
-/**
- * \brief Helper struct to profile and log frozen functions.
- */
-struct ProfilerPhase {
-    std::string m_message;
-    ProfilerPhase(const char *message) {
-        if (log_enabled(LogLevel::Debug)) {
-            m_message = message;
-            jit_log(LogLevel::Debug, "profiler start: %s", message);
-        }
-#if defined(DRJIT_ENABLE_NVTX)
-        jit_profile_range_push(message);
-#endif
-    }
-
-    ProfilerPhase(const drjit::TraversableBase *traversable) {
-        char message[1024] = { 0 };
-        const char *name   = typeid(*traversable).name();
-        snprintf(message, 1024, "traverse_cb %s", name);
-
-        if (log_enabled(LogLevel::Debug)) {
-            m_message = message;
-            jit_log(LogLevel::Debug, "profiler start: %s", message);
-        }
-        jit_profile_range_push(message);
-    }
-
-    ~ProfilerPhase() {
-#if defined(DRJIT_ENABLE_NVTX)
-        jit_profile_range_pop();
-#endif
-        if (!m_message.empty())
-            jit_log(LogLevel::Debug, "profiler end: %s", m_message.c_str());
-    }
-};
-
 struct ADScopeContext {
     bool process_postponed;
     ADScopeContext(drjit::ADScope type, size_t size, const uint64_t *indices,
@@ -198,30 +156,6 @@ struct ADScopeContext {
         ad_scope_enter(type, size, indices, symbolic);
     }
     ~ADScopeContext() { ad_scope_leave(process_postponed); }
-};
-
-struct scoped_set_flag {
-    uint32_t backup;
-    scoped_set_flag(JitFlag flag, bool enabled) : backup(jit_flags()) {
-        uint32_t flags = backup;
-        if (enabled)
-            flags |= (uint32_t) flag;
-        else
-            flags &= ~(uint32_t) flag;
-
-        jit_set_flags(flags);
-    }
-
-    ~scoped_set_flag() { jit_set_flags(backup); }
-};
-
-struct state_lock_guard {
-    state_lock_guard() { jit_state_lock(); }
-    ~state_lock_guard() { jit_state_unlock(); }
-};
-struct state_unlock_guard {
-    state_unlock_guard() { jit_state_unlock(); }
-    ~state_unlock_guard() { jit_state_lock(); }
 };
 
 using namespace detail;

--- a/src/python/freeze.cpp
+++ b/src/python/freeze.cpp
@@ -772,36 +772,51 @@ void FlatVariables::assign_ad_var(Layout &layout_, nb::handle dst) {
 }
 
 /**
- * Traverse a C++ tree using its `traverse_1_cb_ro` callback.
+ * Traverse a C++ tree using its `traverse_cb` callback.
  */
 void FlatVariables::traverse_cb(const drjit::TraversableBase *traversable,
                                 TraverseContext &ctx, nb::object type) {
-    // ProfilerPhase profiler(traversable);
-
     uint32_t layout_index_ = (uint32_t) this->layout.size();
     Layout &layout_        = this->layout.emplace_back();
-    layout_.type           = nb::borrow<nb::type_object>(type);
 
-    struct Payload {
-        TraverseContext &ctx;
-        FlatVariables *flat_variables = nullptr;
-        uint32_t num_fields           = 0;
-    };
+    // Objects without a Python counterpart are deduplicated here, objects
+    // with one by the ``visited`` map of the Python-level traversal.
+    if (!ctx.visited_cpp.insert(traversable).second) {
+        layout_.flags |= (uint32_t) LayoutFlag::RecursiveRef;
+        return;
+    }
+    layout_.type = nb::borrow<nb::type_object>(type);
 
-    Payload p{ ctx, this, 0 };
-
-    traversable->traverse_1_cb_ro(
-        (void *) &p,
-        [](void *p, uint64_t index, const char *variant_, const char *domain) {
-            if (!index)
-                return;
-            Payload *payload = (Payload *) p;
-            payload->flat_variables->add_domain(variant_, domain);
-            payload->flat_variables->traverse_ad_index(index, payload->ctx);
-            payload->num_fields++;
+    uint32_t num_fields = 0;
+    for_each_member(
+        const_cast<drjit::TraversableBase *>(traversable),
+        drjit::TraverseRole::Freeze,
+        [&](uint64_t index, const char *, const char *variant_,
+            const char *domain) {
+            if (index) {
+                add_domain(variant_, domain);
+                traverse_ad_index(index, ctx);
+                num_fields++;
+            }
+            return index;
+        },
+        [&](drjit::TraversableBase *child, const char *) {
+            num_fields++;
+            if (PyObject *self = child->self_py())
+                traverse(self, ctx);
+            else
+                traverse_cb(child, ctx);
         });
 
-    this->layout[layout_index_].num = p.num_fields;
+    // Attributes of a Python subclass instance
+    if (nb::dict dict = traversable_dict(traversable); dict.is_valid()) {
+        for (nb::handle value : dict.values()) {
+            num_fields++;
+            traverse(value, ctx);
+        }
+    }
+
+    this->layout[layout_index_].num = num_fields;
 }
 
 /**
@@ -828,36 +843,53 @@ uint64_t FlatVariables::assign_cb_internal(uint64_t index,
  * Assigns variables using its `traverse_cb_rw` callback.
  * This corresponds to `traverse_cb`.
  */
-void FlatVariables::assign_cb(drjit::TraversableBase *traversable) {
+void FlatVariables::assign_cb(drjit::TraversableBase *traversable,
+                              TraverseContext &ctx) {
     Layout &layout_ = this->layout[layout_index++];
 
-    struct Payload {
-        FlatVariables *flat_variables = nullptr;
-        Layout &layout;
-        index64_vector tmp;
-        uint32_t field_counter = 0;
-    };
-    Payload p{ this, layout_, index64_vector(), 0 };
-    traversable->traverse_1_cb_rw(
-        (void *) &p,
-        [](void *p, uint64_t index, const char *, const char *) {
-        if (!index)
-            return index;
-        Payload *payload = (Payload *) p;
-        if (payload->field_counter >= payload->layout.num)
-            jit_raise("While traversing an object "
-                      "for assigning inputs, the number of variables to "
-                      "assign (>%u) did not match the number of variables "
-                      "traversed when recording (%u)!",
-                      payload->field_counter, payload->layout.num);
-        payload->field_counter++;
-        return payload->flat_variables->assign_cb_internal(index, payload->tmp);
-    });
+    if (layout_.flags & (uint32_t) LayoutFlag::RecursiveRef)
+        return;
 
-    if (p.field_counter != layout_.num)
-        jit_raise("While traversing and object for assigning inputs, the "
-                  "number of variables to assign did not match the number "
-                  "of variables traversed when recording!");
+    index64_vector tmp;
+    uint32_t num = layout_.num, field_counter = 0;
+    auto count = [&] {
+        if (field_counter >= num)
+            jit_raise("While traversing an object for assigning inputs, "
+                      "the number of variables to assign (>%u) did not "
+                      "match the number of variables traversed when "
+                      "recording (%u)!",
+                      field_counter, num);
+        field_counter++;
+    };
+
+    for_each_member(
+        traversable, drjit::TraverseRole::Freeze,
+        [&](uint64_t index, const char *, const char *, const char *) {
+            if (!index)
+                return index;
+            count();
+            return assign_cb_internal(index, tmp);
+        },
+        [&](drjit::TraversableBase *child, const char *) {
+            count();
+            if (PyObject *self = child->self_py())
+                assign(self, ctx);
+            else
+                assign_cb(child, ctx);
+        });
+
+    if (nb::dict dict = traversable_dict(traversable); dict.is_valid()) {
+        for (nb::handle value : dict.values()) {
+            count();
+            assign(value, ctx);
+        }
+    }
+
+    if (field_counter != num)
+        jit_raise("While traversing an object for assigning inputs, the "
+                  "number of variables to assign (%u) did not match the "
+                  "number of variables traversed when recording (%u)!",
+                  field_counter, num);
 }
 
 /**
@@ -907,8 +939,6 @@ struct scoped_path {
  * about the drjit variable in the layout. Therefore, the layout can be used
  * as an identifier to the recording of the frozen function.
  */
-// NOTE: callers of this function (from outside of its recursion) have to set
-// the ``JitFlag::EnableObjectTraversal`` flag (see ``traverse_with_registry``)
 void FlatVariables::traverse(nb::handle h, TraverseContext &ctx) {
     if (recursion_level == 0)
         m_log_enabled = log_enabled(LogLevel::Debug);
@@ -1015,7 +1045,7 @@ void FlatVariables::traverse(nb::handle h, TraverseContext &ctx) {
                 scoped_path ps(ctx, nb::str(k).c_str());
                 traverse(nb::getattr(h, k), ctx);
             }
-        } else if (nb::object df = get_dataclass_fields(tp); df.is_valid()) {
+        } else if (nb::object df = dataclass_fields(tp); df.is_valid()) {
 
             for (auto field : df) {
                 nb::object k = field.attr(DR_STR(name));
@@ -1028,27 +1058,11 @@ void FlatVariables::traverse(nb::handle h, TraverseContext &ctx) {
                 scoped_path ps(ctx, nb::str(k).c_str());
                 traverse(nb::getattr(h, k), ctx);
             }
-        } else if (auto traversable = get_traversable_base(h); traversable) {
+        } else if (auto traversable = traversable_ptr(h); traversable) {
             traverse_cb(traversable, ctx, nb::borrow<nb::type_object>(tp));
-        } else if (auto cb = get_traverse_cb_ro(tp); cb.is_valid()) {
-            ProfilerPhase profiler2("traverse cb");
-
-            uint32_t num_fields = 0;
-
-            // Traverse the opaque C++ object
-            cb(h, nb::cpp_function([&](uint64_t index, const char *variant_,
-                                       const char *domain) {
-                   if (!index)
-                       return;
-                   add_domain(variant_, domain);
-                   num_fields++;
-                   this->traverse_ad_index(index, ctx, nb::none());
-                   return;
-               }));
-
-            // Update layout number of fields
-            this->layout[layout_index_].num = num_fields;
         } else {
+            raise_if_unbound_traversable(tp);
+
             jit_log(LogLevel::Debug,
                     "traverse(): You passed a value of type %s to a frozen "
                     "function, it could not be converted to a Dr.Jit type. "
@@ -1162,7 +1176,7 @@ nb::object FlatVariables::construct() {
             for (auto k : layout_.fields)
                 nb::setattr(tmp, k, construct());
             return tmp;
-        } else if (nb::object df = get_dataclass_fields(layout_.type);
+        } else if (nb::object df = dataclass_fields(layout_.type);
                    df.is_valid()) {
             nb::dict dict;
             for (auto k : layout_.fields)
@@ -1195,8 +1209,6 @@ nb::object FlatVariables::construct() {
  * Assigns the flattened variables to an already existing PyTree.
  * This is used when input variables have changed.
  */
-// NOTE: callers of this function (from outside of its recursion) have to set
-// the ``JitFlag::EnableObjectTraversal`` flag (see ``assign_with_registry``)
 void FlatVariables::assign(nb::handle dst, TraverseContext &ctx) {
     if (recursion_level == 0)
         m_log_enabled = log_enabled(LogLevel::Debug);
@@ -1283,7 +1295,7 @@ void FlatVariables::assign(nb::handle dst, TraverseContext &ctx) {
                 else
                     nb::setattr(dst, k, construct());
             }
-        } else if (nb::object df = get_dataclass_fields(tp); df.is_valid()) {
+        } else if (nb::object df = dataclass_fields(tp); df.is_valid()) {
             for (auto k : layout_.fields) {
                 scoped_path ps(ctx, nb::str(k).c_str());
                 if (nb::hasattr(dst, k))
@@ -1291,38 +1303,8 @@ void FlatVariables::assign(nb::handle dst, TraverseContext &ctx) {
                 else
                     nb::setattr(dst, k, construct());
             }
-        } else if (auto traversable = get_traversable_base(dst); traversable) {
-            assign_cb(traversable);
-        } else if (nb::object cb = get_traverse_cb_rw(tp); cb.is_valid()) {
-            index64_vector tmp;
-            uint32_t num_fields = 0;
-
-            cb(dst, nb::cpp_function([&](uint64_t index, const char *,
-                                         const char *) {
-                   if (!index)
-                       return index;
-                   jit_log(LogLevel::Debug,
-                           "assign(): traverse_cb[%u] was a%u r%u", num_fields,
-                           (uint32_t) (index >> 32), (uint32_t) index);
-                   num_fields++;
-                   if (num_fields > layout_.num)
-                       jit_raise(
-                           "While traversing the object of type %s at location "
-                           "%s for assigning inputs, the number of variables "
-                           "to assign (>%u) did not match the number of "
-                           "variables traversed when recording(%u)!",
-                           ctx.path.get(), nb::str(tp).c_str(), num_fields,
-                           layout_.num);
-                   return assign_cb_internal(index, tmp);
-               }));
-            if (num_fields != layout_.num)
-                jit_raise(
-                    "While traversing the object of type %s at location %s "
-                    "for assigning inputs, the number of variables "
-                    "to assign did not match the number of variables "
-                    "traversed when recording!",
-                    ctx.path.get(), nb::str(tp).c_str());
-        } else {
+        } else if (auto traversable = traversable_ptr(dst); traversable) {
+            assign_cb(traversable, ctx);
         }
     } catch (nb::python_error &e) {
         nb::raise_from(e, PyExc_RuntimeError,
@@ -1348,8 +1330,6 @@ void FlatVariables::assign(nb::handle dst, TraverseContext &ctx) {
  * additional data to vcalls is tracked correctly.
  */
 void FlatVariables::traverse_with_registry(nb::handle h, TraverseContext &ctx) {
-    scoped_set_flag traverse_scope(JitFlag::EnableObjectTraversal, true);
-
     // Traverse the handle
     traverse(h, ctx);
 
@@ -1407,8 +1387,6 @@ void FlatVariables::traverse_with_registry(nb::handle h, TraverseContext &ctx) {
  * Corresponds to `traverse_with_registry`.
  */
 void FlatVariables::assign_with_registry(nb::handle dst, TraverseContext &ctx) {
-    scoped_set_flag traverse_scope(JitFlag::EnableObjectTraversal, true);
-
     // Assign the handle
     assign(dst, ctx);
 
@@ -1458,7 +1436,7 @@ void FlatVariables::assign_with_registry(nb::handle dst, TraverseContext &ctx) {
             if (self)
                 assign(self, ctx);
             else
-                assign_cb(traversable);
+                assign_cb(traversable, ctx);
         }
         jit_log(LogLevel::Debug, "}");
     }
@@ -1834,8 +1812,6 @@ nb::object FunctionRecording::record(nb::callable func,
         ADScopeContext ad_scope(drjit::ADScope::Resume, 0, nullptr, -1, false);
 
         {
-            scoped_set_flag traverse_scope(JitFlag::EnableObjectTraversal,
-                                           true);
             TraverseContext ctx;
             ctx.postponed          = &postponed;
             ctx.deduplicate_pytree = false;
@@ -1915,8 +1891,6 @@ nb::object FunctionRecording::record(nb::callable func,
         }
         // NOTE: temporarily disable this to not enqueue twice
         try {
-            scoped_set_flag traverse_scope(JitFlag::EnableObjectTraversal,
-                                           true);
             TraverseContext ctx;
             out_variables.assign(input, ctx);
         } catch (std::exception &) {
@@ -2256,7 +2230,6 @@ static PyType_Slot slots[] = { { Py_tp_traverse,
 void export_freeze(nb::module_ & /*m*/) {
 
     nb::module_ d = nb::module_::import_("drjit.detail");
-    nb::class_<drjit::TraversableBase>(d, "TraversableBase").freeze();
     nb::class_<FrozenFunction>(d, "FrozenFunction", nb::type_slots(slots))
         .def(nb::init<nb::callable, int, uint32_t, JitBackend, bool>())
         .def_prop_ro(

--- a/src/python/freeze.cpp
+++ b/src/python/freeze.cpp
@@ -1,152 +1,63 @@
 /**
- * This file implements the frontend for the frozen function feature.
- * The `FrozenFunction` class represents a function that has been annotated with
- * the `@dr.freeze` decorator. When calling the `operator()` of this object for
- * the first time, the wrapped callable is recorded. On subsequent calls, the
- * input is checked, and if compatible, the previously recorded function is
- * replayed. The `FrozenFunction` class should not be used directly, and is
- * wrapped in a higher-level class in `__init__.py`.
+ * This file contains the frontend part of function freezing (``@dr.freeze()``).
  *
- * When calling the `operator()` of a `FrozenFunction` object, the
- * inputs of the function have to be traversed. This collects the JIT variables
- * in the input and information about the layout of the PyTree. We store
- * both in a `FlatVariables` struct. To evaluate all side effects, and so that
- * the freezing backend can handle these JIT variables, they are evaluated.
+ * It provides Python bindings of the ``FrozenFunction`` class, which is not
+ * used directly but rather via a higher-level wrapper in `__init__.py`.
+ * A ``FrozenFunction`` represents a function annotated with `@dr.freeze()`. A
+ * call to its `operator()` proceeds as follows:
  *
- * Only evaluated variables can change between calls to the function
- * without re-tracing it. Therefore, we need to make changing literals opaque.
- * The auto-opaque feature detects changes in literal variables from one call of
- * the function to another. For this reason, traversal of the input is split up
- * into six steps. These steps are performed every time the frozen function is
- * called, and depending on the result, a previous recording can be replayed or a
- * new recording has to be made.
+ * 1. If the wrapped callable was previously recorded, it walks through the
+ *    ``Layout`` representing the prior input configuration. While doing so, it
+ *    checks the current inputs for compatibility and binds detected variables.
+ *    If the input is deemed compatible, it launches the kernel graph directly.
  *
- * 1. The input is traversed using the `FlatVariables::traverse_with_registry`
- *    function. It traverses the PyTree, including a subset of the registry when
- *    class variables are present in the input (i.e., pointers to classes with
- *    Dr.Jit virtual function calls). Information about the layout of the PyTree
- *    is stored in the `Layout` structs of the `layout` vector of the
- *    `FlatVariables` class. If a JIT variable is encountered during this
- *    traversal step, its index will be stored in the `index` field of the
- *    corresponding `Layout` entry.
- * 2. If the `auto_opaque` feature is enabled, the key of the previous iteration
- *    is checked to see if it is compatible with the currently recorded key. If this
- *    is the case, the `opaque_mask` of the last iteration will be used in the
- *    next step; otherwise, it will be cleared.
- * 3. The flattened input variables are traversed by
- *    `FlatVariables::schedule_jit_variables`, and all JIT variables are either
- *    scheduled or force-scheduled, depending on the `opaque_mask` value for
- *    that layout node. After scheduling the variables, they are evaluated,
- *    clearing all side effects.
- * 4. In order to be able to record or replay the function, an array of
- *    deduplicated indices of evaluated JIT variables has to be provided to
- *    either `jit_freeze_start` or `jit_freeze_replay` respectively. The
- *    function `FlatVariables::record_jit_variables` iterates over the flattened
- *    variables, deduplicates indices of evaluated JIT variables, and
- *    additionally records information about them that only becomes available
- *    after evaluation. Additional information is stored in the
- *    `FlatVariables::var_layout` vector.
- * 5. If the `auto_opaque` feature is enabled, we create a mask of literal
- *    variables that have to be evaluated because they changed from one call
- *    to another. To this end, we use the `FlatVariables::fill_opaque_mask`
- *    function, which iterates over the flattened variables and finds such
- *    literals, setting the corresponding boolean to true.
- * 6. If we detect that the number of such literal variables changed, steps 1
- *    to 5 are repeated one time.
+ * 2. If no recording exists or the input is incompatible, it captures a new
+ *    ``Layout`` characterizing the input configuration. When the "auto-opaque"
+ *    feature is enabled, it may materialize literal input arrays into buffers.
+ *    It then compares the layout against a potentially larger set of cached
+ *    recordings, replays the match if found, or otherwise records.
  *
- * After traversing the input, the frozen function decides whether to record a
- * new version of the function or replay an old version. The
- * `FrozenFunction::recordings` hashmap is used to look up old versions of the
- * function. The flattened input PyTree serves as a key to the hashmap. However,
- * only a subset of the flattened PyTree is used for the key. Refer to the
- * `FlatVariables::operator==` function to see which changes to the input can
- * cause the function to be re-traced.
+ * The implementation optimizes for the fast path in (1) where a single
+ * recording is reused over and over again.
  *
- * If no matching recording was found in the hashmap, the following steps will
- * be executed to record the function. Steps 2 to 6 are located in the
- * `FunctionRecording::record` function and can be invoked from the
- * `FunctionRecording::replay` function as well if a dry-run failed.
+ * The interaction with the backend involves the following functions:
  *
- * 1. The flattened version of the input is assigned back to the input PyTree.
- *    This is required so that evaluating variables is reflected in the PyTree.
- * 2. Kernel recording is started with the `jit_freeze_start` function by
- *    providing it with the flattened evaluated variables of the input.
- * 3. The inner function is executed while recording all launched kernels.
- * 4. While kernels are still recorded, the outputs as well as the inputs of the
- *    function are traversed and collected into a single `FlatVariables`
- *    object. The inputs could have changed when executing the function, and we
- *    handle these new inputs in a similar manner to outputs of the function.
- *    Analogous to the above section, the outputs and new inputs are traversed,
- *    scheduled, evaluated, and recorded.
- * 5. Using the deduplicated JIT indices collected by traversing the outputs,
- *    kernel freezing is stopped with the `jit_freeze_stop` function.
- * 6. Finally, we catch any potential errors when assigning variables or
- *    constructing outputs early (i.e., after recording a function rather than
- *    after replaying it later). Therefore, we assign the flattened inputs to
- *    the input PyTree and construct the output from its flattened version. For
- *    assigning the input variables, `FlatVariables::assign_with_registry` is
- *    used. For constructing the output, `FlatVariables::construct` is used.
- *    The layout of the output is also stored in the recording.
+ * - ``jit_freeze_start()`` enters the recording mode, with the variables bound
+ *   to the layout's slots as inputs.
  *
- * In the above case, the new recording is added to the `recordings` hashmap
- * with the input `FlatVariables` as the key.
+ * - ``jit_freeze_stop()`` ends the recording and registers its outputs.
  *
- * If, on the other hand, the function has already been recorded with compatible
- * inputs, this recording will be replayed. The following steps outline
- * replaying a function recording:
+ * - ``jit_freeze_abort()`` discards a recording interrupted by an exception.
  *
- * 1. A dry-run of the recording is launched if this is required, using
- *    `jit_freeze_dry_run`.
- * 2. If the dry-run failed, the current recording will be overwritten by
- *    calling `FunctionRecording::record` on this recording, executing steps 2
- *    to 6 of the above section.
- * 3. If the dry-run succeeded, the recording will be replayed by calling
- *    `jit_freeze_replay` with the flattened evaluated variables of the input
- *    PyTree. The `variables` field of the output flat variables will be used to
- *    store the output variables from the replay.
- * 4. The output from replaying the recording as well as the stored layout is
- *    used to both construct the output PyTree and assign the JIT
- *    variables to the input PyTree.
+ * - ``jit_freeze_dry_run()`` checks whether a recording can be replayed with
+ *   the sizes of the current input. For example, block reductions may not be
+ *   compatible. If not, the function is recorded again in place.
+ *
+ * - ``jit_freeze_replay()`` launches the recorded kernels and returns the
+ *   outputs, from which the frontend constructs the result and writes modified
+ *   inputs back into the input PyTree.
+ *
+ * - ``jit_freeze_destroy()`` releases a recording.
  */
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#endif
 
 #include "freeze.h"
 
-#include <drjit-core/hash.h>
 #include <drjit-core/jit.h>
-#include <drjit/array_router.h>
 #include <drjit/autodiff.h>
 #include <drjit/extra.h>
-#include <drjit/fwd.h>
-#include <drjit/traversable_base.h>
 #include <nanobind/nanobind.h>
-#include <xxh3.h>
-
-#include "autodiff.h"
-#include "base.h"
+#include <exception>
 #include "common.h"
-#include "listobject.h"
-#include "object.h"
-#include "pyerrors.h"
-#include "reduce.h"
-#include "shape.h"
-#include "tupleobject.h"
 
-#include "../ext/nanobind/src/buffer.h"
-
-#if defined(_MSC_VER)
-// Methods in this file will frequently use local variables, whose name matches class attributes.
-// This is intentional. The latter are prefixed with this->name. Tell MSVC not to warn about this.
-#  pragma warning(disable : 4458) /* disable: C4458: declaration of 'layout' hides class member */
-#endif
-
-using Buffer = nanobind::detail::Buffer;
+/// Call ``func`` with the positional and keyword arguments of the call
+static nb::object call_python(nb::handle func, nb::handle args,
+                              nb::handle kwargs) {
+    nb::object result =
+        nb::steal(PyObject_Call(func.ptr(), args.ptr(), kwargs.ptr()));
+    if (!result.is_valid())
+        nb::raise_python_error();
+    return result;
+}
 
 struct ADScopeContext {
     bool process_postponed;
@@ -158,1580 +69,34 @@ struct ADScopeContext {
     ~ADScopeContext() { ad_scope_leave(process_postponed); }
 };
 
-using namespace detail;
-
-bool Layout::operator==(const Layout &rhs) const {
-    if (!this->type.is(rhs.type))
-        return false;
-
-    if (this->num != rhs.num)
-        return false;
-
-    if (this->fields.size() != rhs.fields.size())
-        return false;
-
-    for (uint32_t i = 0; i < this->fields.size(); ++i) {
-        if (this->fields[i].ptr() != rhs.fields[i].ptr() &&
-            !(this->fields[i].equal(rhs.fields[i])))
-            return false;
-    }
-
-    if (this->index != rhs.index)
-        return false;
-
-    if (this->flags != rhs.flags)
-        return false;
-
-    if (this->literal != rhs.literal)
-        return false;
-
-    if (this->vt != rhs.vt)
-        return false;
-
-    if (this->py_object.ptr() != rhs.py_object.ptr() &&
-        (((bool) this->py_object != (bool) rhs.py_object) ||
-         !this->py_object.equal(rhs.py_object)))
-        return false;
-
-    return true;
-}
-
-bool VarLayout::operator==(const VarLayout &rhs) const {
-    if (this->vt != rhs.vt)
-        return false;
-
-    if (this->vs != rhs.vs)
-        return false;
-
-    if (this->flags != rhs.flags)
-        return false;
-
-    if (this->size_index != rhs.size_index)
-        return false;
-
-    return true;
-}
-
-/**
- * \brief Add a variant domain pair to be traversed using the registry.
- *
- * When traversing a jit variable that references a pointer to a class, we
- * have to traverse all objects registered with that variant-domain pair in
- * the registry. This function adds the variant-domain pair, deduplicating
- * the domain. Whether a variable references a class is represented by its
- * ``IsClass`` const
- * attribute. If the domain is an empty string (""), this function skips
- * adding the variant-domain pair.
- */
-void FlatVariables::add_domain(const char *variant_, const char *domain) {
-    // Since it is not possible to pass nullptr strings to nanobind functions we
-    // assume, that a valid domain indicates a valid variant. If the variant is
-    // empty at the end of traversal, we know that no Class variable was
-    // traversed, and registry traversal is not necessary.
-    if (domain && variant_ && strcmp(domain, "") != 0) {
-        jit_log(LogLevel::Debug, "variant=%s, domain=%s", variant_, domain);
-
-        if (domains.empty()) {
-            this->variant = variant_;
-        } else if (this->variant != variant_)
-            jit_raise("traverse(): Variant mismatch! All arguments to a "
-                      "frozen function have to have the same variant. "
-                      "Variant %s of a previous argument does not match "
-                      "variant %s of this argument.",
-                      this->variant.c_str(), variant_);
-
-        bool contains = false;
-        for (std::string &d : domains) {
-            if (d == domain) {
-                contains = true;
-                break;
-            }
-        }
-        if (!contains)
-            domains.push_back(domain);
-    }
-}
-
-/**
- * Adds a jit index to the flattened array, deduplicating it.
- * This allows to check for aliasing conditions, where two variables
- * actually refer to the same index. The function should only be called for
- * scheduled non-literal variable indices.
- */
-uint32_t FlatVariables::add_jit_index(uint32_t index) {
-    uint32_t next_slot = (uint32_t) this->variables.size();
-    auto result        = this->index_to_slot.try_emplace(index, next_slot);
-    auto it            = result.first;
-    bool inserted      = result.second;
-
-    if (inserted) {
-        this->variables.push_back(index);
-        // Borrow the variable
-        jit_var_inc_ref(index);
-        this->var_layout.emplace_back();
-        return next_slot;
-    } else {
-        return it.value();
-    }
-}
-
-/**
- *
- * The auto opaque feature, is able to track changes of literal values in the
- * PyTree between calls to the function. If a literal value changes between two
- * calls, it should be made opaque before the second call. To accomplish this, a
- * boolean array (``opaque_mask``) is used, which indicates which variables
- * should be made opaque before recording a function. Tracking the literals,
- * which should be made opaque can only be done as long as the structure
- * of the input PyTree does not change significantly. If such a change is
- * detected, the opaque_mask is reset with ``false``, and the next call does not
- * force evaluate literals.
- * This function is responsible for detecting changes between two flattened
- * PyTrees (``FlatVariables``), that force us to reset the ``opaque_mask``
- * array.
- */
-bool compatible_auto_opaque(FlatVariables &cur, FlatVariables &prev) {
-    // NOTE: We only test the size of the layout, as a full test is somewhat
-    // expensive, and the worst case is that we make too many variables opaque,
-    // which does not impact correctness. If this causes problems, more
-    // extensive tests might have to be reintroduced.
-    if (cur.layout.size() != prev.layout.size()) {
-        return false;
-    }
-    return true;
-}
-
-bool FlatVariables::fill_opaque_mask(FlatVariables &prev,
-                                     drjit::vector<bool> &opaque_mask) {
-    // If we notice that only a literal has changed, we can set the
-    // corresponding bit in the mask, indicating that this literal should be
-    // made opaque next time.
-    uint32_t opaque_counter = 0;
-    bool new_opaques        = false;
-    for (uint32_t i = 0; i < this->layout.size(); i++) {
-        Layout &layout_     = this->layout[i];
-        Layout &prev_layout = prev.layout[i];
-
-        bool requires_opaque =
-            (layout_.flags & (uint32_t) LayoutFlag::Literal) &&
-            (prev_layout.flags & (uint32_t) LayoutFlag::Literal) &&
-            (layout_.literal != prev_layout.literal ||
-             layout_.literal_size != prev_layout.literal_size);
-
-        opaque_mask[i] |= requires_opaque;
-        new_opaques |= requires_opaque;
-        opaque_counter += requires_opaque;
-    }
-
-    jit_log(LogLevel::Debug,
-            "compare_opaque(): %u variables will be made opaque",
-            opaque_counter);
-
-    return new_opaques;
-}
-
-void FlatVariables::schedule_jit_variables(
-    bool schedule_force, const drjit::vector<bool> *opaque_mask) {
-
-    ProfilerPhase profiler("schedule_jit_variables");
-    for (uint32_t i = layout_index; i < layout.size(); i++) {
-        Layout &layout_ = this->layout[i];
-
-        if (!(layout_.flags & (uint32_t) LayoutFlag::JitIndex))
-            continue;
-
-        uint32_t index = layout_.index;
-
-        int rv = 0;
-        // Undefined variables (i.e. ones created with ``dr.empty``) are handled
-        // similarly to literals, and can be allocated when replaying.
-        if (schedule_force ||
-            (opaque_mask && (*opaque_mask)[i - layout_index])) {
-            // Returns owning reference
-            index = jit_var_schedule_force(index, &rv);
-        } else {
-            // Schedule and create owning reference
-            rv = jit_var_schedule(index);
-            jit_var_inc_ref(index);
-        }
-
-        VarInfo info = jit_var_info(index);
-        if (backend == info.backend || this->backend == JitBackend::None) {
-            backend = info.backend;
-        } else {
-            const char *info_name = "scalar", *bk_name = "scalar";
-            switch (info.backend) {
-                case JitBackend::CUDA:  info_name = "CUDA";  break;
-                case JitBackend::LLVM:  info_name = "LLVM";  break;
-                case JitBackend::Metal: info_name = "Metal"; break;
-                default: break;
-            }
-            switch (backend) {
-                case JitBackend::CUDA:  bk_name = "CUDA";  break;
-                case JitBackend::LLVM:  bk_name = "LLVM";  break;
-                case JitBackend::Metal: bk_name = "Metal"; break;
-                default: break;
-            }
-            jit_raise("freeze(): backend mismatch error (backend of this "
-                      "variable %s does not match backend of others %s)!",
-                      info_name, bk_name);
-        }
-
-        if (info.state == VarState::Literal) {
-            // Special case, where the variable is a literal.
-            layout_.literal = info.literal;
-            // Store size in index variable, as this is not used for literals.
-            layout_.literal_size  = (uint32_t) info.size;
-            layout_.vt            = (uint32_t) info.type;
-            layout_.literal_index = index;
-
-            layout_.flags |= (uint32_t) LayoutFlag::Literal;
-        } else if (info.state == VarState::Undefined) {
-            // Special case, where the variable is a literal.
-            // Store size in index variable, as this is not used for literals.
-            layout_.literal_size  = (uint32_t) info.size;
-            layout_.vt            = (uint32_t) info.type;
-            layout_.literal_index = index;
-
-            layout_.flags |= (uint32_t) LayoutFlag::Undefined;
-        } else {
-            layout_.index = this->add_jit_index(index);
-            layout_.vt    = (uint32_t) info.type;
-            jit_var_dec_ref(index);
-        }
-    }
-    layout_index = (uint32_t) layout.size();
-}
-
-/**
- * \brief Records information about jit variables, that have been traversed.
- *
- * After traversing the PyTree, collecting non-literal indices in
- * ``variables`` and evaluating the collected indices, we can collect
- * information about the underlying variables. This information is used in
- * the key of the ``RecordingMap`` to determine which recording should be
- * replayed or if the function has to be re-traced. This function iterates
- * over the collected indices and collects that information.
- */
-void FlatVariables::record_jit_variables() {
-    ProfilerPhase profiler("record_jit_variables");
-    assert(variables.size() == var_layout.size());
-    for (uint32_t i = 0; i < var_layout.size(); i++) {
-        uint32_t index     = variables[i];
-        VarLayout &layout_ = var_layout[i];
-
-        VarInfo info = jit_var_info(index);
-        if (info.type == VarType::Pointer) {
-            // We do not support pointers as inputs. It might be possible with
-            // some extra handling, but they are never used directly.
-            jit_raise("Pointer inputs not supported!");
-        }
-
-        layout_.vs         = info.state;
-        layout_.vt         = info.type;
-        layout_.size_index = this->add_size((uint32_t) info.size);
-
-        if (info.state == VarState::Evaluated) {
-            // Special case, handling evaluated/opaque variables.
-
-            layout_.flags |=
-                (info.size == 1 ? (uint32_t) LayoutFlag::SingletonArray : 0);
-            layout_.flags |=
-                (info.unaligned ? (uint32_t) LayoutFlag::Unaligned : 0);
-
-        } else {
-            jit_raise("collect(): found variable %u in unsupported state %u!",
-                      index, (uint32_t) info.state);
-        }
-    }
-}
-
-/**
- * This function returns an index of an equivalence class for the variable
- * size in the flattened variables.
- * It uses a hashmap and vector to deduplicate sizes.
- *
- * This is necessary, to catch cases, where two variables had the same size
- * when freezing a function and two different sizes when replaying.
- * In that case one kernel would be recorded, that evaluates both variables.
- * However, when replaying two kernels would have to be launched since the
- * now differently sized variables cannot be evaluated by the same kernel.
- */
-uint32_t FlatVariables::add_size(uint32_t size) {
-    uint32_t next_slot = (uint32_t) this->sizes.size();
-    auto result        = this->size_to_slot.try_emplace(size, next_slot);
-    auto it            = result.first;
-    bool inserted      = result.second;
-
-    if (inserted) {
-        this->sizes.push_back(size);
-        return next_slot;
-    } else {
-        return it.value();
-    }
-}
-
-/**
- * Traverse a variable referenced by a JIT index and add it to the flat
- * variables. An optional Python type can be supplied if it is known.
- * Depending on the ``TraverseContext::schedule_force`` the underlying
- * variable is either scheduled (``jit_var_schedule``) or force scheduled
- * (``jit_var_schedule_force``). If the variable after evaluation is a
- * literal, it is directly recorded in the ``layout``, otherwise it is added
- * to the ``variables`` array, allowing the variables to be used when
- * recording the frozen function.
- */
-void FlatVariables::traverse_jit_index(uint32_t index, TraverseContext &ctx,
-                                       nb::handle tp) {
-    (void) ctx;
-    Layout &layout_ = this->layout.emplace_back();
-
-    if (tp)
-        layout_.type = nb::borrow<nb::type_object>(tp);
-
-    layout_.flags |= (uint32_t) LayoutFlag::JitIndex;
-    layout_.index = index;
-    layout_.vt    = (uint32_t) jit_var_type(index);
-}
-
-/**
- * Construct a variable, given its layout.
- * This is the counterpart to `traverse_jit_index`.
- *
- * Optionally, the index of a variable can be provided that will be
- * overwritten with the result of this function. In that case, the function
- * will check for compatible variable types.
- */
-uint32_t FlatVariables::construct_jit_index(uint32_t prev_index) {
-    Layout &layout_ = this->layout[layout_index++];
-
-    uint32_t index;
-    VarType vt;
-    if ((layout_.flags & (uint32_t) LayoutFlag::Literal) ||
-        (layout_.flags & (uint32_t) LayoutFlag::Undefined)) {
-        index = layout_.literal_index;
-        jit_var_inc_ref(index);
-        vt = (VarType) layout_.vt;
-    } else {
-        VarLayout &var_layout_ = this->var_layout[layout_.index];
-        index                  = this->variables[layout_.index];
-        if (m_log_enabled)
-            jit_log(LogLevel::Debug, "    uses output[%u] = r%u",
-                    layout_.index, index);
-
-        jit_var_inc_ref(index);
-        vt = var_layout_.vt;
-    }
-
-    if (prev_index) {
-        if (vt != (VarType) jit_var_type(prev_index))
-            jit_raise("After replaying a frozen function, when updating"
-                      "its input a VarType mismatch occured %u != %u while"
-                      "assigning (r%u) -> (r%u). This likely occured because "
-                      "part of the frozen function could not be replayed "
-                      "resulting in a different input layout.",
-                      (uint32_t) vt, (uint32_t) jit_var_type(prev_index),
-                      (uint32_t) prev_index, (uint32_t) index);
-    }
-    return index;
-}
-
-/**
- * Add an AD variable by its index. Both the value and gradient are added
- * to the flattened variables. If the AD index has been marked as postponed
- * in the \c TraverseContext.postponed field, we mark the resulting layout
- * with that flag. This will cause the gradient edges to be propagated when
- * assigning to the input. The function takes an optional Python type if
- * it is known.
- */
-void FlatVariables::traverse_ad_index(uint64_t index, TraverseContext &ctx,
-                                      nb::handle tp) {
-    // NOTE: instead of emplacing a Layout representing the ad variable always,
-    // we only do so if the gradients have been enabled. We use this format,
-    // since most variables will not be ad enabled. The layout therefore has to
-    // be peeked in ``construct_ad_index`` before deciding if an ad or jit
-    // index should be constructed/assigned.
-    int grad_enabled = ad_grad_enabled(index);
-    if (grad_enabled) {
-        Layout &layout_   = this->layout.emplace_back();
-        uint32_t ad_index = (uint32_t) (index >> 32);
-
-        if (tp)
-            layout_.type = nb::borrow<nb::type_object>(tp);
-        layout_.num = 2;
-
-        // Set flags
-        layout_.flags |= (uint32_t) LayoutFlag::GradEnabled;
-        // If the edge with this node as its target has been postponed by
-        // the isolate gradient scope, it has been enqueued and we mark the
-        // ad variable as such.
-        if (ctx.postponed && ctx.postponed->contains(ad_index)) {
-            layout_.flags |= (uint32_t) LayoutFlag::Postponed;
-        }
-
-        traverse_jit_index((uint32_t) index, ctx, tp);
-        uint32_t grad = ad_grad(index);
-        traverse_jit_index(grad, ctx, tp);
-        ctx.free_list.push_back_steal(grad);
-    } else {
-        traverse_jit_index((uint32_t) index, ctx, tp);
-    }
-}
-
-/**
- * Construct/assign the variable index given a layout.
- * This corresponds to `traverse_ad_index`.
- *
- * This function is also used for assignment to AD variables.
- * If a `prev_index` is provided, and it is an AD variable, the gradient and
- * value of the flat variables will be applied to the AD variable,
- * preserving the `ad_index`.
- *
- * It returns an owning reference.
- */
-uint64_t FlatVariables::construct_ad_index(uint64_t prev_index) {
-    Layout &layout1 = this->layout[this->layout_index];
-
-    uint64_t index;
-    if ((layout1.flags & (uint32_t) LayoutFlag::GradEnabled) != 0) {
-        Layout &layout2 = this->layout[this->layout_index++];
-        bool postponed = (layout2.flags & (uint32_t) LayoutFlag::Postponed);
-
-        uint32_t val  = construct_jit_index((uint32_t) prev_index);
-        uint32_t grad = construct_jit_index((uint32_t) prev_index);
-
-        // Resize the gradient if it is a literal
-        if ((VarState) jit_var_state(grad) == VarState::Literal) {
-            uint32_t new_grad = jit_var_resize(grad, jit_var_size(val));
-            jit_var_dec_ref(grad);
-            grad = new_grad;
-        }
-
-        // If the prev_index variable is provided we assign the new value
-        // and gradient to the ad variable of that index instead of creating
-        // a new one.
-        uint32_t ad_index = (uint32_t) (prev_index >> 32);
-        if (ad_index) {
-            index = (((uint64_t) ad_index) << 32) | ((uint64_t) val);
-            ad_var_inc_ref(index);
-        } else
-            index = ad_var_new(val);
-
-        if (m_log_enabled)
-            jit_log(LogLevel::Debug, " -> ad_var r%zu", index);
-        jit_var_dec_ref(val);
-
-        // Equivalent to set_grad
-        ad_clear_grad(index);
-        ad_accum_grad(index, grad);
-        jit_var_dec_ref(grad);
-
-        // Variables, that have been postponed by the isolate gradient scope
-        // will be enqueued, which propagates their gradient to previous
-        // functions.
-        if (ad_index && postponed) {
-            ad_enqueue(drjit::ADMode::Backward, index);
-        }
-    } else {
-        index = construct_jit_index((uint32_t) prev_index);
-    }
-
-    return index;
-}
-
-/**
- * Wrapper around traverse_ad_index for a Python handle.
- */
-void FlatVariables::traverse_ad_var(nb::handle h, TraverseContext &ctx) {
-    auto s = supp(h.type());
-
-    if (s.is_class) {
-        auto variant_ = nb::borrow<nb::str>(nb::getattr(h, "Variant"));
-        auto domain   = nb::borrow<nb::str>(nb::getattr(h, "Domain"));
-        add_domain(variant_.c_str(), domain.c_str());
-    }
-
-    raise_if(s.index == nullptr, "freeze(): ArraySupplement index function "
-                                 "pointer is nullptr.");
-
-    uint64_t index = s.index(inst_ptr(h));
-
-    this->traverse_ad_index(index, ctx, h.type());
-}
-
-/**
- * Construct an AD variable given its layout.
- * This corresponds to `traverse_ad_var`.
- */
-nb::object FlatVariables::construct_ad_var(const Layout &layout_) {
-    uint64_t index = construct_ad_index();
-
-    auto result              = nb::inst_alloc_zero(layout_.type);
-    const ArraySupplement &s = supp(result.type());
-    s.init_index(index, inst_ptr(result));
-    nb::inst_mark_ready(result);
-
-    // We have to release the reference, since assignment will borrow from
-    // it.
-    ad_var_dec_ref(index);
-
-    return result;
-}
-
-/**
- * Assigns an AD variable.
- * Corresponds to `traverse_ad_var`.
- * This uses `construct_ad_index` to either construct a new AD variable or
- * assign the value and gradient to an already existing one.
- */
-void FlatVariables::assign_ad_var(Layout &layout_, nb::handle dst) {
-    const ArraySupplement &s = supp(layout_.type);
-
-    uint64_t index;
-    if (s.index) {
-        // ``construct_ad_index`` is used for assignment
-        index = construct_ad_index(s.index(inst_ptr(dst)));
-    } else
-        index = construct_ad_index();
-
-    s.reset_index(index, inst_ptr(dst));
-    if (m_log_enabled)
-        jit_log(LogLevel::Debug,
-                "index=%zu, grad_enabled=%u, ad_grad_enabled=%u", index,
-                grad_enabled(dst), ad_grad_enabled(index));
-
-    // Release reference, since ``construct_ad_index`` returns owning
-    // reference and ``s.reset_index`` borrows from it.
-    ad_var_dec_ref(index);
-}
-
-/**
- * Traverse a C++ tree using its `traverse_cb` callback.
- */
-void FlatVariables::traverse_cb(const drjit::TraversableBase *traversable,
-                                TraverseContext &ctx, nb::object type) {
-    uint32_t layout_index_ = (uint32_t) this->layout.size();
-    Layout &layout_        = this->layout.emplace_back();
-
-    // Objects without a Python counterpart are deduplicated here, objects
-    // with one by the ``visited`` map of the Python-level traversal.
-    if (!ctx.visited_cpp.insert(traversable).second) {
-        layout_.flags |= (uint32_t) LayoutFlag::RecursiveRef;
-        return;
-    }
-    layout_.type = nb::borrow<nb::type_object>(type);
-
-    uint32_t num_fields = 0;
-    for_each_member(
-        const_cast<drjit::TraversableBase *>(traversable),
-        drjit::TraverseRole::Freeze,
-        [&](uint64_t index, const char *, const char *variant_,
-            const char *domain) {
-            if (index) {
-                add_domain(variant_, domain);
-                traverse_ad_index(index, ctx);
-                num_fields++;
-            }
-            return index;
-        },
-        [&](drjit::TraversableBase *child, const char *) {
-            num_fields++;
-            if (PyObject *self = child->self_py())
-                traverse(self, ctx);
-            else
-                traverse_cb(child, ctx);
-        });
-
-    // Attributes of a Python subclass instance
-    if (nb::dict dict = traversable_dict(traversable); dict.is_valid()) {
-        for (nb::handle value : dict.values()) {
-            num_fields++;
-            traverse(value, ctx);
-        }
-    }
-
-    this->layout[layout_index_].num = num_fields;
-}
-
-/**
- * Helper function, used to assign a callback variable.
- *
- * \param tmp
- *     This vector is populated with the indices to variables that have been
- *     constructed. It is required to release the references, since the
- *     references created by `construct_ad_index` are owning and they are
- *     borrowed after the callback returns.
- */
-uint64_t FlatVariables::assign_cb_internal(uint64_t index,
-                                           index64_vector &tmp) {
-    if (!index)
-        return index;
-
-    uint64_t new_index = this->construct_ad_index(index);
-
-    tmp.push_back_steal(new_index);
-    return new_index;
-}
-
-/**
- * Assigns variables using its `traverse_cb_rw` callback.
- * This corresponds to `traverse_cb`.
- */
-void FlatVariables::assign_cb(drjit::TraversableBase *traversable,
-                              TraverseContext &ctx) {
-    Layout &layout_ = this->layout[layout_index++];
-
-    if (layout_.flags & (uint32_t) LayoutFlag::RecursiveRef)
-        return;
-
-    index64_vector tmp;
-    uint32_t num = layout_.num, field_counter = 0;
-    auto count = [&] {
-        if (field_counter >= num)
-            jit_raise("While traversing an object for assigning inputs, "
-                      "the number of variables to assign (>%u) did not "
-                      "match the number of variables traversed when "
-                      "recording (%u)!",
-                      field_counter, num);
-        field_counter++;
-    };
-
-    for_each_member(
-        traversable, drjit::TraverseRole::Freeze,
-        [&](uint64_t index, const char *, const char *, const char *) {
-            if (!index)
-                return index;
-            count();
-            return assign_cb_internal(index, tmp);
-        },
-        [&](drjit::TraversableBase *child, const char *) {
-            count();
-            if (PyObject *self = child->self_py())
-                assign(self, ctx);
-            else
-                assign_cb(child, ctx);
-        });
-
-    if (nb::dict dict = traversable_dict(traversable); dict.is_valid()) {
-        for (nb::handle value : dict.values()) {
-            count();
-            assign(value, ctx);
-        }
-    }
-
-    if (field_counter != num)
-        jit_raise("While traversing an object for assigning inputs, the "
-                  "number of variables to assign (%u) did not match the "
-                  "number of variables traversed when recording (%u)!",
-                  field_counter, num);
-}
-
-/**
- * Helper struct to construct path strings to variables.
- * Used to provide helpful logs and error messages.
- */
-struct scoped_path {
-    TraverseContext &m_ctx;
-
-    uint32_t m_size;
-    scoped_path(TraverseContext &ctx, const char *suffix, bool dict = false)
-        : m_ctx(ctx), m_size((uint32_t) ctx.path.size()) {
-        if (dict) {
-            if (ctx.recursion_level == 0) {
-                ctx.path.put_dstr(suffix);
-            } else {
-                ctx.path.put("[\"");
-                ctx.path.put_dstr(suffix);
-                ctx.path.put("\"]");
-            }
-        } else {
-            ctx.path.put('.');
-            ctx.path.put_dstr(suffix);
-        }
-        ctx.recursion_level++;
-    }
-    scoped_path(TraverseContext &ctx, uint32_t suffix)
-        : m_ctx(ctx), m_size((uint32_t) ctx.path.size()) {
-        ctx.path.put('[');
-        ctx.path.put_uint32(suffix);
-        ctx.path.put(']');
-        ctx.recursion_level++;
-    }
-    ~scoped_path() {
-        m_ctx.path.rewind(m_ctx.path.size() - m_size);
-        m_ctx.recursion_level--;
+/// Aborts a recording when an exception unwinds the scope
+struct freeze_abort_guard {
+    JitBackend backend;
+    bool armed = true;
+    ~freeze_abort_guard() {
+        if (armed)
+            jit_freeze_abort(backend);
     }
 };
 
-/**
- * Traverses a PyTree in DFS order, and records its layout in the
- * `layout` vector.
- *
- * When hitting a drjit primitive type, it calls the
- * `traverse_dr_var` method, which will add their indices to the
- * `flat_variables` vector. The collect method will also record metadata
- * about the drjit variable in the layout. Therefore, the layout can be used
- * as an identifier to the recording of the frozen function.
- */
-void FlatVariables::traverse(nb::handle h, TraverseContext &ctx) {
-    if (recursion_level == 0)
-        m_log_enabled = log_enabled(LogLevel::Debug);
-    recursion_guard guard(this);
+nb::object FunctionRecording::record(nb::handle func, nb::handle root,
+                                     const uint32_t *inputs) {
+    JitBackend backend = layout->backend;
+    uint32_t n_inputs  = (uint32_t) layout->slots.size();
 
-    ProfilerPhase profiler("traverse");
-    nb::handle tp = h.type();
+    jit_freeze_start(backend, inputs, n_inputs);
+    freeze_abort_guard abort_guard { backend };
 
-    if (m_log_enabled)
-        jit_log(LogLevel::Debug, "FlatVariables::traverse(): %s {",
-                nb::type_name(tp).c_str());
-
-    uint32_t layout_index_ = (uint32_t) this->layout.size();
-    Layout &layout_        = this->layout.emplace_back();
-
-    const void *key     = h.ptr();
-    auto [it, inserted] = ctx.visited.try_emplace(key, nb::borrow(h));
-    if (!inserted) {
-        layout_.flags |= (uint32_t) LayoutFlag::RecursiveRef;
-        return;
-    }
-    try {
-        layout_.type = nb::borrow<nb::type_object>(tp);
-        if (is_drjit_type(tp)) {
-            const ArraySupplement &s = supp(tp);
-            if (s.is_tensor) {
-                nb::handle array = s.tensor_array(h.ptr());
-
-                auto full_shape = nb::borrow<nb::tuple>(shape(h));
-
-                // Instead of adding the whole shape of a tensor to the key, we
-                // only add the inner part, not containing dimension 0. When
-                // indexing into a tensor, this is the only dimension that is
-                // not used in the index calculation. When constructing a tensor
-                // this dimension is reconstructed from the width of the
-                // underlying array.
-
-                size_t ndim = full_shape.size();
-                nb::tuple_builder inner_shape(ndim > 0 ? ndim - 1 : 0);
-                for (size_t i = 1; i < ndim; ++i)
-                    inner_shape.put(full_shape[i]);
-
-                layout_.py_object = inner_shape.commit();
-
-                traverse(nb::steal(array), ctx);
-            } else if (s.ndim != 1) {
-                Py_ssize_t len = s.shape[0];
-                if (len == DRJIT_DYNAMIC)
-                    len = s.len(inst_ptr(h));
-
-                layout_.num = (uint32_t) len;
-
-                for (Py_ssize_t i = 0; i < len; ++i) {
-                    scoped_path ps(ctx, (uint32_t) i);
-                    traverse(nb::steal(s.item(h.ptr(), i)), ctx);
-                }
-            } else {
-                layout_.num = 1;
-                traverse_ad_var(h, ctx);
-            }
-        } else if (tp.is(&PyTuple_Type)) {
-            nb::tuple tuple = nb::borrow<nb::tuple>(h);
-
-            layout_.num = (uint32_t) tuple.size();
-
-            for (uint32_t i = 0; i < tuple.size(); i++) {
-                scoped_path ps(ctx, (uint32_t) i);
-                auto h2 = tuple[i];
-                traverse(h2, ctx);
-            }
-        } else if (tp.is(&PyList_Type)) {
-            nb::list list = nb::borrow<nb::list>(h);
-
-            layout_.num = (uint32_t) list.size();
-
-            for (uint32_t i = 0; i < list.size(); i++) {
-                scoped_path ps(ctx, (uint32_t) i);
-                auto h2 = list[i];
-                traverse(h2, ctx);
-            }
-        } else if (tp.is(&PyDict_Type)) {
-            nb::dict dict = nb::borrow<nb::dict>(h);
-
-            layout_.num = (uint32_t) dict.size();
-            layout_.fields.reserve(layout_.num);
-            // Note: these loops look mergeable but are not. traverse() may
-            // leave layout_ dangling.
-            for (auto [k, v] : dict)
-                layout_.fields.push_back(nb::borrow(k));
-
-            for (auto [k, v] : dict) {
-                scoped_path ps(ctx, nb::str(k).c_str(), true);
-                traverse(v, ctx);
-            }
-        } else if (nb::dict ds = get_drjit_struct(tp); ds.is_valid()) {
-
-            layout_.num = (uint32_t) ds.size();
-            layout_.fields.reserve(layout_.num);
-            for (auto k : ds.keys()) {
-                layout_.fields.push_back(nb::borrow(k));
-            }
-
-            for (auto [k, v] : ds) {
-                scoped_path ps(ctx, nb::str(k).c_str());
-                traverse(nb::getattr(h, k), ctx);
-            }
-        } else if (nb::object df = dataclass_fields(tp); df.is_valid()) {
-
-            for (auto field : df) {
-                nb::object k = field.attr(DR_STR(name));
-                layout_.fields.push_back(nb::borrow(k));
-            }
-            layout_.num = (uint32_t) layout_.fields.size();
-
-            for (nb::handle field : df) {
-                nb::object k = field.attr(DR_STR(name));
-                scoped_path ps(ctx, nb::str(k).c_str());
-                traverse(nb::getattr(h, k), ctx);
-            }
-        } else if (auto traversable = traversable_ptr(h); traversable) {
-            traverse_cb(traversable, ctx, nb::borrow<nb::type_object>(tp));
-        } else {
-            raise_if_unbound_traversable(tp);
-
-            jit_log(LogLevel::Debug,
-                    "traverse(): You passed a value of type %s to a frozen "
-                    "function, it could not be converted to a Dr.Jit type. "
-                    "Changing this value in future calls to the frozen "
-                    "function will cause it to be re-traced. The value is "
-                    "located at %s.",
-                    nb::str(tp).c_str(), ctx.path.get());
-
-            layout_.py_object = nb::borrow<nb::object>(h);
-        }
-    } catch (nb::python_error &e) {
-        auto ts = nb::str(tp);
-        nb::raise_from(
-            e, PyExc_RuntimeError,
-            "FlatVariables::traverse(): error encountered while "
-            "processing an argument of type '%s' at location %s (see above).",
-            ts.c_str(), ctx.path.get());
-    } catch (const std::exception &e) {
-        auto ts = nb::str(tp);
-        nb::chain_error(
-            PyExc_RuntimeError,
-            "FlatVariables::traverse(): error encountered "
-            "while processing an argument of type '%s' at location %s: %s",
-            ts.c_str(), ctx.path.get(), e.what());
-        nb::raise_python_error();
-    }
-
-    if (!ctx.deduplicate_pytree)
-        ctx.visited.erase(key);
-
-    if (m_log_enabled)
-        jit_log(LogLevel::Debug, "}");
-}
-
-/**
- * This is the counterpart to the ``traverse`` method, used to construct the
- * output of a frozen function. Given a layout vector and flat_variables, it
- * re-constructs the PyTree.
- */
-nb::object FlatVariables::construct() {
-    if (recursion_level == 0)
-        m_log_enabled = log_enabled(LogLevel::Debug);
-    recursion_guard guard(this);
-
-    if (this->layout.size() == 0) {
-        return nb::none();
-    }
-
-    const Layout &layout_ = this->layout[layout_index++];
-
-    if (m_log_enabled)
-        jit_log(LogLevel::Debug, "FlatVariables::construct(): %s {",
-                nb::type_name(layout_.type).c_str());
-
-    if (layout_.type.is(nb::none().type())) {
-        return nb::none();
-    }
-    try {
-        if (is_drjit_type(layout_.type)) {
-            const ArraySupplement &s = supp(layout_.type);
-            if (s.is_tensor) {
-                nb::object array = construct();
-
-                // Reconstruct the full shape from the inner part, stored in the
-                // layout and the width of the underlying array.
-                auto inner_shape = nb::borrow<nb::tuple>(layout_.py_object);
-                auto first_dim   = prod(shape(array), nb::none())
-                                     .floor_div(prod(inner_shape, nb::none()));
-
-                nb::tuple_builder full_shape(inner_shape.size() + 1);
-                full_shape.put(first_dim);
-                for (size_t i = 0; i < inner_shape.size(); ++i)
-                    full_shape.put(inner_shape[i]);
-
-                nb::object tensor = layout_.type(array, full_shape.commit());
-                return tensor;
-            } else if (s.ndim != 1) {
-                auto result      = nb::inst_alloc_zero(layout_.type);
-                dr::ArrayBase *p = inst_ptr(result);
-                size_t size      = s.shape[0];
-                if (size == DRJIT_DYNAMIC) {
-                    size = layout_.num;
-                    s.init(size, p);
-                }
-                for (size_t i = 0; i < size; ++i) {
-                    result[i] = construct();
-                }
-                nb::inst_mark_ready(result);
-                return result;
-            } else {
-                return construct_ad_var(layout_);
-            }
-        } else if (layout_.type.is(&PyTuple_Type)) {
-            nb::tuple_builder tuple(layout_.num);
-            for (uint32_t i = 0; i < layout_.num; ++i)
-                tuple.put(construct());
-            return tuple.commit();
-        } else if (layout_.type.is(&PyList_Type)) {
-            nb::list_builder list(layout_.num);
-            for (uint32_t i = 0; i < layout_.num; ++i)
-                list.put(construct());
-            return list.commit();
-        } else if (layout_.type.is(&PyDict_Type)) {
-            nb::dict dict;
-            for (auto k : layout_.fields)
-                dict[k] = construct();
-            return std::move(dict);
-        } else if (nb::dict ds = get_drjit_struct(layout_.type); ds.is_valid()) {
-            nb::object tmp = layout_.type();
-            // TODO: validation against `ds`
-            for (auto k : layout_.fields)
-                nb::setattr(tmp, k, construct());
-            return tmp;
-        } else if (nb::object df = dataclass_fields(layout_.type);
-                   df.is_valid()) {
-            nb::dict dict;
-            for (auto k : layout_.fields)
-                dict[k] = construct();
-            return layout_.type(**dict);
-        } else if (layout_.py_object) {
-            return layout_.py_object;
-        } else {
-            nb::raise("Tried to construct a variable of type %s that is not "
-                      "constructable!",
-                      nb::type_name(layout_.type).c_str());
-        }
-    } catch (nb::python_error &e) {
-        nb::raise_from(e, PyExc_RuntimeError,
-                       "FlatVariables::construct(): error encountered while "
-                       "processing an argument of type '%U' (see above).",
-                       nb::type_name(layout_.type).ptr());
-    } catch (const std::exception &e) {
-        nb::chain_error(PyExc_RuntimeError,
-                        "FlatVariables::construct(): error encountered "
-                        "while processing an argument of type '%U': %s",
-                        nb::type_name(layout_.type).ptr(), e.what());
-        nb::raise_python_error();
-    }
-
-    // jit_log(LogLevel::Debug, "}"); // Never executed error
-}
-
-/**
- * Assigns the flattened variables to an already existing PyTree.
- * This is used when input variables have changed.
- */
-void FlatVariables::assign(nb::handle dst, TraverseContext &ctx) {
-    if (recursion_level == 0)
-        m_log_enabled = log_enabled(LogLevel::Debug);
-    recursion_guard guard(this);
-
-    nb::handle tp  = dst.type();
-    Layout &layout_ = this->layout[layout_index++];
-
-    if (layout_.flags & (uint32_t) LayoutFlag::RecursiveRef)
-        return;
-
-    if (m_log_enabled)
-        jit_log(LogLevel::Debug, "FlatVariables::assign(): %s with %s {",
-                nb::type_name(tp).c_str(),
-                nb::type_name(layout_.type).c_str());
-
-    if (!layout_.type.equal(tp))
-        jit_raise("Type mismatch! Type of the object at location %s when "
-                  "recording (%s) does not match type of object that is "
-                  "assigned (%s).",
-                  ctx.path.get(), nb::type_name(tp).c_str(),
-                  nb::type_name(layout_.type).c_str());
-
-    try {
-        if (is_drjit_type(tp)) {
-            const ArraySupplement &s = supp(tp);
-
-            if (s.is_tensor) {
-                nb::handle array = s.tensor_array(dst.ptr());
-                assign(nb::steal(array), ctx);
-            } else if (s.ndim != 1) {
-                Py_ssize_t len = s.shape[0];
-                if (len == DRJIT_DYNAMIC)
-                    len = s.len(inst_ptr(dst));
-
-                for (Py_ssize_t i = 0; i < len; ++i) {
-                    scoped_path ps(ctx, (uint32_t) i);
-                    assign(dst[i], ctx);
-                }
-            } else {
-                assign_ad_var(layout_, dst);
-            }
-        } else if (tp.is(&PyTuple_Type)) {
-            nb::tuple tuple = nb::borrow<nb::tuple>(dst);
-            raise_if(
-                tuple.size() != layout_.num,
-                "The number of objects in this tuple changed from %u to %u "
-                "while recording the function.",
-                layout_.num, (uint32_t) tuple.size());
-
-            for (uint32_t i = 0; i < tuple.size(); i++) {
-                scoped_path ps(ctx, (uint32_t) i);
-                auto h2 = tuple[i];
-                assign(h2, ctx);
-            }
-        } else if (tp.is(&PyList_Type)) {
-            nb::list list = nb::borrow<nb::list>(dst);
-            raise_if(
-                list.size() != layout_.num,
-                "The number of objects in a list at %s changed from %u to %u "
-                "while recording the function.",
-                ctx.path.get(), layout_.num, (uint32_t) list.size());
-
-            for (uint32_t i = 0; i < list.size(); i++) {
-                scoped_path ps(ctx, (uint32_t) i);
-                auto h2 = list[i];
-                assign(h2, ctx);
-            }
-        } else if (tp.is(&PyDict_Type)) {
-            nb::dict dict = nb::borrow<nb::dict>(dst);
-            for (auto &k : layout_.fields) {
-                scoped_path ps(ctx, nb::str(k).c_str(), true);
-                nb::object value = dict.get(k, nb::handle());
-                if (value.is_valid())
-                    assign(value, ctx);
-                else
-                    dst[k] = construct();
-            }
-        } else if (nb::dict ds = get_drjit_struct(dst); ds.is_valid()) {
-            for (auto &k : layout_.fields) {
-                scoped_path ps(ctx, nb::str(k).c_str());
-                if (nb::hasattr(dst, k))
-                    assign(nb::getattr(dst, k), ctx);
-                else
-                    nb::setattr(dst, k, construct());
-            }
-        } else if (nb::object df = dataclass_fields(tp); df.is_valid()) {
-            for (auto k : layout_.fields) {
-                scoped_path ps(ctx, nb::str(k).c_str());
-                if (nb::hasattr(dst, k))
-                    assign(nb::getattr(dst, k), ctx);
-                else
-                    nb::setattr(dst, k, construct());
-            }
-        } else if (auto traversable = traversable_ptr(dst); traversable) {
-            assign_cb(traversable, ctx);
-        }
-    } catch (nb::python_error &e) {
-        nb::raise_from(e, PyExc_RuntimeError,
-                       "FlatVariables::assign(): error encountered while "
-                       "processing an argument at %s "
-                       "of type '%U' (see above).",
-                       ctx.path.get(), nb::type_name(tp).ptr());
-    } catch (const std::exception &e) {
-        nb::chain_error(PyExc_RuntimeError,
-                        "FlatVariables::assign(): error encountered "
-                        "while processing an argument at %s "
-                        "of type '%U': %s",
-                        ctx.path.get(), nb::type_name(tp).ptr(), e.what());
-        nb::raise_python_error();
-    }
-
-    if (m_log_enabled)
-        jit_log(LogLevel::Debug, "}");
-}
-
-/**
- * First traverses the PyTree, then the registry. This ensures that
- * additional data to vcalls is tracked correctly.
- */
-void FlatVariables::traverse_with_registry(nb::handle h, TraverseContext &ctx) {
-    // Traverse the handle
-    traverse(h, ctx);
-
-    // Traverse the registry (if a class variable was traversed)
-    if (!domains.empty()) {
-        ProfilerPhase profiler("traverse_registry");
-        uint32_t layout_index_ = (uint32_t) this->layout.size();
-        Layout &layout_        = this->layout.emplace_back();
-        layout_.type           = nb::borrow<nb::type_object>(nb::none());
-
-        uint32_t num_fields = 0;
-
-        jit_log(LogLevel::Debug, "registry{");
-
-        drjit::vector<void *> registry_pointers;
-        for (std::string &domain : domains) {
-            uint32_t registry_bound =
-                jit_registry_id_bound(variant.c_str(), domain.c_str());
-            uint32_t offset = (uint32_t) registry_pointers.size();
-            registry_pointers.resize(registry_pointers.size() + registry_bound,
-                                     nullptr);
-            jit_registry_get_pointers(variant.c_str(), domain.c_str(),
-                                      &registry_pointers[offset]);
-        }
-
-        jit_log(LogLevel::Debug, "registry_bound=%u", registry_pointers.size());
-        jit_log(LogLevel::Debug, "layout_index=%u", this->layout.size());
-        for (void *ptr : registry_pointers) {
-            jit_log(LogLevel::Debug, "ptr=%p", ptr);
-            if (!ptr)
-                continue;
-
-            // WARN: very unsafe cast!
-            // We assume, that any object added to the registry inherits from
-            // TraversableBase. This is ensured by the signature of the
-            // ``drjit::registry_put`` function.
-            auto traversable = (drjit::TraversableBase *) ptr;
-            auto self        = traversable->self_py();
-
-            if (self)
-                traverse(self, ctx);
-            else
-                traverse_cb(traversable, ctx);
-
-            num_fields++;
-        }
-        jit_log(LogLevel::Debug, "}");
-
-        this->layout[layout_index_].num = num_fields;
-    }
-}
-
-/**
- * First assigns the registry and then the PyTree.
- * Corresponds to `traverse_with_registry`.
- */
-void FlatVariables::assign_with_registry(nb::handle dst, TraverseContext &ctx) {
-    // Assign the handle
-    assign(dst, ctx);
-
-    // Assign registry (if a class variable was traversed)
-    if (!domains.empty()) {
-        Layout &layout_ = this->layout[layout_index++];
-
-        jit_log(LogLevel::Debug, "registry{");
-
-        drjit::vector<void *> registry_pointers;
-        for (std::string &domain : domains) {
-            uint32_t registry_bound =
-                jit_registry_id_bound(variant.c_str(), domain.c_str());
-            uint32_t offset = (uint32_t) registry_pointers.size();
-            registry_pointers.resize(registry_pointers.size() + registry_bound,
-                                     nullptr);
-            jit_registry_get_pointers(variant.c_str(), domain.c_str(),
-                                      &registry_pointers[offset]);
-        }
-
-        uint32_t num_fields = 0;
-
-        for (void *ptr : registry_pointers)
-            if (ptr)
-                num_fields++;
-
-        if (num_fields != layout_.num)
-            jit_raise("assign_with_registry(): The number of registry "
-                      "entries (%zu) did not match the number of registry "
-                      "entries recorded (%u)!",
-                      registry_pointers.size(), layout_.num);
-
-        jit_log(LogLevel::Debug, "registry_bound=%u", registry_pointers.size());
-        jit_log(LogLevel::Debug, "layout_index=%u", this->layout_index);
-        for (void *ptr : registry_pointers) {
-            jit_log(LogLevel::Debug, "ptr=%p", ptr);
-            if (!ptr)
-                continue;
-
-            // WARN: very unsafe cast!
-            // We assume, that any object added to the registry inherits from
-            // TraversableBase. This is ensured by the signature of the
-            // ``drjit::registry_put`` function.
-            auto traversable = (drjit::TraversableBase *) ptr;
-            auto self        = traversable->self_py();
-
-            if (self)
-                assign(self, ctx);
-            else
-                assign_cb(traversable, ctx);
-        }
-        jit_log(LogLevel::Debug, "}");
-    }
-}
-
-FlatVariables::~FlatVariables() {
-    state_lock_guard guard;
-    for (uint32_t i = 0; i < layout.size(); ++i) {
-        Layout &l = layout[i];
-        if (((l.flags & (uint32_t) LayoutFlag::Literal) ||
-             (l.flags & (uint32_t) LayoutFlag::Undefined)) &&
-            l.literal_index) {
-            jit_var_dec_ref(l.literal_index);
-        }
-    }
-}
-
-void FlatVariables::borrow() {
-    state_lock_guard guard;
-    for (uint32_t &index : this->variables)
-        jit_var_inc_ref(index);
-}
-
-void FlatVariables::release() {
-    state_lock_guard guard;
-    for (uint32_t &index : this->variables)
-        jit_var_dec_ref(index);
-}
-
-bool log_diff_variable(LogLevel level, const FlatVariables &curr,
-                       const FlatVariables &prev, uint32_t slot,
-                       TraverseContext &ctx) {
-    const VarLayout &curr_l = curr.var_layout[slot];
-    const VarLayout &prev_l = prev.var_layout[slot];
-
-    if (curr_l.vt != prev_l.vt) {
-        jit_log(level, "%s: The variable type changed from %u to %u.",
-                ctx.path.get(), prev_l.vt, curr_l.vt);
-        return false;
-    }
-    if (curr_l.size_index != prev_l.size_index) {
-        jit_log(level,
-                "%s: The size equivalence class of the variable changed from "
-                "%u to %u.",
-                ctx.path.get(), prev_l.size_index, curr_l.size_index);
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * Log the difference of the layout nodes at ``index`` for the two
- * FlatVariables.
- */
-bool log_diff(LogLevel level, const FlatVariables &curr,
-              const FlatVariables &prev, uint32_t &index,
-              TraverseContext &ctx) {
-
-    // A subtree can contribute a different number of entries and desync the walk
-    if (index >= curr.layout.size() || index >= prev.layout.size()) {
-        jit_log(level,
-                "%s: The two inputs are structured differently, the comparison "
-                "cannot continue past this point.",
-                ctx.path.get());
-        return false;
-    }
-
-    const Layout &curr_l = curr.layout[index];
-    const Layout &prev_l = prev.layout[index];
-    index++;
-
-    if (curr_l.flags != prev_l.flags) {
-        jit_log(level, "%s: The flags of this node changed from 0x%lx to 0x%lx",
-                ctx.path.get(), prev_l.flags, curr_l.flags);
-        return false;
-    }
-
-    if (curr_l.index != prev_l.index) {
-        jit_log(level,
-                "%s: The index into the array of deduplicated variables "
-                "changed from s%u to s%u. This can occur if two variables "
-                "referred to the same JIT index, but do no longer.",
-                ctx.path.get(), prev_l.index, curr_l.index);
-        return false;
-    }
-
-    if (curr_l.flags & (uint32_t) LayoutFlag::JitIndex &&
-        !(curr_l.flags & (uint32_t) LayoutFlag::Literal) &&
-        !(curr_l.flags & (uint32_t) LayoutFlag::Undefined)) {
-        uint32_t slot = curr_l.index;
-        if (!log_diff_variable(level, curr, prev, slot, ctx))
-            return false;
-    }
-
-    if (((bool) curr_l.type != (bool) prev_l.type) ||
-        !(curr_l.type.equal(prev_l.type))) {
-        jit_log(level, "%s: The type of this node changed from %s to %s",
-                ctx.path.get(), nb::str(prev_l.type).c_str(),
-                nb::str(curr_l.type).c_str());
-        return false;
-    }
-
-    if (curr_l.literal != prev_l.literal) {
-        jit_log(level,
-                "%s: The literal value of this variable changed from 0x%llx to "
-                "0x%llx",
-                ctx.path.get(), prev_l.literal, curr_l.literal);
-        return false;
-    }
-
-    if (((bool) curr_l.py_object != (bool) prev_l.py_object) ||
-        !curr_l.py_object.equal(prev_l.py_object)) {
-        jit_log(level, "%s: The object changed from %s to %s", ctx.path.get(),
-                nb::str(prev_l.py_object).c_str(),
-                nb::str(curr_l.py_object).c_str());
-        return false;
-    }
-
-    if (curr_l.num != prev_l.num) {
-        jit_log(level,
-                "%s: The number of elements of this container changed from %u "
-                "to %u",
-                ctx.path.get(), prev_l.num, curr_l.num);
-        return false;
-    }
-
-    if (curr_l.fields.size() != prev_l.fields.size()) {
-        jit_log(level,
-                "%s: The number of elements of this container changed from %u "
-                "to %u",
-                ctx.path.get(), prev_l.fields.size(), curr_l.fields.size());
-        return false;
-    }
-
-    for (uint32_t i = 0; i < curr_l.fields.size(); ++i) {
-        if (!(curr_l.fields[i].equal(prev_l.fields[i]))) {
-            jit_log(level, "%s: The %ith key changed from \"%s\" to \"%s\"",
-                    ctx.path.get(), i, nb::str(curr_l.fields[i]).c_str(),
-                    nb::str(prev_l.fields[i]).c_str());
-        }
-    }
-
-    // Stop at the first difference; beyond it the two walks are out of sync
-    if (curr_l.fields.size() > 0) {
-        for (uint32_t i = 0; i < curr_l.fields.size(); i++) {
-            auto &field = curr_l.fields[i];
-
-            scoped_path ps(ctx, nb::str(field).c_str(),
-                           curr_l.type.is(&PyDict_Type));
-
-            if (!log_diff(level, curr, prev, index, ctx))
-                return false;
-        }
-    } else {
-        for (uint32_t i = 0; i < curr_l.num; i++) {
-            scoped_path ps(ctx, (uint32_t) i);
-
-            if (!log_diff(level, curr, prev, index, ctx))
-                return false;
-        }
-    }
-
-    return true;
-}
-
-/**
- * Log the difference of the two FlatVariables.
- */
-bool log_diff(LogLevel level, const FlatVariables &curr,
-              const FlatVariables &prev) {
-    // Skip expensive logging if set log level is not high enough.
-    if (level > jit_log_level_callback() && level > jit_log_level_stderr())
-        return true;
-
-    if (curr.flags != prev.flags) {
-        jit_log(level, "The flags of the input changed from %lx to %lx",
-                prev.flags, curr.flags);
-        return false;
-    }
-    if (curr.layout.size() != prev.layout.size()) {
-        jit_log(level,
-                "The number of elements in the input changed from %u to %u.",
-                (uint32_t) prev.layout.size(), (uint32_t) curr.layout.size());
-        return false;
-    }
-    if (curr.var_layout.size() != prev.var_layout.size()) {
-        jit_log(level,
-                "The number of opaque variables in the input changed from %u "
-                "to %u.",
-                (uint32_t) prev.var_layout.size(),
-                (uint32_t) curr.var_layout.size());
-        return false;
-    }
-
-    uint32_t index = 0;
-    TraverseContext ctx;
-    log_diff(level, curr, prev, index, ctx);
-
-    return true;
-}
-
-size_t FlatVariablesHasher::operator()(
-    const std::shared_ptr<FlatVariables> &key) const {
-    ProfilerPhase profiler("hash");
-    // Hash the layout
-
-    drjit::vector<uint64_t> &data = scratch;
-    data.clear();
-    data.reserve(2 + key->layout.size() * 4 + key->var_layout.size());
-
-    data.push_back(key->flags);
-    data.push_back((uint64_t) (key->layout.size() << 32) |
-                   (uint64_t) (key->var_layout.size() << 2));
-
-    for (const Layout &layout_ : key->layout) {
-        // If layout.fields is not 0 then layout.num == layout.fields.size()
-        // therefore we can omit layout.fields.size().
-        // This makes the assumption that we don't have more than 2^27-1
-        // elements in one layout or variables in the FlatVariables. If more
-        // elements are part of the layout, hash collisions might occur,
-        // impacting performance but not correctness.
-        if (layout_.num >> 26)
-            jit_log(LogLevel::Warn,
-                    "The layout consists of more than 100M elements, which "
-                    "might lead to hash collisions when looking up previous "
-                    "recordings of frozen functions.");
-        if (layout_.index >> 26 &&
-            !(layout_.flags & ((uint32_t) LayoutFlag::Undefined |
-                               (uint32_t) LayoutFlag::Literal))) {
-            jit_log(
-                LogLevel::Warn,
-                "The layout consists of more than 100M opaque variables, which "
-                "might lead to hash collisions when looking up previous "
-                "recordings of frozen functions.");
-        }
-        union {
-            struct {
-                uint64_t num : 26;
-                uint64_t index : 26;
-                uint64_t flags : 8;
-                uint64_t vt : 4;
-            };
-            uint64_t data;
-        } lkey;
-        static_assert(sizeof(lkey) == sizeof(uint64_t));
-        lkey.num   = layout_.num;
-        lkey.index = layout_.index;
-        lkey.flags = layout_.flags;
-        lkey.vt    = layout_.vt;
-
-        data.push_back(lkey.data);
-        if (layout_.flags & (uint32_t) LayoutFlag::JitIndex)
-            data.push_back(layout_.literal);
-
-        uint32_t type_hash = 0;
-        if (layout_.type)
-            type_hash = (uint32_t) nb::hash(layout_.type);
-
-        uint32_t object_hash = 0;
-        if (layout_.py_object) {
-            PyObject *ptr = layout_.py_object.ptr();
-            Py_hash_t rv  = PyObject_Hash(ptr);
-
-            // Try to hash the object, and otherwise fallback to ``id()``
-            if (rv == -1 && PyErr_Occurred()) {
-                PyErr_Clear();
-                object_hash = (uint32_t) (uintptr_t) ptr;
-            } else {
-                object_hash = (uint32_t) rv;
-            }
-        }
-        if (type_hash && object_hash)
-            data.push_back(((uint64_t) type_hash << 32) |
-                           ((uint64_t) (uint32_t) object_hash));
-        for (auto &field : layout_.fields)
-            data.push_back(nb::hash(field.ptr()));
-    }
-
-    for (const VarLayout &layout_ : key->var_layout) {
-        // layout_.vt: 4
-        // layout_.vs: 4
-        // layout_.flags: 8
-        data.push_back(((uint64_t) layout_.size_index << 32) |
-                       ((uint64_t) layout_.flags << 8) |
-                       ((uint64_t) layout_.vs << 4) | ((uint64_t) layout_.vt));
-    }
-
-    return (size_t) XXH3_64bits(data.data(), data.size() * sizeof(uint64_t));
-}
-
-/*
- * Record a function, given its python input and flattened input.
- */
-nb::object FunctionRecording::record(nb::callable func,
-                                     FrozenFunction *frozen_func,
-                                     nb::dict input,
-                                     const FlatVariables &in_variables,
-                                     bool after_dry_run) {
-    ProfilerPhase profiler("record");
-    JitBackend backend = in_variables.backend;
-
-    frozen_func->recording_counter++;
-    // The in-flight recording is counted but not cached yet; any further gap
-    // beyond LRU evictions means a recording was discarded.
-    uint32_t prev_recordings =
-        frozen_func->recording_counter - 1 - frozen_func->evicted_counter;
-    if (frozen_func->recording_counter > frozen_func->warn_recording_count &&
-        prev_recordings >= 1) {
-        if (after_dry_run) {
-            jit_log(LogLevel::Warn,
-                    "This frozen function was traced %u times. A recorded "
-                    "operation could not handle the sizes of the current "
-                    "arguments, so its recording was overwritten by a new "
-                    "trace. This happens for example when a block reduction "
-                    "receives an input whose size is not divisible by the "
-                    "block size.",
-                    frozen_func->recording_counter);
-        } else if (frozen_func->recordings.size() < prev_recordings) {
-            jit_log(LogLevel::Warn,
-                    "This frozen function was traced %u times, and %u of those "
-                    "traces had to be thrown away because the recorded code "
-                    "called ``jit_freeze_discard()``. Calls that reach such "
-                    "code can never be served from the cache and pay the full "
-                    "tracing cost every time.",
-                    frozen_func->recording_counter,
-                    prev_recordings -
-                        (uint32_t) frozen_func->recordings.size());
-        } else {
-            jit_log(
-                LogLevel::Warn,
-                "This frozen function was traced %u times. Tracing repeatedly "
-                "defeats the purpose of freezing it, and normally means that "
-                "its arguments keep changing in a way that no cached recording "
-                "covers, for instance a Python value such as an index. Call "
-                "``dr.set_log_level(dr.LogLevel.Info)`` to see how the "
-                "arguments differ from the previous call.",
-                frozen_func->recording_counter);
-        }
-        log_diff(LogLevel::Info, in_variables, *frozen_func->prev_key);
-    }
-
-    jit_log(LogLevel::Debug,
-            "Recording (n_inputs=%u):", in_variables.variables.size());
-    jit_freeze_start(backend, in_variables.variables.data(),
-                     (uint32_t) in_variables.variables.size());
-
-    // Record the function
     nb::object output;
     {
-        ProfilerPhase profiler2("function");
+        ProfilerPhase profiler2("dr.freeze(): executing function");
         state_unlock_guard guard;
-        output = func(input);
+        output = call_python(func,
+                             PyTuple_GetItem(root.ptr(), 0),
+                             PyTuple_GetItem(root.ptr(), 1));
     }
 
-    // Collect nodes, that have been postponed by the `Isolate` scope in a
-    // hash set.
-    // These are the targets of postponed edges, as the isolate gradient
-    // scope only handles backward mode differentiation.
-    // If they are, then we have to enqueue them when replaying the
-    // recording.
+    // Collect AD nodes postponed by the isolation scope.
     tsl::robin_set<uint32_t, UInt32Hasher> postponed;
     {
         drjit::vector<uint32_t> postponed_vec;
@@ -1740,441 +105,411 @@ nb::object FunctionRecording::record(nb::callable func,
             postponed.insert(index);
     }
 
+    // Describe the result and the input after the call
+    SlotBindings out_bindings;
     {
-        ProfilerPhase profiler2("traverse output");
         // Enter Resume scope, so we can track gradients
         ADScopeContext ad_scope(drjit::ADScope::Resume, 0, nullptr, -1, false);
-
-        {
-            TraverseContext ctx;
-            ctx.postponed          = &postponed;
-            ctx.deduplicate_pytree = false;
-            out_variables.traverse(output, ctx);
-            out_variables.schedule_jit_variables(false, nullptr);
-        }
-
-        {
-            TraverseContext ctx;
-            ctx.postponed = &postponed;
-            out_variables.traverse_with_registry(input, ctx);
-            out_variables.schedule_jit_variables(false, nullptr);
-        }
-
-        out_variables.layout_index = 0;
-
-        {
-            state_unlock_guard guard;
-            { // Evaluate the variables, scheduled when traversing
-                nb::gil_scoped_release guard2;
-                jit_eval();
-            }
-        }
-
-        out_variables.record_jit_variables();
+        out_layout = build_output_layout(output, root, layout->arg_names,
+                                         backend, postponed, out_bindings);
     }
+
+    drjit::vector<uint32_t> outputs =
+        plan_outputs(out_layout, out_bindings.indices.data(), *layout, inputs);
 
     jit_freeze_pause(backend);
 
-    if ((out_variables.variables.size() > 0 &&
-         in_variables.variables.size() > 0) &&
-        out_variables.backend != backend) {
-        Recording *recording_ = jit_freeze_stop(backend, nullptr, 0);
-        jit_freeze_destroy(recording_);
+    // Exceptions raised by the recorded functions are re-raised here
+    recording = jit_freeze_stop(backend, outputs.data(),
+                                (uint32_t) outputs.size());
+    abort_guard.armed = false;
 
-        nb::raise(
-            "freeze(): backend mismatch error (backend %u of "
-            "output variables did not match backend %u of input variables)",
-            (uint32_t) out_variables.backend, (uint32_t) backend);
-    }
-
-    // Exceptions, thrown by the recording functions will be recorded and
-    // re-thrown when calling ``jit_freeze_stop``. Since the output variables
-    // are borrowed, we have to release them in that case, and catch these
-    // exceptions.
-    try {
-        recording = jit_freeze_stop(backend, out_variables.variables.data(),
-                                    (uint32_t) out_variables.variables.size());
-    } catch (nb::python_error &e) {
-        out_variables.release();
-        nb::raise_from(e, PyExc_RuntimeError,
-                       "record(): error encountered while recording a function "
-                       "(see above).");
-    } catch (const std::exception &e) {
-        out_variables.release();
-        nb::chain_error(PyExc_RuntimeError, "record(): %s", e.what());
-        nb::raise_python_error();
-    }
-
-    jit_log(LogLevel::Debug, "Recording done (n_outputs=%u)",
-            out_variables.variables.size());
-
-    // For catching input assignment mismatches, we assign the input and
-    // output
+    // Construct the result and write the input back right away, so that
+    // errors surface when recording rather than when replaying
     {
-        state_lock_guard guard;
-        // Enter Resume scope, so we can track gradients
         ADScopeContext ad_scope(drjit::ADScope::Resume, 0, nullptr, -1, false);
-
-        out_variables.layout_index = 0;
-        jit_log(LogLevel::Debug, "Construct:");
-        try {
-            output = nb::borrow<nb::object>(out_variables.construct());
-        } catch (std::exception &) {
-            out_variables.release();
-            throw;
-        }
-        // NOTE: temporarily disable this to not enqueue twice
-        try {
-            TraverseContext ctx;
-            out_variables.assign(input, ctx);
-        } catch (std::exception &) {
-            out_variables.release();
-            throw;
-        }
-        out_variables.layout_index = 0;
+        output = construct_output(out_layout, outputs.data());
+        update_input(out_layout, root, outputs.data());
     }
-
-    // Traversal takes owning references, so here we need to release them.
-    out_variables.release();
 
     return output;
 }
-/*
- * Replays the recording.
- *
- * This constructs the output and re-assigns the input.
- */
-nb::object FunctionRecording::replay(nb::callable func,
-                                     FrozenFunction *frozen_func,
-                                     nb::dict input,
-                                     const FlatVariables &in_variables) {
-    ProfilerPhase profiler("replay");
 
-    jit_log(LogLevel::Info, "Replaying:");
-    int dryrun_success;
+bool FunctionRecording::dry_run(const uint32_t *inputs) {
+    return jit_freeze_dry_run(recording, inputs) != 0;
+}
+
+nb::object FunctionRecording::replay(nb::handle root, const uint32_t *inputs) {
+    drjit::detail::index32_vector out_values(out_layout.n_outputs);
     {
-        ProfilerPhase profiler2("dry run");
-        dryrun_success =
-            jit_freeze_dry_run(recording, in_variables.variables.data());
-    }
-    if (!dryrun_success) {
-        // Dry run has failed. Re-record the function.
-        jit_log(LogLevel::Info, "Dry run failed! re-recording");
-        this->clear();
-        try {
-            return this->record(func, frozen_func, input, in_variables, true);
-        } catch (nb::python_error &e) {
-            nb::raise_from(e, PyExc_RuntimeError,
-                           "replay(): error encountered while re-recording a "
-                           "function (see above).");
-        } catch (const std::exception &e) {
-            jit_freeze_abort(in_variables.backend);
-
-            nb::chain_error(PyExc_RuntimeError, "record(): %s", e.what());
-            nb::raise_python_error();
-        }
-    } else {
-        ProfilerPhase profiler2("jit replay");
         state_unlock_guard guard;
-        {
-            nb::gil_scoped_release guard2;
-            jit_freeze_replay(recording, in_variables.variables.data(),
-                              out_variables.variables.data());
-        }
+        nb::gil_scoped_release guard2;
+        jit_freeze_replay(recording, inputs, out_values.data());
     }
-    jit_log(LogLevel::Info, "Replaying done:");
 
-    // Construct Output variables
     nb::object output;
     {
-        state_lock_guard guard;
         // Enter Resume scope, so we can track gradients
         ADScopeContext ad_scope(drjit::ADScope::Resume, 0, nullptr, -1, false);
-        out_variables.layout_index = 0;
-        try {
-            ProfilerPhase profiler2("construct output");
-            output = nb::borrow<nb::object>(out_variables.construct());
-        } catch (std::exception &) {
-            out_variables.release();
-            throw;
-        }
-        try {
-            ProfilerPhase profiler2("assign input");
-            TraverseContext ctx;
-            out_variables.assign_with_registry(input, ctx);
-        } catch (std::exception &) {
-            out_variables.release();
-            throw;
-        }
+        output = construct_output(out_layout, out_values.data());
+        update_input(out_layout, root, out_values.data());
     }
-
-    // out_variables is assigned by ``jit_record_replay``, which transfers
-    // ownership to this array. Therefore, we have to drop the variables
-    // afterwards.
-    out_variables.release();
 
     return output;
 }
 
-nb::object FrozenFunction::operator()(nb::dict input) {
-    ProfilerPhase profiler("frozen function");
+nb::object FrozenFunction::operator()(nb::args args, nb::kwargs kwargs) {
+    if (!enabled)
+        return call_python(env.func, args, kwargs);
+
+    ProfilerPhase profiler("drjit.freeze()");
+
+    // Kernel freezing can be disabled with ``JitFlag::KernelFreezing``. Nested
+    // calls to frozen functions are ignored and baked into the current
+    // recording.
+    bool freeze = jit_flag(JitFlag::KernelFreezing) &&
+                  !jit_flag(JitFlag::FreezingScope) && max_cache_size != 0;
+
+    // Call the function without recording it
+    if (!freeze) {
+        ProfilerPhase profiler2("drjit.freeze(): executing function");
+        state_lock_guard guard;
+        ADScopeContext ad_scope(drjit::ADScope::Isolate, 0, nullptr, -1, true);
+        state_unlock_guard guard2;
+        return call_python(env.func, args, kwargs);
+    }
+
+    // The input of the call: its arguments, the values of the globals and
+    // closure variables that the function reads, and the optional state
+    nb::object state =
+        state_fn.is_none() ? nb::none() : call_python(state_fn, args, kwargs);
+    nb::tuple root = nb::make_tuple(args, kwargs, env.capture(), state);
+
     state_lock_guard guard;
     nb::object result;
     {
-        // Enter Isolate grad scope, so that gradients are not propagated
-        // outside of the function scope.
-        ADScopeContext ad_scope(drjit::ADScope::Isolate, 0, nullptr, -1, true);
-
-        // Kernel freezing can be enabled or disabled with the
-        // ``JitFlag::KernelFreezing``. Alternatively, when calling a frozen
-        // function from another one, we simply record the inner function.
-        if (!jit_flag(JitFlag::KernelFreezing) ||
-            jit_flag(JitFlag::FreezingScope) || max_cache_size == 0) {
-            ProfilerPhase profiler2("function");
-            state_unlock_guard guard2;
-            return func(input);
-        }
-
         call_counter++;
 
-        auto in_variables =
-            std::make_shared<FlatVariables>(FlatVariables(in_heuristics));
-        uint32_t flags        = jit_flags();
-        in_variables->flags   = flags;
-        in_variables->backend = this->default_backend;
-        // Evaluate and traverse input variables (args and kwargs)
-        // Repeat this a max of 2 times if the number of variables that should
-        // be made opaque changed.
-        for (uint32_t i = 0; i < 2; i++) {
-            // Enter Resume scope, so we can track gradients
+        // RAII helper to release references in the SlotBindings
+        struct release_bindings {
+            SlotBindings &b;
+            ~release_bindings() { b.release(); }
+        } guard2 { bindings };
+
+        // Fast path: verify the input against the recording used by the
+        // previous call and replay it with the resulting slot bindings. The
+        // Isolate scope keeps gradients from propagating outside of the
+        // function, and ``call_slow()`` opens its own one.
+        if (last_recording) {
+            ADScopeContext ad_scope(drjit::ADScope::Isolate, 0, nullptr, -1,
+                                    true);
             ADScopeContext ad_scope2(drjit::ADScope::Resume, 0, nullptr, 0,
                                      true);
+            FunctionRecording *rec = last_recording;
 
-            // Traverse input variables
-            ProfilerPhase profiler2("traverse input");
-
-            TraverseContext ctx;
-            // Preallocate based on the number of layout entries
-            ctx.visited.reserve(in_heuristics.layout);
-            in_variables->traverse_with_registry(input, ctx);
-
-            // If this is the first time the frozen function has been called or
-            // the layout is not compatible with the previous one, we clear the
-            // opaque_mask.
-            bool auto_opaque_ = false;
-            if (prev_key) {
-                auto_opaque_ = compatible_auto_opaque(*in_variables, *prev_key);
-                if (!auto_opaque_) {
-                    // The mask is reset if they are not compatible
-                    opaque_mask.resize(in_variables->layout.size());
-                    for (uint32_t i2 = 0; i2 < opaque_mask.size(); i2++)
-                        opaque_mask[i2] = false;
-                    jit_log(LogLevel::Debug, "auto-opaque incompatible");
-                }
-            } else
-                opaque_mask.resize(in_variables->layout.size(), false);
-
-            in_variables->schedule_jit_variables(!this->auto_opaque,
-                                                 &opaque_mask);
-
-            in_variables->layout_index = 0;
-
-            {
-                state_unlock_guard guard3;
-                { // Evaluate the variables, scheduled when traversing
-                    ProfilerPhase profiler3("eval");
-                    nb::gil_scoped_release guard2;
-                    jit_eval();
-                }
-            }
-
-            in_variables->record_jit_variables();
-            bool new_opaques = false;
-            if (prev_key && auto_opaque_)
-                new_opaques =
-                    in_variables->fill_opaque_mask(*prev_key, opaque_mask);
-
-            if (new_opaques) {
-                // If new variables have been discovered that should be made
-                // opaque, we repeat traversal of the input to make them opaque.
-                // This reduces the number of variants that are saved by one.
-                jit_log(LogLevel::Info,
-                        "While traversing the frozen function input, new "
-                        "literal variables have been discovered which changed "
-                        "from one call to another. These will be made opaque, "
-                        "and the input will be traversed again. This will "
-                        "incur some overhead. To prevent this, make those "
-                        "variables opaque in beforehand. Below, a list of "
-                        "variables that changed will be shown.");
-                if (prev_key)
-                    log_diff(LogLevel::Info, *in_variables, *prev_key);
-                in_variables->release();
-                in_variables = std::make_shared<FlatVariables>(
-                    FlatVariables(in_heuristics));
-                in_variables->flags = flags;
-            } else {
-                break;
+            if (verify_layout(*rec->layout, root, scratch, bindings) &&
+                rec->dry_run(bindings.indices.data())) {
+                rec->last_used = call_counter;
+                result = rec->replay(root, bindings.indices.data());
             }
         }
 
-        in_heuristics = in_heuristics.max(in_variables->heuristic());
-
-        raise_if(in_variables->backend == JitBackend::None,
-                 "freeze(): Cannot infer backend without providing input "
-                 "variable to frozen function!");
-
-        auto it = this->recordings.find(in_variables);
-
-        // Evict the least recently used recording if the cache is "full"
-        if (max_cache_size > 0 &&
-            recordings.size() >= (uint32_t) max_cache_size &&
-            it == this->recordings.end()) {
-
-            uint32_t lru_last_used        = UINT32_MAX;
-            RecordingMap::iterator lru_it = recordings.begin();
-
-            for (auto it2 = recordings.begin(); it2 != recordings.end(); it2++) {
-                auto &recording = it2.value();
-                if (recording->last_used < lru_last_used) {
-                    lru_last_used = recording->last_used;
-                    lru_it        = it2;
-                }
-            }
-            recordings.erase_fast(lru_it);
-            evicted_counter++;
-
-            it = this->recordings.find(in_variables);
-        }
-
-        if (it == this->recordings.end()) {
-            {
-                // TODO: single traverse
-                ADScopeContext ad_scope2(drjit::ADScope::Resume, 0, nullptr, 0,
-                                         true);
-                TraverseContext ctx;
-                in_variables->assign_with_registry(input, ctx);
-            }
-
-            // FunctionRecording recording;
-            auto recording       = std::make_unique<FunctionRecording>();
-            recording->last_used = call_counter - 1;
-
-            try {
-                result = recording->record(func, this, input, *in_variables);
-            } catch (nb::python_error &e) {
-                in_variables->release();
-                jit_freeze_abort(in_variables->backend);
-                nb::raise_from(
-                    e, PyExc_RuntimeError,
-                    "record(): error encountered while recording a frozen "
-                    "function (see above).");
-            } catch (const std::exception &e) {
-                in_variables->release();
-                jit_freeze_abort(in_variables->backend);
-
-                nb::chain_error(PyExc_RuntimeError, "record(): %s", e.what());
-                nb::raise_python_error();
-            };
-
-            in_variables->release();
-
-            this->prev_key = in_variables;
-            if (!jit_freeze_discarded(recording->recording))
-                this->recordings.insert(
-                    { std::move(in_variables), std::move(recording) });
-        } else {
-            FunctionRecording *recording = it.value().get();
-
-            recording->last_used = call_counter - 1;
-
-            try {
-                result = recording->replay(func, this, input, *in_variables);
-            } catch (std::exception &) {
-                in_variables->release();
-                throw;
-            }
-
-            // Drop references to variables
-            in_variables->release();
-        }
+        if (!result.is_valid())
+            result = call_slow(root);
     }
     ad_traverse(drjit::ADMode::Backward,
                 (uint32_t) drjit::ADFlag::ClearVertices);
     return result;
 }
 
-void FrozenFunction::clear() {
-    recordings.clear();
-    prev_key          = std::make_shared<FlatVariables>(FlatVariables());
-    recording_counter = 0;
-    call_counter      = 0;
-    evicted_counter   = 0;
-}
+std::shared_ptr<Layout> FrozenFunction::build_layout(nb::handle root) {
+    // Enter Resume scope to track gradients
+    ADScopeContext ad_scope(drjit::ADScope::Resume, 0, nullptr, 0, true);
 
-/**
- * This function inspects the content of the frozen function to detect reference
- * cycles, that could lead to memory or type leaks. It can be called by the
- * garbage collector by adding it to the ``type_slots`` of the
- * ``FrozenFunction`` definition.
- */
-int frozen_function_tp_traverse(PyObject *self, visitproc visit, void *arg) {
-    FrozenFunction *f = nb::inst_ptr<FrozenFunction>(self);
+    // The layout of the previous recording flags the literals made opaque by
+    // the auto-opaque feature so far, and the builder compares literals
+    // against it to detect changing ones
+    const Layout *prev = auto_opaque ? prev_layout.get() : nullptr;
+    std::shared_ptr<Layout> layout =
+        build_input_layout(root, env.arg_names, default_backend, prev,
+                           !auto_opaque, bindings);
 
-    nb::handle func = nb::find(f->func);
-    Py_VISIT(func.ptr());
-
-    for (auto &it : f->recordings) {
-        for (auto &layout : it.first->layout) {
-            nb::handle type = nb::find(layout.type);
-            Py_VISIT(type.ptr());
-            nb::handle object = nb::find(layout.py_object);
-            Py_VISIT(object.ptr());
-        }
-        for (auto &layout : it.second->out_variables.layout) {
-            nb::handle type = nb::find(layout.type);
-            Py_VISIT(type.ptr());
-            nb::handle object = nb::find(layout.py_object);
-            Py_VISIT(object.ptr());
-        }
+    // A previous layout with a different structure may have forced literals
+    // at unrelated positions, in which case the layout is built again
+    // without it
+    if (prev && layout->nodes.size() != prev->nodes.size()) {
+        bool forced = false;
+        for (const Node &n : layout->nodes)
+            forced |= n.has(NodeFlag::ForceOpaque);
+        if (forced)
+            layout = build_input_layout(root, env.arg_names, default_backend,
+                                        nullptr, false, bindings);
     }
 
-    return 0;
+    raise_if(layout->backend == JitBackend::None,
+             "drjit.freeze(): Cannot infer backend without providing input "
+             "variable to frozen function!");
+
+    return layout;
 }
 
-/**
- * This function releases the internal function of the ``FrozenFunction``
- * object. It is used by the garbage collector to "break" potential reference
- * cycles, resulting from the frozen function being referenced in the closure of
- * the wrapped variable.
- */
-int frozen_function_clear(PyObject *self) {
+void FrozenFunction::warn_recordings(const Layout &layout, bool retried,
+                                     bool evicted) {
+    if (recording_counter <= warn_recording_count || recording_counter < 2)
+        return;
+
+    if (retried) {
+        jit_log(LogLevel::Warn,
+                "This frozen function was traced %u times. A recorded "
+                "operation could not handle the sizes of the current "
+                "arguments, so its recording was overwritten by a new "
+                "trace. This happens for example when a block reduction "
+                "receives an input whose size is not divisible by the "
+                "block size.",
+                recording_counter);
+        return;
+    }
+
+    // Name the input that differs from the one of the previous recording
+    std::string reason;
+    if (prev_layout)
+        reason = layout_diff(layout, *prev_layout);
+    if (reason.empty())
+        reason = "unknown";
+
+    // A full cache had to evict a recording to make room for this one, so
+    // that the two keep replacing each other
+    if (evicted)
+        jit_log(LogLevel::Warn,
+                "This frozen function was traced %u times, while its cache "
+                "holds at most %i recording(s) (``limit=%i`` was passed to "
+                "@dr.freeze). Recordings are therefore evicted and traced "
+                "again. Repeated tracing defeats the purpose of function "
+                "freezing and is caused by structural changes of the "
+                "function's inputs. The change that triggered this recording "
+                "was: %s.",
+                recording_counter, max_cache_size, max_cache_size,
+                reason.c_str());
+    else
+        jit_log(LogLevel::Warn,
+                "This frozen function was traced %u times. Repeated tracing "
+                "defeats the purpose of function freezing and is caused by "
+                "structural changes of the function's inputs. The change that "
+                "triggered this recording was: %s.",
+                recording_counter, reason.c_str());
+}
+
+nb::object FrozenFunction::call_slow(nb::handle root) {
+    // Detect structural changes in the input and potentially
+    // try recording once more
+    for (bool retried = false;; retried = true) {
+        ADScopeContext ad_scope(drjit::ADScope::Isolate, 0, nullptr, -1, true);
+
+        std::shared_ptr<Layout> layout = build_layout(root);
+        const uint32_t *inputs = bindings.indices.data();
+
+        // Drops the cache entry at position ``i``
+        auto erase = [&](size_t i) {
+            if (recordings[i].get() == last_recording)
+                last_recording = nullptr;
+            recordings[i] = std::move(recordings.back());
+            recordings.pop_back();
+        };
+
+        // Replay the cached recording if its dry run succeeds. Otherwise,
+        // drop the cache entry and record once more.
+        bool retry = false;
+        for (size_t i = 0; i < recordings.size(); ++i) {
+            FunctionRecording *rec = recordings[i].get();
+            if (!layout_equal(*rec->layout, *layout))
+                continue;
+            if (rec->dry_run(inputs)) {
+                rec->last_used = call_counter;
+                last_recording = rec;
+                return rec->replay(root, inputs);
+            }
+            jit_log(LogLevel::Info, "drjit.freeze(): dry run failed, re-recording.");
+            erase(i);
+            retry = true;
+            break;
+        }
+
+        // Evict the least recently used recording if the cache is "full"
+        bool evicted =
+            max_cache_size > 0 && recordings.size() >= (uint32_t) max_cache_size;
+        if (evicted) {
+            size_t lru = 0;
+            for (size_t i = 1; i < recordings.size(); ++i)
+                if (recordings[i]->last_used < recordings[lru]->last_used)
+                    lru = i;
+            erase(lru);
+        }
+
+        auto rec = std::make_unique<FunctionRecording>();
+        rec->last_used = call_counter;
+        rec->layout    = layout;
+
+        recording_counter++;
+        warn_recordings(*layout, retry, evicted);
+
+        nb::object result;
+        try {
+            result = rec->record(env.func, root, inputs);
+        } catch (const InputChanged &e) {
+            if (retried)
+                nb::raise("drjit.freeze(): %s, and did so again when it was "
+                          "recorded a second time. A frozen function may assign "
+                          "new arrays to its input, but it must not change the "
+                          "structure of the input or the Python values it holds, "
+                          "since a replay cannot reproduce such a change.",
+                          e.what());
+            jit_log(LogLevel::Info, "drjit.freeze(): %s, re-recording.", e.what());
+
+            // Restore gradient state
+            bindings.restore_grads();
+            ad_scope.process_postponed = false;
+            continue;
+        } catch (nb::python_error &e) {
+            nb::raise_from(e, PyExc_RuntimeError,
+                           "drjit.freeze(): error encountered while recording a frozen "
+                           "function (see above).");
+        } catch (const std::exception &e) {
+            nb::chain_error(PyExc_RuntimeError,
+                            "drjit.freeze(): error encountered while recording a frozen "
+                            "function: %s", e.what());
+            nb::raise_python_error();
+        }
+
+        prev_layout = layout;
+        last_recording = rec.get();
+        recordings.push_back(std::move(rec));
+
+        return result;
+    }
+}
+
+void FrozenFunction::clear() {
+    last_recording = nullptr;
+    bindings.release();
+    recordings.clear();
+    prev_layout.reset();
+    recording_counter = 0;
+    call_counter      = 0;
+}
+
+/// Offset of the instance dictionary (``nb::dynamic_attr()``)
+static Py_ssize_t dict_offset = 0;
+
+static PyObject **inst_dict_ptr(PyObject *self) {
+    return (PyObject **) ((char *) self + dict_offset);
+}
+
+/// Enable Python's GC to collect reference cycles involving frozen functions
+int frozen_function_tp_traverse(PyObject *self, visitproc visit,
+                                void *arg) noexcept {
+    Py_VISIT(Py_TYPE(self));
+    Py_VISIT(*inst_dict_ptr(self));
+
+    // The C++ constructor may not have run yet
+    if (!nb::inst_ready(self))
+        return 0;
+
     FrozenFunction *f = nb::inst_ptr<FrozenFunction>(self);
 
-    f->func.release();
+    int rv = f->env.tp_traverse(visit, arg);
+    if (rv)
+        return rv;
+    Py_VISIT(f->state_fn.ptr());
+
+    for (auto &rec : f->recordings) {
+        rv = rec->layout->tp_traverse(visit, arg);
+        if (rv)
+            return rv;
+        rv = rec->out_layout.tp_traverse(visit, arg);
+        if (rv)
+            return rv;
+    }
+
+    if (f->prev_layout.use_count() == 1)
+        return f->prev_layout->tp_traverse(visit, arg);
 
     return 0;
 }
 
-// Slot data structure referencing the above two functions
-static PyType_Slot slots[] = { { Py_tp_traverse,
-                                 (void *) frozen_function_tp_traverse },
-                               { Py_tp_clear, (void *) frozen_function_clear },
-                               { 0, nullptr } };
+/// Enable Python's GC to clear reference cycles involving frozen functions
+int frozen_function_tp_clear(PyObject *self) noexcept {
+    Py_CLEAR(*inst_dict_ptr(self));
 
-void export_freeze(nb::module_ & /*m*/) {
+    if (!nb::inst_ready(self))
+        return 0;
 
-    nb::module_ d = nb::module_::import_("drjit.detail");
-    nb::class_<FrozenFunction>(d, "FrozenFunction", nb::type_slots(slots))
-        .def(nb::init<nb::callable, int, uint32_t, JitBackend, bool>())
-        .def_prop_ro(
-            "n_cached_recordings",
-            [](FrozenFunction &self) { return self.n_cached_recordings(); })
-        .def_ro("n_recordings", &FrozenFunction::recording_counter)
-        .def("clear", &FrozenFunction::clear)
-        .def("__call__", &FrozenFunction::operator())
-        .freeze();
+    FrozenFunction *f = nb::inst_ptr<FrozenFunction>(self);
+    f->clear();
+    f->env.tp_clear();
+    f->state_fn.reset();
+    return 0;
 }
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+/// ``tp_descr_get`` slot. When ``@dr.freeze`` decorates a method, accessing
+/// the frozen function through an instance must produce a bound method, just
+/// as accessing a plain function would. This reimplements the ``__get__``
+/// behavior of Python functions using ``types.MethodType``.
+PyObject *frozen_function_descr_get(PyObject *self, PyObject *obj,
+                                    PyObject *) noexcept {
+    if (!obj || obj == Py_None)
+        return Py_NewRef(self);
+    return PyObject_CallFunctionObjArgs(
+        lazy_import(LazyImport::TypesMethodType).ptr(), self, obj, nullptr);
+}
+
+PyObject *frozen_function_tp_call(PyObject *self, PyObject *args,
+                                  PyObject *kwargs) noexcept {
+    FrozenFunction *f = nb::inst_ptr<FrozenFunction>(self);
+    try {
+        // Python passes no dictionary when the call site has no keyword
+        // arguments, while both the layout and ``PyObject_Call()`` want one
+        nb::kwargs kwargs_o = kwargs ? nb::borrow<nb::kwargs>(kwargs)
+                                     : nb::kwargs();
+        return (*f)(nb::borrow<nb::args>(args), std::move(kwargs_o))
+            .release().ptr();
+    } catch (nb::python_error &e) {
+        e.restore();
+    } catch (const std::exception &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "FrozenFunction.__call__(): uncaught exception!");
+    }
+    return nullptr;
+}
+
+// Python type slots for frozen functions
+static PyType_Slot slots[] = {
+    { Py_tp_traverse, (void *) frozen_function_tp_traverse },
+    { Py_tp_clear, (void *) frozen_function_tp_clear },
+    { Py_tp_descr_get, (void *) frozen_function_descr_get },
+    { Py_tp_call, (void *) frozen_function_tp_call },
+    { 0, nullptr }
+};
+
+void export_freeze(nb::module_ &m) {
+    // The instance dictionary lets ``functools.wraps()`` copy the metadata
+    // of the decorated function (``__name__``, ``__doc__``, ``__wrapped__``, ..)
+    nb::class_<FrozenFunction> cls(m, "FrozenFunction", nb::type_slots(slots),
+                                   nb::dynamic_attr(),
+                                   nb::is_weak_referenceable(),
+                                   doc_FrozenFunction);
+    cls.def(nb::init<nb::callable, nb::object, int, uint32_t, JitBackend, bool,
+                     bool>(),
+            "func"_a, "state_fn"_a.none(), "limit"_a, "warn_after"_a,
+            "backend"_a, "auto_opaque"_a, "enabled"_a)
+       .def_prop_ro(
+           "n_cached_recordings",
+           [](FrozenFunction &self) { return self.recordings.size(); })
+       .def_ro("n_recordings", &FrozenFunction::recording_counter)
+       .def_rw("enabled", &FrozenFunction::enabled)
+       .def("clear", &FrozenFunction::clear)
+       .freeze();
+
+    dict_offset = nb::cast<Py_ssize_t>(cls.attr("__dictoffset__"));
+}

--- a/src/python/freeze.h
+++ b/src/python/freeze.h
@@ -11,626 +11,77 @@
 #pragma once
 
 #include "common.h"
-#include <drjit-core/hash.h>
+#include "freeze_layout.h"
+#include "funcenv.h"
 #include <drjit-core/jit.h>
 #include <drjit/autodiff.h>
-#include <string>
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable: 4324) // structure was padded due to alignment specifier
-#endif
-#include <tsl/robin_map.h>
-#include <tsl/robin_set.h>
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
-#include <drjit/fwd.h>
+#include <memory>
 
-#include "../ext/nanobind/src/buffer.h"
-
-struct FrozenFunction;
-
-namespace detail {
-
-using Buffer = nanobind::detail::Buffer;
-
-using index64_vector = drjit::detail::index64_vector;
-using index32_vector = drjit::detail::index32_vector;
-
-// This enum defines flags used in the input layout nodes, representing the
-// PyTree.
-enum class LayoutFlag : uint32_t {
-    /// Whether this variable has size 1
-    SingletonArray = (1 << 0),
-    /// Whether this variable is unaligned in memory
-    Unaligned = (1 << 1),
-    /// Whether this layout represents a literal variable
-    Literal = (1 << 2),
-    /// Whether this layout represents an undefined variable (they behave
-    /// similarly to literals)
-    Undefined = (1 << 3),
-    /// Whether this variable has gradients enabled
-    GradEnabled = (1 << 4),
-    /// Did this variable have gradient edges attached when recording, that
-    /// were postponed by the ``isolate_grad`` function?
-    Postponed = (1 << 5),
-    /// Does this node represent a JIT Index?
-    JitIndex = (1 << 6),
-    /// This layout node is a recursive reference to another node.
-    RecursiveRef = (1 << 7),
-};
-
-/// Stores information about python objects, such as their type, their number of
-/// sub-elements or their field keys. This can be used to reconstruct a PyTree
-/// from a flattened variable array.
-struct Layout {
-
-    /// The literal data
-    uint64_t literal = 0;
-
-    /// Optional field identifiers of the container
-    /// for example: keys in dictionary
-    drjit::vector<nb::object> fields;
-
-    /// Number of members in this container.
-    /// Can be used to traverse the layout without knowing the type.
-    uint32_t num = 0;
-
-    /// Either store the index if this is an opaque variable or the size of
-    /// the variable if this is a Literal or Undefined variable. This will be
-    /// hashed as part of the key.
-    union {
-        /// The index in the flat_variables array of this variable.
-        /// This can be used to determine aliasing.
-        uint32_t index = 0;
-        /// If this node is representing a literal or undefined variable, the
-        /// size is stored here instead.
-        uint32_t literal_size;
-    };
-
-    /// Flags, storing information about variables and literals.
-    uint32_t flags : 8; // LayoutFlag
-
-    /// Optional drjit type of the variable
-    uint32_t vt : 4; // VarType
-
-    /// Variable index of literal. Instead of constructing a literal every time,
-    /// we keep a reference to it.
-    uint32_t literal_index = 0;
-
-    /// If a non drjit type is passed as function arguments or result, we simply
-    /// cache it here.
-    nb::object py_object;
-
-    /// Nanobind type of the container/variable
-    nb::type_object type;
-
-    bool operator==(const Layout &rhs) const;
-    bool operator!=(const Layout &rhs) const { return !(*this == rhs); }
-
-    Layout()
-        : literal(0), fields(), num(0), index(0), flags(0), vt(0),
-          literal_index(0), py_object(), type() {};
-
-    Layout(const Layout &)            = delete;
-    Layout &operator=(const Layout &) = delete;
-
-    Layout(Layout &&)            = default;
-    Layout &operator=(Layout &&) = default;
-};
-
-/**
- * \brief Stores information about opaque variables.
- *
- * When traversing a PyTree, literal variables are stored directly and
- * non-literal variables are first scheduled and their indices deduplicated and
- * added to the ``FlatVariables::variables`` field. After calling ``jit_eval``,
- * information about variables can be recorded using
- * ``FlatVariables::record_jit_variables``. This struct stores that information
- * per deduplicated variable.
- */
-struct VarLayout {
-    /// Optional drjit type of the variable
-    VarType vt = VarType::Void;
-
-    /// Optional evaluation state of the variable
-    VarState vs = VarState::Invalid;
-
-    /// Flags, storing information about variables (see `LayoutFlag` enum above)
-    uint32_t flags = 0;
-
-    /// We have to track the condition, where two variables have the same size
-    /// during recording but don't when replaying, however we do not want to
-    /// bake the size into the recording key.Therefore we construct equivalence
-    /// classes of sizes using a hashmap. When a variable with a new size is
-    /// traversed, this size is added to the `size_to_slot` map in
-    /// `FlatVariables`, and a unique index representing this size is assigned
-    /// to this field.
-    uint32_t size_index = 0;
-
-    VarLayout() = default;
-
-    VarLayout(const VarLayout &)            = delete;
-    VarLayout &operator=(const VarLayout &) = delete;
-
-    VarLayout(VarLayout &&)            = default;
-    VarLayout &operator=(VarLayout &&) = default;
-
-    bool operator==(const VarLayout &rhs) const;
-    bool operator!=(const VarLayout &rhs) const { return !(*this == rhs); }
-};
-
-// Additional context required when traversing the inputs
-struct TraverseContext {
-    /// Set of postponed AD nodes, used to mark inputs to functions.
-    const tsl::robin_set<uint32_t, UInt32Hasher> *postponed = nullptr;
-    tsl::robin_map<const void *, nb::object, PointerHasher> visited;
-    index32_vector free_list;
-    /// If this flag is set to ``true``, the PyTree will not be deduplicated
-    /// during traversal. Refcycles will still be prevented, but some objects
-    /// might be traversed multiple times.
-    bool deduplicate_pytree = true;
-    uint32_t recursion_level = 0;
-    /// C++ objects visited so far. Shared objects are visited once, which
-    /// also terminates reference cycles.
-    tsl::robin_set<const drjit::TraversableBase *, PointerHasher> visited_cpp;
-    Buffer path;
-
-    TraverseContext() : path(1024) {}
-};
-
-/**
- * \brief A flattened representation of the PyTree.
- *
- * This struct stores a flattened representation of a PyTree as well a
- * representation of it. It can therefore be used to either construct the PyTree
- * as well as assign the variables to an existing PyTree. Furthermore, this
- * struct can also be used as a key to the ``RecordingMap``, determining which
- * recording should be used given an input to a frozen function.
- * Information about the PyTree is stored in DFS Encoding. Every node of the
- * tree is represented by a ``Layout`` element in the ``layout`` vector.
- */
-struct FlatVariables {
-    // Stores the JIT flags (see `jit_flags`), set when traversing the inputs.
-    uint32_t flags = 0;
-
-    /// The flattened and de-duplicated variable indices of the input/output to
-    /// a frozen function
-    drjit::vector<uint32_t> variables;
-
-    /// Mapping from drjit jit index to index in flat variables. Used to
-    /// deduplicate jit indices.
-    tsl::robin_map<uint32_t, uint32_t, UInt32Hasher> index_to_slot;
-
-    /// We have to track the condition, where two variables have the same size
-    /// during recording but don't when replaying.
-    /// Therefore we construct equivalence classes of sizes.
-    /// This vector represents the different sizes, encountered during
-    /// traversal. The algorithm used to "add" a size is the same as for adding
-    /// a variable index.
-    drjit::vector<uint32_t> sizes;
-
-    /// Mapping from the size to its index in the ``sizes`` vector. This is used
-    /// to construct size equivalence classes (i.e. deduplicating sizes).
-    tsl::robin_map<uint32_t, uint32_t, UInt32Hasher> size_to_slot;
-
-    /// This saves information about the type, size and fields of pytree
-    /// objects. The information is stored in DFS order.
-    drjit::vector<Layout> layout;
-
-    /// Stores information about non-literal jit variables.
-    drjit::vector<VarLayout> var_layout;
-
-    /// The collective backend for all input variables. It can be used to ensure
-    /// that all variables have the same backend.
-    JitBackend backend = JitBackend::None;
-
-    /// The variant, if any, used to traverse the registry.
-    std::string variant;
-
-    /// All domains (deduplicated), encountered while traversing the PyTree and
-    /// its C++ objects. This can be used to traverse the registry. We use a
-    /// vector instead of a hash set, since we expect the number of domains not
-    /// to exceed 100.
-    drjit::vector<std::string> domains;
-
-    // Index, used to iterate over the variables/layouts when constructing
-    // python objects
-    uint32_t layout_index = 0;
-
-    uint32_t recursion_level = 0;
-
-    /// Caches whether Debug-level log messages are enabled
-    bool m_log_enabled = false;
-
-    struct recursion_guard {
-        FlatVariables *flat_variables;
-        recursion_guard(FlatVariables *flat_variables)
-            : flat_variables(flat_variables) {
-            if (flat_variables->recursion_level >= 50) {
-                PyErr_SetString(PyExc_RecursionError,
-                                "runaway recursion detected");
-                nb::raise_python_error();
-            }
-            // NOTE: the recursion_level has to be incremented after potentially
-            // throwing an exception, as throwing an exception in the
-            // constructor prevents the destructor from being called.
-            flat_variables->recursion_level++;
-        }
-        ~recursion_guard() { flat_variables->recursion_level--; }
-    };
-
-    /**
-     * Describes how many elements have to be pre-allocated for the ``layout``,
-     * ``index_to_slot`` and ``size_to_slot`` containers.
-     */
-    struct Heuristic {
-        size_t layout        = 0;
-        size_t index_to_slot = 0;
-        size_t size_to_slot  = 0;
-
-        Heuristic max(Heuristic rhs) {
-            return Heuristic{
-                std::max(layout, rhs.layout),
-                std::max(index_to_slot, rhs.index_to_slot),
-                std::max(size_to_slot, rhs.size_to_slot),
-            };
-        }
-    };
-
-    FlatVariables() {}
-    FlatVariables(Heuristic heuristic) {
-        layout.reserve(heuristic.layout);
-        index_to_slot.reserve(heuristic.index_to_slot);
-        size_to_slot.reserve(heuristic.size_to_slot);
-    }
-
-    FlatVariables(const FlatVariables &)            = delete;
-    FlatVariables &operator=(const FlatVariables &) = delete;
-
-    FlatVariables(FlatVariables &&)            = default;
-    FlatVariables &operator=(FlatVariables &&) = default;
-
-    ~FlatVariables();
-
-    void clear() {
-        layout_index = 0;
-        variables.clear();
-        index_to_slot.clear();
-        layout.clear();
-        backend = JitBackend::None;
-    }
-    /// Borrow all variables held by this struct.
-    void borrow();
-    /// Release all variables held by this struct.
-    void release();
-
-    /**
-     * Generates a mask of variables that should be made opaque in the next
-     * iteration. This should only be called if \c compatible_auto_opaque
-     * returns true for the corresponding \c FlatVariables pair.
-     *
-     * Returns true if new variables have been discovered that should be made
-     * opaque, otherwise returns false.
-     */
-    bool fill_opaque_mask(FlatVariables &prev,
-                          drjit::vector<bool> &opaque_mask);
-
-    /**
-     * Schedule variables that have been collected when traversing the PyTree.
-     *
-     * This function iterates over all ``Layout`` nodes that represent JIT
-     * indices and either calls ``jit_var_schedule`` or
-     * ``jit_var_schedule_force`` on them, depending on whether
-     * ``schedule_force`` is true or the boolean in the ``opaque_mask``
-     * corresponding to that variable is true.
-     *
-     * \param schedule_force
-     *     Overrides the use of \c opaque_mask and makes all variables opaque
-     *
-     * \param opaque_mask
-     *     A pointer to a compatible boolean array, indicating if some of the
-     *     variables should be made opaque. Can be \c nullptr, in which case it
-     *     will be ignored.
-     */
-    void schedule_jit_variables(bool schedule_force,
-                                const drjit::vector<bool> *opaque_mask);
-
-    /**
-     * \brief Records information about JIT variables that have been traversed.
-     *
-     * After traversing the PyTree, collecting non-literal indices in
-     * ``variables`` and evaluating the collected indices, we can collect
-     * information about the underlying variables. This information is used in
-     * the key of the ``RecordingMap`` to determine which recording should be
-     * replayed or if the function has to be re-traced. This function iterates
-     * over the collected indices and collects that information.
-     */
-    void record_jit_variables();
-
-    /**
-     * Returns a struct representing heuristics to pre-allocate memory for the
-     * layout, of the flat variables. This accelerates subsequent traversals and
-     * replays.
-     */
-    Heuristic heuristic() {
-        return Heuristic{
-            layout.size(),
-            index_to_slot.size(),
-            size_to_slot.size(),
-        };
-    };
-
-    /**
-     * \brief Add a variant domain pair to be traversed using the registry.
-     *
-     * When traversing a jit variable that references a pointer to a class, we
-     * have to traverse all objects registered with that variant-domain pair in
-     * the registry. This function adds the variant-domain pair, deduplicating
-     * the domain. Whether a variable references a class is represented by its
-     * ``IsClass`` const
-     * attribute. If the domain is an empty string (""), this function skips
-     * adding the variant-domain pair.
-     */
-    void add_domain(const char *variant, const char *domain);
-
-    /**
-     * Adds a JIT index to the flattened array, deduplicating it.
-     * This allows to check for aliasing conditions, where two variables
-     * actually refer to the same index. The function should only be called for
-     * scheduled non-literal variable indices.
-     */
-    uint32_t add_jit_index(uint32_t variable_index);
-
-    /**
-     * This function returns an index into the ``sizes`` vector, representing an
-     * equivalence class of variable sizes. It uses a HashMap and vector to
-     * deduplicate sizes.
-     *
-     * This is necessary, to catch cases, where two variables had the same size
-     * when recording a function and two different sizes when replaying.
-     * In that case one kernel would be recorded, that evaluates both variables.
-     * However, when replaying two kernels would have to be launched since the
-     * now differently sized variables cannot be evaluated by the same kernel.
-     */
-    uint32_t add_size(uint32_t size);
-
-    /**
-     * Traverse a variable referenced by a JIT index and add it to the flat
-     * variables. An optional Python type can be supplied if it is known.
-     * Depending on the ``TraverseContext::schedule_force`` the underlying
-     * variable is either scheduled (``jit_var_schedule``) or force scheduled
-     * (``jit_var_schedule_force``). If the variable after evaluation is a
-     * literal, it is directly recorded in the ``layout``, otherwise it is added
-     * to the ``variables`` array, allowing the variables to be used when
-     * recording the frozen function.
-     */
-    void traverse_jit_index(uint32_t index, TraverseContext &ctx,
-                            nb::handle tp = {});
-    /**
-     * Add an AD variable by its index. Both the value and gradient are added
-     * to the flattened variables. If the AD index has been marked as postponed
-     * in the \c TraverseContext.postponed field, we mark the resulting layout
-     * with that flag. This will cause the gradient edges to be propagated when
-     * assigning to the input. The function takes an optional Python type if
-     * it is known.
-     */
-    void traverse_ad_index(uint64_t index, TraverseContext &ctx,
-                           nb::handle tp = {});
-
-    /**
-     * Wrapper around traverse_ad_index for a Python handle.
-     */
-    void traverse_ad_var(nb::handle h, TraverseContext &ctx);
-
-    /**
-     * Traverse a C++ tree using its `traverse_1_cb_ro` callback.
-     */
-    void traverse_cb(const drjit::TraversableBase *traversable,
-                     TraverseContext &ctx, nb::object type = nb::none());
-
-    /**
-     * Traverses a PyTree in DFS order, and records its layout in the
-     * `layout` vector.
-     *
-     * When hitting a drjit primitive type, it calls the
-     * `traverse_dr_var` method, which will add their indices to the
-     * `flat_variables` vector. The collect method will also record metadata
-     * about the drjit variable in the layout. Therefore, the layout can be used
-     * as an identifier to the recording of the frozen function.
-     */
-    void traverse(nb::handle h, TraverseContext &ctx);
-
-    /**
-     * First traverses the PyTree, then the registry. This ensures that
-     * additional data to vcalls is tracked correctly.
-     */
-    void traverse_with_registry(nb::handle h, TraverseContext &ctx);
-
-    /**
-     * Construct a variable, given its layout.
-     * This is the counterpart to `traverse_jit_index`.
-     *
-     * Optionally, the index of a variable can be provided that will be
-     * overwritten with the result of this function. In that case, the function
-     * will check for compatible variable types.
-     */
-    uint32_t construct_jit_index(uint32_t prev_index = 0);
-
-    /**
-     * Construct/assign the variable index given a layout.
-     * This corresponds to `traverse_ad_index`.
-     *
-     * This function is also used for assignment to AD variables.
-     * If a `prev_index` is provided, and it is an AD variable the gradient and
-     * value of the flat variables will be applied to the ad variable,
-     * preserving the `ad_index`.
-     *
-     * It returns an owning reference.
-     */
-    uint64_t construct_ad_index(uint64_t prev_index = 0);
-
-    /**
-     * Construct an ad variable given its layout.
-     * This corresponds to `traverse_ad_var`
-     */
-    nb::object construct_ad_var(const Layout &layout);
-
-    /**
-     * This is the counterpart to the traverse method, used to construct the
-     * output of a frozen function. Given a layout vector and flat_variables, it
-     * re-constructs the PyTree.
-     */
-    nb::object construct();
-
-    /**
-     * Assigns an ad variable.
-     * Corresponds to `traverse_ad_var`.
-     * This uses `construct_ad_index` to either construct a new ad variable or
-     * assign the value and gradient to an already existing one.
-     */
-    void assign_ad_var(Layout &layout, nb::handle dst);
-
-    /**
-     * Helper function, used to assign a callback variable.
-     *
-     * \param tmp
-     *     This vector is populated with the indices to variables that have been
-     *     constructed. It is required to release the references, since the
-     *     references created by `construct_ad_index` are owning and they are
-     *     borrowed after the callback returns.
-     */
-    uint64_t assign_cb_internal(uint64_t index, index64_vector &tmp);
-
-    /**
-     * Assigns variables using its `traverse_cb_rw` callback.
-     * This corresponds to `traverse_cb`.
-     */
-    void assign_cb(drjit::TraversableBase *traversable, TraverseContext &ctx);
-
-    /**
-     * Assigns the flattened variables to an already existing PyTree.
-     * This is used when input variables have changed.
-     */
-    void assign(nb::handle dst, TraverseContext &ctx);
-
-    /**
-     * First assigns the registry and then the PyTree.
-     * Corresponds to `traverse_with_registry`.
-     */
-    void assign_with_registry(nb::handle dst, TraverseContext &ctx);
-
-    bool operator==(const FlatVariables &rhs) const {
-        return this->layout == rhs.layout &&
-               this->var_layout == rhs.var_layout && this->flags == rhs.flags;
-    }
-};
-
-/// Helper struct to hash input variables
-struct FlatVariablesHasher {
-    size_t operator()(const std::shared_ptr<FlatVariables> &key) const;
-
-    /// Scratch space for the layout description hash input
-    mutable drjit::vector<uint64_t> scratch;
-};
-
-/// Helper struct to compare input variables
-struct FlatVariablesEqual {
-    using is_transparent = void;
-    bool operator()(const std::shared_ptr<FlatVariables> &lhs,
-                    const std::shared_ptr<FlatVariables> &rhs) const {
-        return *lhs.get() == *rhs.get();
-    }
-};
-
-/**
- * \brief A recording of a frozen function, recorded with a certain layout of
- * input variables.
- */
+/// A recording of a frozen function, made with a certain input layout
 struct FunctionRecording {
-    /// The index of the \c call_counter when this recording was last used
-    /// (recorded or replayed). If the \c max_cache_size variable is set, this
-    /// will be used to evict the least recently used recording.
-    uint32_t last_used   = 0;
+    /// Value of ``FrozenFunction::call_counter`` when this recording was
+    /// last recorded or replayed (used to evict the least recently used one)
+    uint32_t last_used = 0;
 
-    /// The opaque JIT recording, that has been recorded with \c
-    /// jit_freeze_start and \c jit_freeze_stop, and is held by this wrapper.
+    /// The backend recording, held by this wrapper
     Recording *recording = nullptr;
 
-    /// The layout of the output variables of this version of the function
-    /// recording. The JIT variables of this object have to be released after
-    /// use in \c record and \c replay.
-    FlatVariables out_variables;
+    /// Description of the input with which this recording was made. It
+    /// serves as the cache key. The reference is shared with
+    /// ``FrozenFunction::prev_layout``, which can outlive the recording when
+    /// it is dropped or evicted from the cache.
+    std::shared_ptr<Layout> layout;
 
-    FunctionRecording() : out_variables() {}
-    FunctionRecording(const FunctionRecording &)            = delete;
+    /// Description of the function result and of the input after the call,
+    /// from which the result is constructed and modified inputs are written
+    /// back.
+    Layout out_layout;
+
+    FunctionRecording() = default;
+    FunctionRecording(const FunctionRecording &) = delete;
     FunctionRecording &operator=(const FunctionRecording &) = delete;
-    FunctionRecording(FunctionRecording &&)                 = default;
-    FunctionRecording &operator=(FunctionRecording &&)      = default;
-
     ~FunctionRecording() {
-        if (this->recording)
-            jit_freeze_destroy(this->recording);
-
-        this->recording = nullptr;
+        if (recording)
+            jit_freeze_destroy(recording);
     }
 
-    /// Clears the recording.
-    void clear() {
-        if (this->recording)
-            jit_freeze_destroy(this->recording);
+    /// Record ``func`` with the given input, whose slot bindings were computed
+    /// with ``layout``, and return its result. Throws ``InputChanged`` when
+    /// the call changed the structure of its input (see ``plan_outputs()``).
+    nb::object record(nb::handle func, nb::handle root, const uint32_t *inputs);
 
-        this->recording     = nullptr;
-        this->out_variables = FlatVariables();
-    }
+    /// Check that the recording can be replayed with the given input slots
+    bool dry_run(const uint32_t *inputs);
 
-    /*
-     * Record a function, given its python input and flattened input.
-     *
-     * ``after_dry_run`` marks a re-recording that replaces a cached entry whose
-     * dry run failed. The counts cannot tell: it re-records in place.
-     */
-    nb::object record(nb::callable func, FrozenFunction *frozen_func,
-                      nb::dict input, const FlatVariables &in_variables,
-                      bool after_dry_run = false);
-    /*
-     * Replays the recording.
-     *
-     * This constructs the output and re-assigns the input.
-     */
-    nb::object replay(nb::callable func, FrozenFunction *frozen_func,
-                      nb::dict input, const FlatVariables &in_variables);
+    /// Replay the recording with the given input slots, construct the output,
+    /// and update the input
+    nb::object replay(nb::handle root, const uint32_t *inputs);
 };
 
-using RecordingMap = tsl::robin_map<std::shared_ptr<FlatVariables>,
-                                    std::unique_ptr<FunctionRecording>,
-                                    FlatVariablesHasher, FlatVariablesEqual>;
-
-} // namespace detail
-
 struct FrozenFunction {
-    /// The inner function, that is wrapped by this frozen function.
-    nb::callable func;
+    /// The frozen callable and everything that was read from it
+    FunctionEnvironment env;
 
-    /// Previously taken recordings, referenced by the layout of the input
-    /// variables.
-    detail::RecordingMap recordings;
+    /// Optional callable that produces additional input state from the
+    /// arguments of a call
+    nb::object state_fn;
 
-    /// The layout of the previous recording, used for taking diffs and auto
-    /// opaque masks.
-    std::shared_ptr<detail::FlatVariables> prev_key;
+    /// When disabled, calls are forwarded to ``func`` without freezing
+    bool enabled = true;
 
-    /// This is used by the auto opaque feature to tag variables that should be
-    /// made opaque before calling the function.
-    drjit::vector<bool> opaque_mask;
+    /// List of recordings made so far
+    drjit::vector<std::unique_ptr<FunctionRecording>> recordings;
+
+    /// The layout of the most recent recording. The auto-opaque feature
+    /// compares new layouts against it to detect literals that change between
+    /// calls, and its ``ForceOpaque`` flags mark the literals made opaque so
+    /// far.
+    std::shared_ptr<Layout> prev_layout;
 
     /// The number of times this function has been recorded. Note, this can
     /// differ from the number of recordings actually cached in \c recordings,
     /// when dry running recordings failed.
     uint32_t recording_counter    = 0;
-
-    /// Number of recordings evicted by the LRU cache (a benign cache-size gap)
-    uint32_t evicted_counter      = 0;
 
     /// A counter, incremented whenever this function is called. It is used to
     /// determine the least recently used recording in order to evict it if the
@@ -656,34 +107,54 @@ struct FrozenFunction {
     /// make those opaque.
     bool auto_opaque = true;
 
-    /// The maximum sizes previously seen for the vectors in \c FlatVariables.
-    /// Pre-allocating these vectors helps with performance.
-    detail::FlatVariables::Heuristic in_heuristics;
+    /// The recording that was used by the most recent call. Its layout is
+    /// verified against the input of the next call before the cache is
+    /// consulted.
+    FunctionRecording *last_recording = nullptr;
 
-    FrozenFunction(nb::callable func, int max_cache_size = -1,
-                   uint32_t warn_recording_count = 10,
-                   JitBackend backend            = JitBackend::None,
-                   bool auto_opaque              = false)
-        : func(func), max_cache_size(max_cache_size),
+    /// Working memory of the layout verifier, reused across calls
+    VerifierScratch scratch;
+
+    /// Slot bindings of the current call, whether verified or built. Reused
+    /// across calls and released once the call is done.
+    SlotBindings bindings;
+
+    FrozenFunction(nb::callable func, nb::object state_fn, int max_cache_size,
+                   uint32_t warn_recording_count, JitBackend backend,
+                   bool auto_opaque, bool enabled)
+        : env(func), state_fn(state_fn),
+          enabled(enabled), max_cache_size(max_cache_size),
           warn_recording_count(warn_recording_count), default_backend(backend),
-          auto_opaque(auto_opaque) {}
-    ~FrozenFunction() {}
+          auto_opaque(auto_opaque) { }
 
-    FrozenFunction(const FrozenFunction &)            = delete;
+    FrozenFunction(const FrozenFunction &) = delete;
     FrozenFunction &operator=(const FrozenFunction &) = delete;
-    FrozenFunction(FrozenFunction &&)                 = default;
-    FrozenFunction &operator=(FrozenFunction &&)      = default;
-
-    /// Returns the number of recordings currently cached.
-    uint32_t n_cached_recordings() { return (uint32_t) this->recordings.size(); }
 
     /// Clears the frozen function recordings and resets the counters.
     void clear();
 
-    /// Operator to call the frozen function and either record a new version or
-    /// replay an old one. It expects a dictionary input, containing the args,
-    /// kwargs and closure of the Python function.
-    nb::object operator()(nb::dict input);
+    /// Call the frozen function with the arguments of a Python call, either
+    /// recording a new version or replaying an old one. The input that the
+    /// layouts describe is the tuple ``(args, kwargs, closure, state)``,
+    /// where ``closure`` holds the values of the globals and closure
+    /// variables (see ``FunctionEnvironment::capture()``) and ``state`` is the
+    /// result of ``state_fn`` (or ``None``). Calls arrive via a ``tp_call``
+    /// type slot, which skips the generic nanobind method dispatch.
+    nb::object operator()(nb::args args, nb::kwargs kwargs);
+
+    /// Build the layout of the input, making literals opaque according to
+    /// the auto-opaque feature. ``bindings`` receives the slot bindings.
+    std::shared_ptr<Layout> build_layout(nb::handle root);
+
+    /// Look up the recording for the input via the cache, replaying or
+    /// recording as needed. A callable that changes the structure of its
+    /// input while it is recorded is recorded once more.
+    nb::object call_slow(nb::handle root);
+
+    /// Warn when the function is recorded more often than expected.
+    /// ``retried`` marks a re-recording after a failed dry run, and
+    /// ``evicted`` that a full cache had to drop a recording for this one.
+    void warn_recordings(const Layout &layout, bool retried, bool evicted);
 };
 
 extern void export_freeze(nb::module_ &);

--- a/src/python/freeze.h
+++ b/src/python/freeze.h
@@ -171,6 +171,9 @@ struct TraverseContext {
     /// might be traversed multiple times.
     bool deduplicate_pytree = true;
     uint32_t recursion_level = 0;
+    /// C++ objects visited so far. Shared objects are visited once, which
+    /// also terminates reference cycles.
+    tsl::robin_set<const drjit::TraversableBase *, PointerHasher> visited_cpp;
     Buffer path;
 
     TraverseContext() : path(1024) {}
@@ -503,7 +506,7 @@ struct FlatVariables {
      * Assigns variables using its `traverse_cb_rw` callback.
      * This corresponds to `traverse_cb`.
      */
-    void assign_cb(drjit::TraversableBase *traversable);
+    void assign_cb(drjit::TraversableBase *traversable, TraverseContext &ctx);
 
     /**
      * Assigns the flattened variables to an already existing PyTree.

--- a/src/python/freeze_layout.cpp
+++ b/src/python/freeze_layout.cpp
@@ -1,0 +1,963 @@
+/*
+    freeze_layout.cpp -- Infrastructure to describe inputs and outputs of
+    frozen functions
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include "freeze_layout.h"
+#include "base.h"
+#include <cstring>
+#include <tsl/robin_map.h>
+
+// =========================================================================
+//  Shared helpers
+// =========================================================================
+
+static const char *backend_name(JitBackend backend) {
+    switch (backend) {
+        case JitBackend::CUDA:  return "CUDA";
+        case JitBackend::LLVM:  return "LLVM";
+        case JitBackend::Metal: return "Metal";
+        default:                return "scalar";
+    }
+}
+
+/// Names of the entries of the root tuple ``(args, kwargs, closure, state)``.
+/// An argument, a keyword argument or a captured variable is named directly,
+/// so these labels only appear when a path stops at this level, or when it
+/// leads into ``state``, whose entries have no names of their own.
+static const char *root_label(uint32_t index) {
+    static const char *labels[] = { "args", "kwargs", "closure", "state" };
+    return index < 4 ? labels[index] : "";
+}
+
+/// The walk of ``node_path()`` is not inside a named entry of the root
+static constexpr uint32_t RootEntryNone = (uint32_t) -1;
+
+void registry_pointers(const Layout &s, drjit::vector<void *> &pointers) {
+    pointers.clear();
+    for (const std::string &domain : s.domains) {
+        uint32_t bound =
+            jit_registry_id_bound(s.variant.c_str(), domain.c_str());
+        size_t offset = pointers.size();
+        pointers.resize(offset + bound, nullptr);
+        jit_registry_get_pointers(s.variant.c_str(), domain.c_str(),
+                                  &pointers[offset]);
+    }
+}
+
+void attach_grad(uint64_t index, uint32_t grad) {
+    ad_clear_grad(index);
+    uint32_t size = (uint32_t) jit_var_size((uint32_t) index);
+    if ((VarState) jit_var_state(grad) == VarState::Literal &&
+        jit_var_size(grad) != size) {
+        uint32_t resized = jit_var_resize(grad, size);
+        ad_accum_grad(index, resized);
+        jit_var_dec_ref(resized);
+    } else {
+        ad_accum_grad(index, grad);
+    }
+}
+
+// =========================================================================
+//  Layout
+// =========================================================================
+
+Layout::Layout() {
+    types.resize(3);
+    types[BareLeafType].cls = TypeClass::BareLeaf;
+    types[ObjectType].cls   = TypeClass::Object;
+    types[RegistryType].cls = TypeClass::Registry;
+}
+
+int Layout::tp_traverse(visitproc visit, void *arg) const {
+    Py_VISIT(arg_names.ptr());
+    for (const TypeInfo &ti : types)
+        Py_VISIT(ti.tp.ptr());
+    for (const nb::object &o : names)
+        Py_VISIT(o.ptr());
+    for (const nb::object &o : opaques)
+        Py_VISIT(o.ptr());
+    return 0;
+}
+
+std::string Layout::node_path(uint32_t node) const {
+    std::string result;
+    uint32_t n_nodes = (uint32_t) nodes.size();
+
+    // A node that is still open (only while the layout is being built)
+    // extends to the end of the node array
+    auto end_of = [&](uint32_t i) { return nodes[i].next ? nodes[i].next : n_nodes; };
+
+    // The result and the input of an output layout form separate trees
+    uint32_t cur = node >= input_begin ? input_begin : 0;
+    bool root = cur == input_begin;
+
+    // The registry node follows the root
+    if (node >= end_of(cur)) {
+        result = "registry";
+        cur = end_of(cur);
+        root = false;
+    }
+
+    // Entry of the root that the walk descended into, while its child is
+    // still to be named
+    uint32_t entry = RootEntryNone;
+
+    while (cur != node) {
+        const Node &n = nodes[cur];
+        const TypeInfo &ti = types[n.type_id];
+
+        // Find the child whose subtree contains the node
+        uint32_t child = cur + 1, ordinal = 0;
+        while (child < end_of(cur) && !(node >= child && node < end_of(child))) {
+            child = end_of(child);
+            ordinal++;
+        }
+        if (child >= end_of(cur))
+            break;
+
+        // The member of a C++ object that reported this child, if any
+        const char *name = node_names[child];
+
+        // An argument, a keyword argument or a captured variable is named
+        // rather than addressed through the entry of the root that holds it
+        if (root && ordinal < 3 && child != node) {
+            entry = ordinal;
+        } else if (root) {
+            result += root_label(ordinal);
+        } else if (entry != RootEntryNone) {
+            if (entry == 0 && ordinal < arg_names.size())
+                result += nb::str(arg_names[ordinal]).c_str();
+            else if (entry == 0)
+                result += "args[" + std::to_string(ordinal) + "]";
+            else
+                result += nb::str(names[n.ref + ordinal]).c_str();
+            entry = RootEntryNone;
+        } else if (*name) {
+            // A member expanding into several entries (a container, a nested
+            // array) reports the same name for each, hence the extra index
+            uint32_t index = 0, count = 0;
+            for (uint32_t i = cur + 1; i < end_of(cur); i = end_of(i)) {
+                if (strcmp(node_names[i], name) != 0)
+                    continue;
+                if (i < child)
+                    index++;
+                count++;
+            }
+            result += "." + std::string(name);
+            if (count > 1)
+                result += "[" + std::to_string(index) + "]";
+        } else if (ti.cls == TypeClass::Dict) {
+            result += "[\"";
+            result += nb::str(names[n.ref + ordinal]).c_str();
+            result += "\"]";
+        } else if (ti.cls == TypeClass::Struct || ti.cls == TypeClass::Dataclass) {
+            result += ".";
+            result += nb::str(names[ti.name_ref + ordinal]).c_str();
+        } else {
+            result += "[" + std::to_string(ordinal) + "]";
+        }
+
+        cur = child;
+        root = false;
+    }
+
+    return result.empty() ? "the root" : result;
+}
+
+// =========================================================================
+//  LayoutBuilder
+// =========================================================================
+
+namespace {
+
+/**
+ * Builds the ``Layout`` of an input or output by walking a PyTree in DFS
+ * order, which is the slow path of a call (see freeze_layout.h). Its methods
+ * come in three families:
+ *
+ * - ``visit*()`` appends one node per object and descends into its children.
+ *   ``visit()`` dispatches on the ``TypeClass`` of a Python object, while
+ *   ``visit_cpp()`` handles objects reached through the traversal callback of
+ *   another object or through the registry.
+ *
+ * - ``bind_var()`` and ``bind_leaf()`` describe the variable of a leaf. They
+ *   schedule it for evaluation, record literals as such, and deduplicate
+ *   everything else into a slot of ``bindings``.
+ *
+ * - ``intern_*()`` add an entry to one of the tables that nodes refer to
+ *   (Python types, C++ types) and return its index.
+ *
+ * Once the caller has evaluated the scheduled variables, ``finish()``
+ * completes the description of the slots.
+ */
+struct LayoutBuilder {
+    Layout &s;
+    SlotBindings &bindings;
+
+    /// Layout of the previous recording
+    const Layout *prev;
+
+    /// Make every literal opaque instead of recording its value, which is
+    /// what happens when the auto-opaque feature is turned off
+    bool force_all;
+
+    /// AD leaves of the input whose gradient edges were postponed by the
+    /// isolated gradient scope
+    const tsl::robin_set<uint32_t, UInt32Hasher> *postponed = nullptr;
+
+    /// Maps the identity of tracked objects (see ``node_identity()``) to the
+    /// node where they were first visited
+    tsl::robin_map<const void *, uint32_t, PointerHasher> visited;
+
+    /// Maps the JIT index of an evaluated leaf to its slot
+    tsl::robin_map<uint32_t, uint32_t, UInt32Hasher> slot_of_index;
+
+    /// Maps a Python type object to its entry in the type table
+    tsl::robin_map<PyObject *, uint16_t, PointerHasher> type_id_of;
+
+    /// Leaves whose literal changed since the previous recording
+    drjit::vector<uint32_t> changed_literals;
+
+    uint32_t depth = 0;
+
+    LayoutBuilder(Layout &s, SlotBindings &bindings, const Layout *prev,
+                  bool force_all)
+        : s(s), bindings(bindings), prev(prev), force_all(force_all) { }
+
+    /// Append a node with the given type table entry and return its index
+    uint32_t new_node(uint16_t type_id, const char *name = "") {
+        uint32_t index = (uint32_t) s.nodes.size();
+        s.nodes.emplace_back().type_id = type_id;
+        s.node_names.push_back(name);
+        return index;
+    }
+
+    /// Mark the end of a node's subtree
+    void close_node(uint32_t node) {
+        s.nodes[node].next = (uint32_t) s.nodes.size();
+    }
+
+    /// Append a dictionary key or field name to the name table
+    void add_name(nb::handle name) {
+        s.names.push_back(nb::borrow(name));
+    }
+
+    /**
+     * Classify the type of the Python object ``h``. ``fields`` receives the
+     * names of the fields declared by a ``DRJIT_STRUCT`` annotation or a
+     * dataclass, if detected.
+     */
+    static void classify_type(nb::handle h, TypeInfo &ti,
+                              drjit::vector<nb::object> &fields) {
+        nb::handle tph = h.type();
+        PyTypeObject *tp = (PyTypeObject *) tph.ptr();
+        ti.tp = nb::borrow(tph);
+
+        // The type flags identify subclasses of the builtin containers
+        unsigned long flags = PyType_GetFlags(tp);
+
+        if (is_builtin_scalar(tph)) {
+            ti.cls = TypeClass::Opaque;
+        } else if (is_drjit_type(tph)) {
+            const ArraySupplement &supp_ = supp(tph);
+            ti.supp = &supp_;
+            if (supp_.is_tensor)
+                ti.cls = TypeClass::Tensor;
+            else if (supp_.ndim > 1 ||
+                     (JitBackend) supp_.backend == JitBackend::None)
+                ti.cls = TypeClass::Nested;
+            else
+                ti.cls = TypeClass::Leaf;
+        } else if (flags & Py_TPFLAGS_TUPLE_SUBCLASS) {
+            ti.cls = TypeClass::Tuple;
+        } else if (flags & Py_TPFLAGS_LIST_SUBCLASS) {
+            ti.cls = TypeClass::List;
+        } else if (flags & Py_TPFLAGS_DICT_SUBCLASS) {
+            ti.cls = TypeClass::Dict;
+        } else if (PyType_IsSubtype(tp, (PyTypeObject *) traversable_base_type.ptr())) {
+            ti.cls = TypeClass::Object;
+        } else if (nb::dict ds = get_drjit_struct(tph); ds.is_valid()) {
+            ti.cls = TypeClass::Struct;
+            for (nb::handle k : ds.keys())
+                fields.push_back(nb::borrow(k));
+        } else if (nb::dict df = dataclass_field_dict(tph); df.is_valid()) {
+            ti.cls = TypeClass::Dataclass;
+            for (auto [k, field] : df)
+                if (is_dataclass_field(field))
+                    fields.push_back(nb::borrow(k));
+        } else {
+            raise_if_unbound_traversable(tph);
+            ti.cls = TypeClass::Opaque;
+        }
+    }
+
+    /// Return the index of the type of ``h`` in the type table, adding it if needed
+    uint16_t intern_type(nb::handle h) {
+        PyObject *tp = (PyObject *) Py_TYPE(h.ptr());
+        auto [it, inserted] = type_id_of.try_emplace(tp, (uint16_t) s.types.size());
+        if (!inserted)
+            return it->second;
+
+        if (s.types.size() >= 0xffff)
+            nb::raise("detected >=65535 distinct Python types in the input, "
+                      "which is beyond the limit.");
+
+        TypeInfo ti;
+        drjit::vector<nb::object> fields;
+        classify_type(h, ti, fields);
+        ti.name_ref = (uint32_t) s.names.size();
+        ti.size     = (uint32_t) fields.size();
+        for (nb::handle k : fields)
+            add_name(k);
+
+        s.types.push_back(std::move(ti));
+        return (uint16_t) (s.types.size() - 1);
+    }
+
+    /// Return the index of a C++ type in ``cpp_types``, adding it if needed
+    uint32_t intern_cpp_type(const std::type_info *type) {
+        for (size_t i = 0; i < s.cpp_types.size(); ++i)
+            if (same_cpp_type(s.cpp_types[i], type))
+                return (uint32_t) i;
+        s.cpp_types.push_back(type);
+        return (uint32_t) (s.cpp_types.size() - 1);
+    }
+
+    /// Return the index of a C++ type that may be subclassed in Python
+    uint16_t intern_object_type(const drjit::TraversableBase *obj) {
+        nb::handle self = obj->self_py();
+        if (self.is_valid() && NB_CALL(nb_inst_python_derived)(self.ptr()))
+            return intern_type(self);
+        return ObjectType;
+    }
+
+    /// Record the variant and domain of a class pointer array
+    void add_domain(const char *variant, const char *domain) {
+        if (!domain || !variant || domain[0] == '\0')
+            return;
+
+        if (s.domains.empty()) {
+            s.variant = variant;
+        } else if (s.variant != variant) {
+            jit_raise("variant mismatch! All arguments to a frozen function "
+                      "have to have the same variant. Variant %s of a previous "
+                      "argument does not match variant %s of this argument.",
+                      s.variant.c_str(), variant);
+        }
+
+        for (const std::string &d : s.domains)
+            if (d == domain)
+                return;
+        s.domains.push_back(domain);
+    }
+
+    /// Did the previous recording see a different literal ``pv``? Such a literal
+    /// is made opaque ("auto-opaque"). ``node`` identifies the leaf for diagnostics.
+    bool literal_changed(const Node *pv, uint32_t node, const Literal &l) {
+        if (!pv || !pv->has(NodeFlag::Literal))
+            return false;
+
+        const Literal &lp = prev->literals[pv->ref];
+        if (l.value == lp.value && l.size == lp.size)
+            return false;
+
+        changed_literals.push_back(node);
+        return true;
+    }
+
+    /// Report the literals that ``literal_changed()`` found. This runs once
+    /// the layout is complete, since rendering a path walks the layout.
+    void log_changed_literals() {
+        if (changed_literals.empty() || !log_enabled(LogLevel::Info))
+            return;
+        jit_log(LogLevel::Info,
+                "drjit.freeze(): the literal values below changed between "
+                "calls and are made opaque, which requires a new recording. "
+                "Making them opaque beforehand avoids this overhead.");
+        for (uint32_t node : changed_literals)
+            jit_log(LogLevel::Info, " - %s", s.node_path(node).c_str());
+    }
+
+    /**
+     * Bind one JIT variable of a leaf. ``n`` is the node of the leaf for its
+     * value, and its entry in ``Layout::grads`` for its gradient; ``pv``
+     * describes the same variable in the previous recording, or is null.
+     * Literals at forced positions are made opaque, and unevaluated variables
+     * are scheduled. ``index`` is updated to the variable that ends up bound
+     * to the slot, and ``forced`` is set when it differs from the input
+     * variable.
+     */
+    void bind_var(Node &n, const Node *pv, uint32_t node, uint32_t &index,
+                  bool &forced) {
+        VarInfo info = jit_var_info(index);
+
+        if (info.type == VarType::Pointer)
+            jit_raise("pointer inputs are not supported!");
+
+        if (s.backend == JitBackend::None)
+            s.backend = info.backend;
+        else if (s.backend != info.backend)
+            jit_raise("backend mismatch error (backend of this variable %s "
+                      "does not match backend of others %s)!",
+                      backend_name(info.backend), backend_name(s.backend));
+
+        n.vt = (uint8_t) info.type;
+
+        bool force = force_all || (pv && pv->has(NodeFlag::ForceOpaque));
+
+        if (info.state == VarState::Literal || info.state == VarState::Undefined) {
+            Literal l { info.state == VarState::Literal ? info.literal : 0,
+                        (uint32_t) info.size,
+                        info.state == VarState::Undefined };
+            if (!force && !literal_changed(pv, node, l)) {
+                n.set(NodeFlag::Literal);
+                n.ref = (uint32_t) s.literals.size();
+                s.literals.push_back(l);
+                return;
+            }
+            force = true;
+            int rv = 0;
+            index = jit_var_schedule_force(index, &rv);
+            bindings.owned.push_back(index);
+            forced = true;
+        } else if (info.state != VarState::Evaluated) {
+            jit_var_schedule(index);
+        }
+
+        if (force)
+            n.set(NodeFlag::ForceOpaque);
+
+        // Deduplicate the variable into a slot
+        auto [it, inserted] = slot_of_index.try_emplace(
+            index, (uint32_t) bindings.indices.size());
+        if (inserted)
+            bindings.indices.push_back(index);
+        n.ref = it->second;
+    }
+
+    /**
+     * Bind a leaf node holding a (possibly AD-attached) variable. When a
+     * literal was made opaque, the function returns an owning combined index
+     * that the caller must store in place of ``index``, and zero otherwise.
+     */
+    uint64_t bind_leaf(uint32_t node, uint64_t index) {
+        uint32_t ad_index = (uint32_t) (index >> 32);
+        bool grad_enabled = ad_index != 0 && ad_grad_enabled(index);
+
+        // Description of this leaf in the previous recording, if any
+        const Node *pn =
+            (prev && node < prev->nodes.size()) ? &prev->nodes[node] : nullptr;
+
+        uint32_t value = (uint32_t) index;
+        bool value_forced = false;
+        bind_var(s.nodes[node], pn, node, value, value_forced);
+
+        uint32_t grad = 0;
+        bool grad_forced = false;
+        if (grad_enabled) {
+            Node &n = s.nodes[node];
+            n.set(NodeFlag::GradEnabled);
+            n.grad = (uint32_t) s.grads.size();
+            if (postponed && postponed->contains(ad_index))
+                n.set(NodeFlag::Postponed);
+
+            const Node *pg = nullptr;
+            if (pn && pn->has(NodeFlag::GradEnabled))
+                pg = &prev->grads[pn->grad];
+
+            grad = ad_grad(index);
+            bindings.owned.push_back(grad);
+            bind_var(s.grads.emplace_back(), pg, node, grad, grad_forced);
+        }
+
+        close_node(node);
+
+        if (value_forced || grad_forced)
+            return make_ad_index(ad_index, value, grad_enabled, grad);
+        return 0;
+    }
+
+    /// Describe the leaf held by the Python array ``h``
+    void visit_leaf(uint32_t node, nb::handle h, const ArraySupplement *supp_) {
+        if (supp_->is_class) {
+            nb::str variant = nb::borrow<nb::str>(nb::getattr(h, "Variant")),
+                    domain  = nb::borrow<nb::str>(nb::getattr(h, "Domain"));
+            add_domain(variant.c_str(), domain.c_str());
+        }
+
+        uint64_t forced = bind_leaf(node, supp_->index(inst_ptr(h)));
+        if (forced) {
+            supp_->reset_index(forced, inst_ptr(h));
+            ad_var_dec_ref(forced);
+        }
+    }
+
+    /// Describe a declared field, keeping the value alive in case a property
+    /// produced it
+    void visit_field(nb::handle h, nb::handle name) {
+        nb::object value = nb::getattr(h, name);
+        visit(value);
+        bindings.keep_alive.push_back(std::move(value));
+    }
+
+    /// Describe the members of a C++ object and its Python attributes
+    void visit_object(uint32_t node, drjit::TraversableBase *obj) {
+        s.nodes[node].ref = intern_cpp_type(cpp_type(obj));
+
+        uint32_t size = traverse_members(
+            obj,
+            [&](uint64_t index, const char *name, const char *variant,
+                const char *domain) -> uint64_t {
+                add_domain(variant, domain);
+                return bind_leaf(new_node(BareLeafType, name), index);
+            },
+            [&](drjit::TraversableBase *child, const char *name) {
+                visit_cpp(child, name);
+            });
+
+        if (nb::dict d = traversable_dict(obj); d.is_valid()) {
+            size++;
+            visit(d);
+        }
+
+        s.nodes[node].size = size;
+    }
+
+    /// Describe a C++ object reached through another object or the registry
+    void visit_cpp(drjit::TraversableBase *obj, const char *name = "") {
+        recursion_guard guard(depth);
+        uint32_t node = new_node(ObjectType, name);
+
+        auto [it, inserted] = visited.try_emplace(obj, node);
+        if (!inserted) {
+            s.nodes[node].set(NodeFlag::RecursiveRef);
+            s.nodes[node].ref = it->second;
+            close_node(node);
+            return;
+        }
+
+        s.nodes[node].type_id = intern_object_type(obj);
+        visit_object(node, obj);
+        close_node(node);
+    }
+
+    /// Describe the Python object ``h``
+    void visit(nb::handle h) {
+        recursion_guard guard(depth);
+
+        uint16_t type_id = intern_type(h);
+        uint32_t node    = new_node(type_id);
+        TypeClass cls    = s.types[type_id].cls;
+
+        if (is_tracked(cls)) {
+            auto [it, inserted] = visited.try_emplace(node_identity(h, cls), node);
+            if (!inserted) {
+                s.nodes[node].set(NodeFlag::RecursiveRef);
+                s.nodes[node].ref = it->second;
+                close_node(node);
+                return;
+            }
+        }
+
+        switch (cls) {
+            case TypeClass::Leaf:
+                visit_leaf(node, h, s.types[type_id].supp);
+                return;
+
+            case TypeClass::Tensor: {
+                const ArraySupplement *supp_ = s.types[type_id].supp;
+                const dr::vector<size_t> &shape = supp_->tensor_shape(inst_ptr(h));
+                s.nodes[node].ref = (uint32_t) s.shapes.size();
+                s.shapes.push_back((uint32_t) shape.size());
+                for (size_t i = 1; i < shape.size(); ++i)
+                    s.shapes.push_back((uint32_t) shape[i]);
+                s.nodes[node].size = 1;
+                visit(nb::steal(supp_->tensor_array(h.ptr())));
+                break;
+            }
+
+            case TypeClass::Nested: {
+                const ArraySupplement *supp_ = s.types[type_id].supp;
+                Py_ssize_t len = supp_->shape[0];
+                if (len == DRJIT_DYNAMIC)
+                    len = (Py_ssize_t) supp_->len(inst_ptr(h));
+                s.nodes[node].size = (uint32_t) len;
+                for (Py_ssize_t i = 0; i < len; ++i)
+                    visit(nb::steal(supp_->item(h.ptr(), i)));
+                break;
+            }
+
+            case TypeClass::Tuple: {
+                Py_ssize_t len = NB_TUPLE_GET_SIZE(h.ptr());
+                s.nodes[node].size = (uint32_t) len;
+                for (Py_ssize_t i = 0; i < len; ++i)
+                    visit(NB_TUPLE_GET_ITEM(h.ptr(), i));
+                break;
+            }
+
+            case TypeClass::List: {
+                Py_ssize_t len = NB_LIST_GET_SIZE(h.ptr());
+                s.nodes[node].size = (uint32_t) len;
+                for (Py_ssize_t i = 0; i < len; ++i)
+                    visit(NB_LIST_GET_ITEM(h.ptr(), i));
+                break;
+            }
+
+            case TypeClass::Dict: {
+                nb::dict dict = nb::borrow<nb::dict>(h);
+                s.nodes[node].size = (uint32_t) dict.size();
+                s.nodes[node].ref = (uint32_t) s.names.size();
+                for (auto [k, v] : dict)
+                    add_name(k);
+                for (auto [k, v] : dict)
+                    visit(v);
+                break;
+            }
+
+            case TypeClass::Struct:
+            case TypeClass::Dataclass: {
+                // The type table may be reallocated by the recursive visits
+                uint32_t name_ref = s.types[type_id].name_ref,
+                         size     = s.types[type_id].size;
+                s.nodes[node].size = size;
+                for (uint32_t i = 0; i < size; ++i)
+                    visit_field(h, s.names[name_ref + i]);
+                break;
+            }
+
+            case TypeClass::Object:
+                visit_object(node, object_ptr(h));
+                break;
+
+            case TypeClass::Opaque:
+                s.nodes[node].ref = (uint32_t) s.opaques.size();
+                s.opaques.push_back(nb::borrow(h));
+                break;
+
+            default:
+                nb::raise("internal error, unexpected type class");
+        }
+
+        close_node(node);
+    }
+
+    /// Describe the registry entries of the domains seen so far
+    void visit_registry() {
+        if (s.domains.empty())
+            return;
+
+        uint32_t node = new_node(RegistryType);
+
+        drjit::vector<void *> pointers;
+        registry_pointers(s, pointers);
+
+        uint32_t count = 0;
+        for (void *ptr : pointers) {
+            if (!ptr)
+                continue;
+            count++;
+            visit_cpp((drjit::TraversableBase *) ptr);
+        }
+
+        s.nodes[node].size = count;
+        close_node(node);
+    }
+
+    /// Describe the slots. Must be called after evaluation.
+    void finish() {
+        uint32_t n_slots = (uint32_t) bindings.indices.size();
+        s.slots.resize(n_slots);
+
+        // Numbers the distinct sizes in order of first appearance
+        tsl::robin_map<uint32_t, uint32_t, UInt32Hasher> class_of_size;
+
+        for (uint32_t slot = 0; slot < n_slots; ++slot) {
+            uint32_t index = bindings.indices[slot];
+
+            // Hold a reference to every input while the function is recorded
+            // so that in-place operations (e.g. scatters) copy the input first
+            bindings.owned.push_back_borrow(index);
+
+            VarInfo info = jit_var_info(index);
+            if (info.state != VarState::Evaluated)
+                jit_raise("internal error, variable r%u is in an unexpected "
+                          "state (%u) after evaluation.", index, (uint32_t) info.state);
+
+            auto [it, inserted] = class_of_size.try_emplace(
+                (uint32_t) info.size, (uint32_t) class_of_size.size());
+
+            Slot &si      = s.slots[slot];
+            si.vt         = (uint8_t) info.type;
+            si.singleton  = info.size == 1;
+            si.unaligned  = info.unaligned;
+            si.size_class = it->second;
+        }
+
+        s.n_size_classes = (uint32_t) class_of_size.size();
+    }
+};
+
+/// Path of the innermost open node that was interrupted by an error
+static std::string open_node_path(const Layout &s) {
+    for (size_t i = s.nodes.size(); i > 0; --i)
+        if (s.nodes[i - 1].next == 0)
+            return s.node_path((uint32_t) (i - 1));
+    return "the root";
+}
+
+/// Run a traversal of ``walk`` with the builder, evaluate and finish the layout
+template <typename Walk>
+static void run_builder(LayoutBuilder &b, const char *what, Walk &&walk) {
+    try {
+        walk();
+    } catch (nb::python_error &e) {
+        nb::raise_from(e, PyExc_RuntimeError,
+                       "drjit.freeze(): error encountered while traversing the "
+                       "%s at %s (see above).",
+                       what, open_node_path(b.s).c_str());
+    } catch (const std::exception &e) {
+        nb::chain_error(PyExc_RuntimeError,
+                        "drjit.freeze(): error encountered while traversing the "
+                        "%s at %s: %s",
+                        what, open_node_path(b.s).c_str(), e.what());
+        nb::raise_python_error();
+    }
+
+    b.log_changed_literals();
+
+    // Evaluate the scheduled variables. This also flushes pending side effects
+    // (e.g. scatters), which must not leak into or out of a recording.
+    {
+        state_unlock_guard guard;
+        nb::gil_scoped_release guard2;
+        jit_eval();
+    }
+
+    b.finish();
+}
+
+} // namespace
+
+std::shared_ptr<Layout>
+build_input_layout(nb::handle root, nb::tuple arg_names, JitBackend backend,
+                   const Layout *prev, bool force_all, SlotBindings &bindings) {
+    ProfilerPhase profile("build_input_layout()");
+    bindings.release();
+    auto layout = std::make_shared<Layout>();
+    Layout &s   = *layout;
+    s.jit_flags = jit_flags();
+    s.backend   = backend;
+    s.arg_names = std::move(arg_names);
+
+    LayoutBuilder b(s, bindings, prev, force_all);
+    run_builder(b, "input", [&] {
+        b.visit(root);
+        b.visit_registry();
+    });
+
+    return layout;
+}
+
+void SlotBindings::release() {
+    owned.release();
+    indices.clear();
+    keep_alive.clear();
+}
+
+// =========================================================================
+//  Key comparison and diagnostics
+// =========================================================================
+
+bool layout_equal(const Layout &a, const Layout &b) {
+    if (a.jit_flags != b.jit_flags ||
+        a.backend != b.backend || a.n_size_classes != b.n_size_classes ||
+        a.nodes.size() != b.nodes.size() || a.types.size() != b.types.size() ||
+        a.slots.size() != b.slots.size() || a.grads.size() != b.grads.size() ||
+        a.literals.size() != b.literals.size() ||
+        a.shapes.size() != b.shapes.size() ||
+        a.names.size() != b.names.size() ||
+        a.opaques.size() != b.opaques.size() || a.variant != b.variant ||
+        a.domains.size() != b.domains.size() ||
+        a.cpp_types.size() != b.cpp_types.size())
+        return false;
+
+    if (memcmp(a.nodes.data(), b.nodes.data(), a.nodes.size() * sizeof(Node)) != 0 ||
+        memcmp(a.slots.data(), b.slots.data(), a.slots.size() * sizeof(Slot)) != 0 ||
+        memcmp(a.grads.data(), b.grads.data(), a.grads.size() * sizeof(Node)) != 0 ||
+        memcmp(a.literals.data(), b.literals.data(), a.literals.size() * sizeof(Literal)) != 0 ||
+        memcmp(a.shapes.data(), b.shapes.data(), a.shapes.size() * sizeof(uint32_t)) != 0)
+        return false;
+
+    for (size_t i = 0; i < a.types.size(); ++i)
+        if (!a.types[i].tp.is(b.types[i].tp) ||
+            a.types[i].cls != b.types[i].cls)
+            return false;
+
+    for (size_t i = 0; i < a.cpp_types.size(); ++i)
+        if (!same_cpp_type(a.cpp_types[i], b.cpp_types[i]))
+            return false;
+
+    for (size_t i = 0; i < a.domains.size(); ++i)
+        if (a.domains[i] != b.domains[i])
+            return false;
+
+    for (size_t i = 0; i < a.names.size(); ++i)
+        if (!py_equal(a.names[i], b.names[i]))
+            return false;
+
+    for (size_t i = 0; i < a.opaques.size(); ++i)
+        if (!py_equal(a.opaques[i], b.opaques[i]))
+            return false;
+
+    return true;
+}
+
+static std::string py_type_name(nb::handle tp) {
+    return tp.is_valid() ? nb::type_name(tp).c_str() : "(none)";
+}
+
+/// Compare the type, literal value and slot properties of one variable held by
+/// a leaf, and return the reason for a difference, or ``nullptr``. Both nodes
+/// must have the same flags, since ``ref`` is only interpreted based on ``va``.
+static const char *var_difference(const Layout &a, const Node &va,
+                                  const Layout &b, const Node &vb) {
+    if (va.vt != vb.vt)
+        return "the variable type changed";
+    if (va.has(NodeFlag::Literal))
+        return memcmp(&a.literals[va.ref], &b.literals[vb.ref],
+                      sizeof(Literal)) != 0
+                   ? "the literal value changed" : nullptr;
+    const Slot &sa = a.slots[va.ref], &sb = b.slots[vb.ref];
+    if (sa.singleton != sb.singleton || sa.size_class != sb.size_class ||
+        sa.unaligned != sb.unaligned)
+        return "the variable size, size class or alignment changed";
+    return nullptr;
+}
+
+std::string node_difference(const Layout &a, uint32_t j, const Layout &b,
+                            uint32_t k, uint32_t a_base, bool leaf_state) {
+    const Node &na = a.nodes[j], &nb_ = b.nodes[k];
+    const TypeInfo &ta = a.types[na.type_id], &tb = b.types[nb_.type_id];
+
+    if (!ta.tp.is(tb.tp) || ta.cls != tb.cls)
+        return "the type changed from " + py_type_name(tb.tp) + " to " +
+               py_type_name(ta.tp);
+
+    bool ref_a = na.has(NodeFlag::RecursiveRef),
+         ref_b = nb_.has(NodeFlag::RecursiveRef);
+    if (ref_a != ref_b || (ref_a && na.ref - a_base != nb_.ref))
+        return "the object is shared with a different part of the input";
+    if (ref_a)
+        return "";
+
+    switch (ta.cls) {
+        case TypeClass::Leaf:
+        case TypeClass::BareLeaf: {
+            if (!leaf_state)
+                return "";
+            if (na.flags != nb_.flags)
+                return "the literal/evaluated/gradient state changed";
+            if (const char *r = var_difference(a, na, b, nb_))
+                return r;
+            if (na.has(NodeFlag::GradEnabled)) {
+                const Node &ga = a.grads[na.grad], &gb = b.grads[nb_.grad];
+                if (ga.flags != gb.flags)
+                    return "the literal/evaluated state of a gradient changed";
+                if (const char *r = var_difference(a, ga, b, gb))
+                    return r;
+            }
+            return "";
+        }
+
+        case TypeClass::Dict:
+            if (na.size == nb_.size) {
+                for (uint32_t i = 0; i < na.size; ++i)
+                    if (!py_equal(a.names[na.ref + i], b.names[nb_.ref + i]))
+                        return "the dictionary keys changed";
+            }
+            break;
+
+        case TypeClass::Tensor: {
+            const uint32_t *sa = a.shapes.data() + na.ref,
+                           *sb = b.shapes.data() + nb_.ref;
+            if (sa[0] != sb[0] || memcmp(sa, sb, sa[0] * sizeof(uint32_t)) != 0)
+                return "the tensor shape changed";
+            break;
+        }
+
+        case TypeClass::Object:
+            if (!same_cpp_type(a.cpp_types[na.ref], b.cpp_types[nb_.ref]))
+                return std::string("the C++ type changed from ") +
+                       b.cpp_types[nb_.ref]->name() + " to " +
+                       a.cpp_types[na.ref]->name();
+            break;
+
+        case TypeClass::Opaque:
+            if (!py_equal(a.opaques[na.ref], b.opaques[nb_.ref]))
+                return "the value changed from " +
+                       std::string(nb::str(b.opaques[nb_.ref]).c_str()) +
+                       " to " + nb::str(a.opaques[na.ref]).c_str();
+            break;
+
+        default:
+            break;
+    }
+
+    if (na.size != nb_.size)
+        return "the number of entries changed from " +
+               std::to_string(nb_.size) + " to " + std::to_string(na.size);
+
+    return "";
+}
+
+std::string layout_diff(const Layout &cur, const Layout &prev) {
+    if (cur.nodes.size() != prev.nodes.size())
+        return "the input is structured differently (" +
+               std::to_string(cur.nodes.size()) + " vs " +
+               std::to_string(prev.nodes.size()) + " nodes)";
+
+    for (uint32_t i = 0; i < (uint32_t) cur.nodes.size(); ++i) {
+        std::string diff = node_difference(cur, i, prev, i, 0, true);
+        if (!diff.empty())
+            return "'" + cur.node_path(i) + "' (" + diff + ")";
+    }
+
+    return "";
+}
+
+// =========================================================================
+//  Output layout containing both the result and potentially updated inputs
+// =========================================================================
+
+Layout build_output_layout(
+    nb::handle output, nb::handle input, nb::tuple arg_names,
+    JitBackend backend, const tsl::robin_set<uint32_t, UInt32Hasher> &postponed,
+    SlotBindings &bindings) {
+    ProfilerPhase profile("build_output_layout()");
+
+    Layout s;
+    s.jit_flags = jit_flags();
+    s.backend   = backend;
+    s.arg_names = std::move(arg_names);
+
+    LayoutBuilder b(s, bindings, nullptr, false);
+    b.postponed = &postponed;
+
+    run_builder(b, "output", [&] {
+        s.input_begin = (uint32_t) -1;
+        b.visit(output);
+        s.input_begin = (uint32_t) s.nodes.size();
+        b.visited.clear();
+        b.visit(input);
+        b.visit_registry();
+    });
+
+    return s;
+}

--- a/src/python/freeze_layout.cpp
+++ b/src/python/freeze_layout.cpp
@@ -133,7 +133,7 @@ std::string Layout::node_path(uint32_t node) const {
             result += root_label(ordinal);
         } else if (entry != RootEntryNone) {
             if (entry == 0 && ordinal < arg_names.size())
-                result += nb::str(arg_names[ordinal]).c_str();
+                result += nb::str(nb::handle(arg_names[ordinal])).c_str();
             else if (entry == 0)
                 result += "args[" + std::to_string(ordinal) + "]";
             else
@@ -474,6 +474,7 @@ struct LayoutBuilder {
 
             grad = ad_grad(index);
             bindings.owned.push_back(grad);
+            bindings.grads.emplace_back(ad_var_inc_ref(index), grad);
             bind_var(s.grads.emplace_back(), pg, node, grad, grad_forced);
         }
 
@@ -765,7 +766,18 @@ build_input_layout(nb::handle root, nb::tuple arg_names, JitBackend backend,
     return layout;
 }
 
+void SlotBindings::restore_grads() {
+    for (auto [index, grad] : grads) {
+        ad_clear_grad(index);
+        if (grad)
+            ad_accum_grad(index, grad);
+    }
+}
+
 void SlotBindings::release() {
+    for (auto [index, grad] : grads)
+        ad_var_dec_ref(index);
+    grads.clear();
     owned.release();
     indices.clear();
     keep_alive.clear();

--- a/src/python/freeze_layout.h
+++ b/src/python/freeze_layout.h
@@ -127,57 +127,51 @@
     pointer arrays seen in the input. Each entry is described like any other
     object (or by a ``RecursiveRef``).
 
-    4. Recording: describing the result and the modified inputs
-    -----------------------------------------------------------
+    4. Recording: the result and modified inputs
+    --------------------------------------------
 
-    A replay must reproduce the variables making up the function result, and
-    inputs modified in place (e.g., ``x += 1`` on an argument or an updated
-    member of a C++ object). ``build_output_layout()`` describes the result
-    and the input as it looks after the call in one ``Layout``, as two
-    consecutive DFS trees: the nodes before ``Layout::input_begin`` describe
-    the result, and the nodes from ``input_begin`` on describe the input
-    (including the registry).
+    A replay must reproduce the function result and any inputs modified in
+    place (e.g., ``x += 1`` on an argument). ``build_output_layout()``
+    describes both in one ``Layout`` holding two consecutive DFS trees: the
+    result before ``Layout::input_begin``, and the post-call input (including
+    the registry) from there on.
 
-    ``plan_outputs()`` then compares the input part of this layout against
-    the input layout, position by position. The function may assign new
-    arrays to the leaves of its input, but it must not change anything else
-    about it (the entries of containers, dictionary keys, tensor shapes, the
-    Python values it holds, ...), since a replay cannot reproduce such a
-    change. ``plan_outputs()`` raises when it finds one. Leaves whose
-    variable changed, and AD leaves whose gradient edges were postponed by
-    the isolated gradient scope (``Postponed``), are flagged ``Dirty`` and
-    their ancestors ``DirtySubtree``. The slots that a replay must produce,
-    namely everything in the result and the dirty input leaves, receive output
-    positions (``slot_output``, ``n_outputs``), and the corresponding
-    variables are registered as outputs of the backend recording. The common
-    case of a large input that the function reads but does not modify costs
-    nothing on replay.
+    ``plan_outputs()`` compares the input part of this layout against the
+    input layout position by position. The function may assign new arrays to
+    input leaves, but any other change (container entries, dictionary keys,
+    tensor shapes, Python values, ...) cannot be replayed. In that case
+    ``plan_outputs()`` throws ``InputChanged`` and the caller records the
+    function once more, which handles callables that initialize part of
+    their input on the first call.
+
+    Leaves whose variable changed, and AD leaves with ``Postponed`` gradient
+    edges, are flagged ``Dirty`` and their ancestors ``DirtySubtree``. The
+    result slots and the dirty input leaves receive output positions
+    (``slot_output``, ``n_outputs``) and become outputs of the backend
+    recording. Inputs that the function only reads cost nothing on replay.
 
     5. Replay: constructing the result and updating the input
     ---------------------------------------------------------
 
     ``jit_freeze_replay()`` returns one variable per output position.
     ``construct_output()`` rebuilds the result from the output layout, and
-    ``update_input()`` walks the input part of the output layout in
-    lockstep with the live input and assigns the dirty leaves, skipping
-    subtrees without the ``DirtySubtree`` flag. Both functions also run once
-    right after recording, so that errors surface when recording rather than
-    when replaying.
+    ``update_input()`` walks the input part in lockstep with the live input
+    and assigns the dirty leaves, skipping subtrees without ``DirtySubtree``.
+    Both also run once right after recording so that errors surface early.
 
     6. Auto-opaque literals
     -----------------------
 
     A literal whose value differs between calls would force a new recording
     every time. With ``auto_opaque`` enabled, the builder compares each
-    literal against the layout of the previous recording (``prev``) at the
-    same node position and makes it opaque (``jit_var_schedule_force()``)
-    when the value changed. It then becomes an ordinary slot flagged
-    ``ForceOpaque``. A build also reads this flag from ``prev``, so forced
-    positions accumulate across recordings, and the verifier makes a literal
-    arriving at such a position opaque as well. Either walker writes the
-    opaque variable into the Python array or C++ object right away, which is
-    safe even if the walk fails later on, since the variable holds the same
-    contents as the literal.
+    literal against the previous recording's layout (``prev``) at the same
+    node position and makes it opaque (``jit_var_schedule_force()``) when
+    the value changed. The slot is then flagged ``ForceOpaque``. This flag
+    is also inherited from ``prev``, so forced positions accumulate across
+    recordings, and the verifier makes literals at such positions opaque as
+    well. The opaque variable is written back into the Python array or C++
+    object right away, which is safe even if the walk fails later since it
+    holds the same contents as the literal.
 */
 
 #pragma once
@@ -189,6 +183,7 @@
 #include <drjit/python.h>
 #include <drjit/traversable_base.h>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <tsl/robin_set.h>
 #include <typeinfo>
@@ -460,7 +455,16 @@ struct SlotBindings {
     /// the bound variables have been used.
     drjit::vector<nb::object> keep_alive;
 
+    /// AD variables of the input whose gradients are enabled (owning
+    /// references), each paired with the gradient it held before the call
+    drjit::vector<std::pair<uint64_t, uint32_t>> grads;
+
+    /// Reset the gradients of the AD variables to their state before the
+    /// call, which undoes the accumulation performed by an aborted recording
+    void restore_grads();
+
     void release();
+    ~SlotBindings() { release(); }
 };
 
 /// Working memory of \ref verify_layout(), reused across calls
@@ -562,8 +566,12 @@ build_output_layout(nb::handle output, nb::handle input, nb::tuple arg_names,
  * ``Dirty`` and their ancestors ``DirtySubtree``, and assigns output
  * positions to the slots that a replay must produce (``slot_output``,
  * ``n_outputs``). Returns the variables that the backend recording must
- * return, in output order. Raises if the function changed anything but the
- * variables of its input (see section 4 of the overview).
+ * return, in output order.
+ *
+ * Throws ``InputChanged`` when the callable changed anything but the
+ * variables of its input (see section 4 of the overview). The caller records
+ * the function once more in that case, since the change is usually a
+ * one-time initialization that the next call no longer performs.
  *
  * \param out
  *     Output layout of the recording, as returned by ``build_output_layout()``
@@ -580,6 +588,12 @@ build_output_layout(nb::handle output, nb::handle input, nb::tuple arg_names,
 extern drjit::vector<uint32_t>
 plan_outputs(Layout &out, const uint32_t *out_bindings, const Layout &in,
              const uint32_t *in_bindings);
+
+/// Thrown by ``plan_outputs()`` when the function changed the structure of
+/// its input or the Python values it holds
+struct InputChanged : std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
 
 /**
  * \brief Construct the result of a frozen function from its output layout

--- a/src/python/freeze_layout.h
+++ b/src/python/freeze_layout.h
@@ -1,0 +1,742 @@
+/*
+    freeze_layout.h -- Infrastructure to describe inputs and outputs of frozen
+    functions
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+
+    Overview
+    --------
+
+    A ``FrozenFunction`` (see freeze.h) records the kernels launched by a
+    Python callable and replays them on later calls. Replay requires the input
+    to be structurally compatible with that of the original recording, meaning
+    that it must have the same PyTree structure, Python types, literal values,
+    and size relationships between variables. Throughout this file, the *root*
+    denotes the input of a call as a whole: the tuple ``(args, kwargs,
+    closure, state)`` that ``FrozenFunction::operator()`` assembles.
+
+    This file defines the class ``Layout``, which encodes all of these
+    properties, along with the operations handling the two main code paths:
+
+    1. Fast path
+    ------------
+
+    Ideally, a frozen function repeatedly receives the same flavor of inputs.
+    The ``verify_layout()`` function exploits this to avoid building a new
+    ``Layout``. It walks the current input in lockstep with the nodes of the
+    most recently used ``Layout``, both to validate compatibility and to
+    collect the argument list needed for the subsequent kernel launches in a
+    ``SlotBindings`` instance. Its working memory (``VerifierScratch``) and
+    the bindings are owned by the frozen function and reused across calls,
+    which minimizes dynamic memory allocation and Python reference counting
+    when one recording is frequently reused.
+
+    2. Slow path
+    ------------
+
+    Otherwise, the implementation calls ``build_input_layout()`` to build a
+    new ``Layout`` from scratch. The ``LayoutBuilder`` walks the PyTree and
+    appends one ``Node`` per visited object, in DFS order.
+
+    Each node links to a ``TypeInfo`` in ``Layout::types``, which caches the
+    classification of a Python type (``TypeClass``: array, tensor, nested
+    array, tuple, list, dict, struct, dataclass, C++ object, opaque value),
+    the ``ArraySupplement`` of Dr.Jit types, and the declared field names of
+    structs and dataclasses. Types are generally used repeatedly, hence this
+    classification happens only once per type object.
+
+    The information most relevant to the backend are the "leaf" arrays tracked
+    by Dr.Jit-Core. These are classified into
+
+    - ``Leaf``: JIT-backed Dr.Jit Python array types with ``ndim==1``
+    - ``BareLeaf``: leaf arrays discovered while traversing C++ classes
+
+    Both can potentially carry gradients, which are referenced by the same node.
+
+    The LayoutBuilder deduplicates the evaluated leaves into "slots", numbered
+    in order of first appearance. It also schedules unevaluated leaves for
+    a joint evaluation done at the end of the walk. Slots do not store sizes
+    and are instead grouped into equivalence classes (``Slot::size_class``).
+    A recording made with one set of input sizes generalizes to other sizes,
+    as long the slots within each size class still agree.
+
+    The remaining payloads live in side tables of the ``Layout``:
+
+    - ``grads``: gradients of the leaves whose gradients are enabled
+    - ``literals``: values and sizes of literal and undefined leaves, which
+      are not slots and must match exactly
+    - ``names``: dictionary keys and field names
+    - ``shapes``: tensor shapes
+    - ``opaques``: opaque Python values (anything that is not traversed)
+    - ``cpp_types``: the dynamic C++ types of objects
+
+    Finally, the layout is compared to cached recordings via ``layout_equal()``.
+    This comparison is bitwise and passes over stored ``Node``, ``Slot``, and
+    ``Literal`` entries, hence it is important that these data structures do
+    not contain undefined padding bytes. If a match is found, it can be
+    replayed using the generated ``SlotBindings``.
+
+    Example: for the input ``(x, [y, y], obj)``, where ``x`` is an evaluated
+    array, ``y`` a literal, and ``obj`` a C++ object holding one array and a
+    child object that holds one array, the layout consists of these nodes:
+
+    ```
+      0  Tuple      size=3
+      1    Leaf     slot 0                    x
+      2    List     size=2
+      3      Leaf   literal                   y
+      4      Leaf   literal                   y (same value, not a slot)
+      5    Object   size=2, cpp_types[0]      obj
+      6      BareLeaf slot 1                  array held by obj
+      7      Object size=1, cpp_types[1]      child
+      8        BareLeaf slot 2                array held by child
+    ```
+
+    3. C++ objects and the registry
+    -------------------------------
+
+    C++ subclasses of ``drjit::TraversableBase`` provide a callback that makes
+    their contents visible to function freezing. Such an object produces an
+    ``Object`` node whose children are the members reported by the callback:
+    a ``BareLeaf`` per array and an ``Object`` subtree per child object.
+    ``Node::ref`` pins the polymorphic C++ type of every ``Object`` in
+    ``Layout::cpp_types``, and ``Layout::node_names`` records the name of the
+    member that each of them was reached through, which ``node_path()`` uses
+    to refer to them.
+
+    C++ types can further be subclassed in Python, where instances may hold
+    additional Dr.Jit arrays in their attributes. The attribute dictionary of
+    such an instance (see ``traversable_dict()`` in common.h) follows the C++
+    members as one more ``Dict`` child, and the Python type is recorded in
+    the type table. A plain nanobind wrapper contributes nothing, so binding
+    a C++ object to Python does not change its description.
+
+    Objects and mutable containers are tracked by identity (C++ or Python
+    pointer). A repeat encounter becomes a ``RecursiveRef`` node that points
+    to the first visit, which deduplicates shared objects and terminates
+    reference cycles.
+
+    Dr.Jit pointer arrays (e.g., ``JitArray<T*>``) refer to objects through
+    the registry, and the callable may reach these objects implicitly. The
+    builder therefore appends a ``Registry`` node after the root, whose
+    children are the live registry entries of every domain associated with
+    pointer arrays seen in the input. Each entry is described like any other
+    object (or by a ``RecursiveRef``).
+
+    4. Recording: describing the result and the modified inputs
+    -----------------------------------------------------------
+
+    A replay must reproduce the variables making up the function result, and
+    inputs modified in place (e.g., ``x += 1`` on an argument or an updated
+    member of a C++ object). ``build_output_layout()`` describes the result
+    and the input as it looks after the call in one ``Layout``, as two
+    consecutive DFS trees: the nodes before ``Layout::input_begin`` describe
+    the result, and the nodes from ``input_begin`` on describe the input
+    (including the registry).
+
+    ``plan_outputs()`` then compares the input part of this layout against
+    the input layout, position by position. The function may assign new
+    arrays to the leaves of its input, but it must not change anything else
+    about it (the entries of containers, dictionary keys, tensor shapes, the
+    Python values it holds, ...), since a replay cannot reproduce such a
+    change. ``plan_outputs()`` raises when it finds one. Leaves whose
+    variable changed, and AD leaves whose gradient edges were postponed by
+    the isolated gradient scope (``Postponed``), are flagged ``Dirty`` and
+    their ancestors ``DirtySubtree``. The slots that a replay must produce,
+    namely everything in the result and the dirty input leaves, receive output
+    positions (``slot_output``, ``n_outputs``), and the corresponding
+    variables are registered as outputs of the backend recording. The common
+    case of a large input that the function reads but does not modify costs
+    nothing on replay.
+
+    5. Replay: constructing the result and updating the input
+    ---------------------------------------------------------
+
+    ``jit_freeze_replay()`` returns one variable per output position.
+    ``construct_output()`` rebuilds the result from the output layout, and
+    ``update_input()`` walks the input part of the output layout in
+    lockstep with the live input and assigns the dirty leaves, skipping
+    subtrees without the ``DirtySubtree`` flag. Both functions also run once
+    right after recording, so that errors surface when recording rather than
+    when replaying.
+
+    6. Auto-opaque literals
+    -----------------------
+
+    A literal whose value differs between calls would force a new recording
+    every time. With ``auto_opaque`` enabled, the builder compares each
+    literal against the layout of the previous recording (``prev``) at the
+    same node position and makes it opaque (``jit_var_schedule_force()``)
+    when the value changed. It then becomes an ordinary slot flagged
+    ``ForceOpaque``. A build also reads this flag from ``prev``, so forced
+    positions accumulate across recordings, and the verifier makes a literal
+    arriving at such a position opaque as well. Either walker writes the
+    opaque variable into the Python array or C++ object right away, which is
+    safe even if the walk fails later on, since the variable holds the same
+    contents as the literal.
+*/
+
+#pragma once
+
+#include "common.h"
+#include <drjit-core/hash.h>
+#include <drjit-core/jit.h>
+#include <drjit/autodiff.h>
+#include <drjit/python.h>
+#include <drjit/traversable_base.h>
+#include <memory>
+#include <string>
+#include <tsl/robin_set.h>
+#include <typeinfo>
+
+/// Classification of a Python type in a layout
+enum class TypeClass : uint8_t {
+    /// JIT-backed Dr.Jit array variable with ``ndim == 1``
+    Leaf,
+
+    /// JIT variable without a Python object, emitted by a C++ object's
+    /// traversal callback
+    BareLeaf,
+
+    /// Dr.Jit tensor
+    Tensor,
+
+    /// Dr.Jit array with ``ndim > 1``, or one that is not backed by the JIT
+    /// compiler. Its entries are described individually, which means that a
+    /// scalar array is captured by value just like a Python ``float``.
+    Nested,
+
+    /// Python sequence types
+    Tuple,
+    List,
+    Dict,
+
+    /// Class with a ``DRJIT_STRUCT`` annotation
+    Struct,
+
+    /// A standard Python ``dataclass``
+    Dataclass,
+
+    /// A C++ object deriving from ``drjit::TraversableBase``
+    Object,
+
+    /// Any other Python object, captured by value
+    Opaque,
+
+    /// The registry pseudo-node appended after the root of the input
+    Registry
+};
+
+/// Per-node flags
+enum class NodeFlag : uint8_t {
+    /// The node refers to an object that appeared earlier (``ref`` is the
+    /// index of the node where it was first visited)
+    RecursiveRef = 1 << 0,
+
+    /// The variable is a literal or undefined (``ref`` indexes
+    /// ``Layout::literals``)
+    Literal      = 1 << 1,
+
+    /// Leaf with enabled gradients, whose gradient is described by the
+    /// entry of ``Layout::grads`` that ``Node::grad`` refers to
+    GradEnabled  = 1 << 2,
+
+    /// Evaluated leaf whose input may arrive as a literal that must be made
+    /// opaque (see the ``auto_opaque`` feature)
+    ForceOpaque  = 1 << 3,
+
+    /// AD leaf of the input whose gradient edges were postponed by the
+    /// isolated gradient scope of the frozen function. Writing it back
+    /// enqueues it for backward propagation.
+    Postponed    = 1 << 4,
+
+    /// Leaf of the input that the function modified and that must be
+    /// written back after a replay
+    Dirty        = 1 << 5,
+
+    /// Node whose subtree contains a dirty leaf
+    DirtySubtree = 1 << 6
+};
+
+/// The Layout builder generates one Node per PyTree element in DFS order.
+/// Subtrees always form a contiguous range delimited by ``Node::next``. The
+/// gradient of an AD leaf is a further ``BareLeaf`` node in ``Layout::grads``
+/// that only uses the fields describing a variable (``flags``, ``vt``,
+/// ``ref``).
+struct Node {
+    /// Index into ``Layout::types``
+    uint16_t type_id = 0;
+
+    /// Combination of ``NodeFlag`` values
+    uint8_t flags = 0;
+
+    /// Variable type of leaves (see \ref VarType)
+    uint8_t vt = 0;
+
+    /// Index of the next sibling, i.e. the end of this node's subtree
+    uint32_t next = 0;
+
+    union {
+        /// Number of children (leaves have none)
+        uint32_t size = 0;
+
+        /// Index of the gradient in ``Layout::grads`` (``GradEnabled`` leaves)
+        uint32_t grad;
+    };
+
+    /// Payload, whose meaning depends on the node:
+    ///
+    /// - evaluated leaf: slot index
+    /// - literal/undefined leaf: index into ``Layout::literals``
+    /// - dict: offset of the keys in ``Layout::names``
+    /// - tensor: offset of the shape in ``Layout::shapes``
+    /// - opaque value: index into ``Layout::opaques``
+    /// - object: index into ``Layout::cpp_types``
+    /// - recursive reference: index of the node first describing the object
+    uint32_t ref = 0;
+
+    bool has(NodeFlag f) const { return (flags & (uint8_t) f) != 0; }
+    void set(NodeFlag f) { flags |= (uint8_t) f; }
+};
+
+static_assert(sizeof(Node) == 16);
+
+/// Information about a Python type referenced by the layout
+struct TypeInfo {
+    /// The Python type, invalid for the fixed entries without a Python type
+    /// (``BareLeaf``, ``Registry``, and C++ objects without a Python side)
+    nb::object tp;
+
+    /// Classification of the type, which selects the code path of the walkers
+    TypeClass cls = TypeClass::Opaque;
+
+    /// Array supplement of Dr.Jit types
+    const ArraySupplement *supp = nullptr;
+
+    /// Offset of the declared field names of Struct/Dataclass types in
+    /// ``Layout::names``
+    uint32_t name_ref = 0;
+
+    /// Number of declared field names
+    uint32_t size = 0;
+};
+
+/// Information about a deduplicated input variable
+struct Slot {
+    /// Variable type (see \ref VarType)
+    uint8_t vt = 0;
+
+    /// Set when the variable has exactly one entry
+    bool singleton = false;
+
+    /// Set when the variable's storage is unaligned
+    bool unaligned = false;
+
+    /// Explicit padding, so that slots can be compared bytewise
+    uint8_t unused = 0;
+
+    /// Index of the size equivalence class
+    uint32_t size_class = 0;
+};
+
+static_assert(sizeof(Slot) == 8);
+
+/// Information about a literal or undefined leaf
+struct Literal {
+    /// Literal value (zero for undefined variables)
+    uint64_t value = 0;
+
+    /// Number of entries
+    uint32_t size = 0;
+
+    /// Set for undefined variables (a full word keeps the struct padding-free)
+    uint32_t undefined = 0;
+};
+
+static_assert(sizeof(Literal) == 16);
+
+/// Layout descriptor of a frozen function's input or output
+struct Layout {
+    /// Nodes of the PyTree in DFS order
+    drjit::vector<Node> nodes;
+
+    /// Name of the C++ member that each node was reached through, parallel to
+    /// ``nodes`` and empty for everything else. The entries are the
+    /// compile-time strings of \ref DR_TRAVERSE_CB and are used by
+    /// ``node_path()``, hence they take no part in ``layout_equal()``.
+    drjit::vector<const char *> node_names;
+
+    /// Classification of the Python types referenced by ``nodes``
+    drjit::vector<TypeInfo> types;
+
+    /// Deduplicated list of leaf arrays
+    drjit::vector<Slot> slots;
+
+    /// Gradients of the leaves flagged ``GradEnabled``
+    drjit::vector<Node> grads;
+
+    /// Values and sizes of literal and undefined leaves
+    drjit::vector<Literal> literals;
+
+    /// Tensor shapes, each stored as the rank followed by all entries except
+    /// the first (which follows from the size of the underlying array)
+    drjit::vector<uint32_t> shapes;
+
+    /// Dictionary keys and field names
+    drjit::vector<nb::object> names;
+
+    /// Opaque values captured by equality
+    drjit::vector<nb::object> opaques;
+
+    /// Dynamic C++ types of the objects in the input
+    drjit::vector<const std::type_info *> cpp_types;
+
+    /// Number of size equivalence classes (see ``Slot::size_class``)
+    uint32_t n_size_classes = 0;
+
+    /// JIT flags in effect when the recording was made
+    uint32_t jit_flags = 0;
+
+    /// Backend of the input variables
+    JitBackend backend = JitBackend::None;
+
+    /// Variant and domains of class arrays, traversed via the registry
+    std::string variant;
+    drjit::vector<std::string> domains;
+
+    /// Names of the positional parameters of the frozen function, which
+    /// ``node_path()`` uses to refer to an input by name
+    nb::tuple arg_names;
+
+    /// Node index of the root of the input. This is zero for an input
+    /// layout. An output layout describes the function result first, and the
+    /// input follows at this index.
+    uint32_t input_begin = 0;
+
+    // =====================================================================
+    //  Fields used by the output layout of a recording only
+    // =====================================================================
+
+    /// Number of variables that the recording returns on replay
+    uint32_t n_outputs = 0;
+
+    /// Maps each slot to its position among the recording's outputs, or
+    /// ``NoOutput`` for an unmodified input that is not returned
+    drjit::vector<uint32_t> slot_output;
+
+    /// Entry of ``slot_output`` for slots that a replay does not produce
+    static constexpr uint32_t NoOutput = (uint32_t) -1;
+
+    Layout();
+    Layout(const Layout &) = delete;
+    Layout &operator=(const Layout &) = delete;
+    Layout(Layout &&) = default;
+    Layout &operator=(Layout &&) = default;
+
+    /// Visit the Python references held by this layout (GC support)
+    int tp_traverse(visitproc visit, void *arg) const;
+
+    /// Render a human-readable path to a node for diagnostics
+    std::string node_path(uint32_t node) const;
+};
+
+/// Variables bound to the slots of a layout. Both the builder and the
+/// verifier produce this structure, and recording and replay consume it.
+struct SlotBindings {
+    /// JIT index bound to each slot
+    drjit::vector<uint32_t> indices;
+
+    /// Owning references that keep the bindings alive until the call is
+    /// done: inputs held while recording, gradients returned by ``ad_grad()``
+    /// and variables created by making literals opaque
+    drjit::detail::index32_vector owned;
+
+    /// Attribute values read during the walk. A property may have produced
+    /// an array that nothing else references, so they are kept alive until
+    /// the bound variables have been used.
+    drjit::vector<nb::object> keep_alive;
+
+    void release();
+};
+
+/// Working memory of \ref verify_layout(), reused across calls
+struct VerifierScratch {
+    /// Identity of the object observed at each node, used to verify
+    /// recursive references
+    drjit::vector<const void *> node_obj;
+
+    /// JIT variable observed in the input for each slot. It differs from the
+    /// bound variable when a literal was made opaque.
+    drjit::vector<uint32_t> slot_source;
+
+    /// Size observed for each size class, or ``Unbound``
+    drjit::vector<uint32_t> class_size;
+
+    /// Slots bound to unevaluated variables. Their state and alignment are
+    /// checked after ``jit_eval()``.
+    drjit::vector<uint32_t> scheduled;
+
+    /// Registry pointers of the current call
+    drjit::vector<void *> registry_ptrs;
+
+    /// Marks slots and size classes that the walk has not bound yet
+    static constexpr uint32_t Unbound = (uint32_t) -1;
+};
+
+/**
+ * \brief Build the layout of a frozen function input
+ *
+ * This is the slow path described in the overview. It schedules and evaluates
+ * unevaluated leaves, deduplicates them into slots, and makes literals opaque
+ * where the auto-opaque feature asks for it.
+ *
+ * \param root
+ *     The input PyTree, i.e., the tuple ``(args, kwargs, closure, state)``
+ *
+ * \param arg_names
+ *     Names of the positional parameters of the function, used to refer to
+ *     an input by name in diagnostics
+ *
+ * \param backend
+ *     Backend to assume when the input contains no JIT variables
+ *
+ * \param prev
+ *     Layout of the previous recording, or null. A literal at a position
+ *     whose node is flagged ``ForceOpaque`` in ``prev``, or where ``prev``
+ *     recorded a different literal, is made opaque.
+ *
+ * \param force_all
+ *     Make every literal opaque, regardless of ``prev``
+ *
+ * \param bindings
+ *     Released on entry, then receives the variable bound to each slot
+ */
+extern std::shared_ptr<Layout>
+build_input_layout(nb::handle root, nb::tuple arg_names, JitBackend backend,
+                   const Layout *prev, bool force_all, SlotBindings &bindings);
+
+/// Compare two layouts as cache keys
+extern bool layout_equal(const Layout &a, const Layout &b);
+
+/// Describe the first difference between two layouts, naming the input that
+/// carries it (an empty string when they agree)
+extern std::string layout_diff(const Layout &cur, const Layout &prev);
+
+/**
+ * \brief Build the output layout of a recording
+ *
+ * The returned layout describes the function result, followed by the input as
+ * it looks after the call (see section 4 of the overview). Unevaluated
+ * variables are scheduled and evaluated.
+ *
+ * \param output
+ *     The value returned by the recorded function
+ *
+ * \param input
+ *     The input PyTree that was passed to ``build_input_layout()``
+ *
+ * \param backend
+ *     Backend of the recording
+ *
+ * \param postponed
+ *     AD indices whose gradient edges were postponed by the isolated gradient
+ *     scope of the call. Their leaves are flagged ``Postponed``.
+ *
+ * \param bindings
+ *     Receives the variable bound to each slot
+ */
+extern Layout
+build_output_layout(nb::handle output, nb::handle input, nb::tuple arg_names,
+                    JitBackend backend,
+                    const tsl::robin_set<uint32_t, UInt32Hasher> &postponed,
+                    SlotBindings &bindings);
+
+/**
+ * \brief Determine which input leaves the recorded function modified
+ *
+ * Compares the input part of ``out`` against ``in``, flags modified leaves
+ * ``Dirty`` and their ancestors ``DirtySubtree``, and assigns output
+ * positions to the slots that a replay must produce (``slot_output``,
+ * ``n_outputs``). Returns the variables that the backend recording must
+ * return, in output order. Raises if the function changed anything but the
+ * variables of its input (see section 4 of the overview).
+ *
+ * \param out
+ *     Output layout of the recording, as returned by ``build_output_layout()``
+ *
+ * \param out_bindings
+ *     Variable bound to each slot of ``out``
+ *
+ * \param in
+ *     Input layout of the recording
+ *
+ * \param in_bindings
+ *     Variable bound to each slot of ``in``
+ */
+extern drjit::vector<uint32_t>
+plan_outputs(Layout &out, const uint32_t *out_bindings, const Layout &in,
+             const uint32_t *in_bindings);
+
+/**
+ * \brief Construct the result of a frozen function from its output layout
+ *
+ * ``values`` holds the variables returned by the replay (or recorded), in
+ * output order. The returned references are borrowed by the constructed
+ * objects.
+ */
+extern nb::object construct_output(const Layout &out, const uint32_t *values);
+
+/**
+ * \brief Update the input PyTree with the leaves that the function modified
+ *
+ * Walks the input part of the output layout in lockstep with the live input
+ * and assigns the variables of dirty leaves from ``values``. Clean subtrees
+ * are skipped.
+ */
+extern void update_input(const Layout &out, nb::handle input,
+                         const uint32_t *values);
+
+/**
+ * \brief Verify an input against a layout and bind its slots
+ *
+ * Returns ``true`` if the input matches, in which case ``bindings.indices``
+ * holds the JIT index of every slot. Variables that were not yet evaluated
+ * are scheduled and evaluated as part of the check. On a mismatch the
+ * bindings are released and ``false`` is returned. A mismatch at the level
+ * of the recording (a different recording must be looked up or made) is not
+ * an error.
+ */
+extern bool verify_layout(const Layout &layout, nb::handle root,
+                          VerifierScratch &scratch, SlotBindings &bindings);
+
+// =====================================================================
+//  Helpers shared by the walkers (freeze_layout.cpp, freeze_output.cpp,
+//  freeze_verify.cpp)
+// =====================================================================
+
+/// Fixed entries of the type table for nodes without a Python type
+static constexpr uint16_t BareLeafType = 0, ObjectType = 1, RegistryType = 2;
+
+/// Objects whose identity is tracked to detect aliasing and cycles
+inline bool is_tracked(TypeClass cls) {
+    switch (cls) {
+        case TypeClass::List:
+        case TypeClass::Dict:
+        case TypeClass::Struct:
+        case TypeClass::Dataclass:
+        case TypeClass::Object:
+            return true;
+        default:
+            return false;
+    }
+}
+
+/// Does this node describe a variable?
+inline bool is_leaf(const Layout &s, const Node &n) {
+    TypeClass cls = s.types[n.type_id].cls;
+    return cls == TypeClass::Leaf || cls == TypeClass::BareLeaf;
+}
+
+/// Dynamic type of a C++ object
+inline const std::type_info *cpp_type(const drjit::TraversableBase *obj) {
+    return &typeid(*obj);
+}
+
+inline bool same_cpp_type(const std::type_info *a, const std::type_info *b) {
+    return a == b || *a == *b;
+}
+
+/// C++ object wrapped by the Python object ``h`` (a ``TraversableBase`` subtype)
+inline drjit::TraversableBase *object_ptr(nb::handle h) {
+    drjit::TraversableBase *obj = traversable_ptr(h);
+    if (!obj)
+        nb::raise("the C++ object of type %s is not initialized (was the base "
+                  "class constructor called?)", nb::inst_name(h).c_str());
+    return obj;
+}
+
+/// Identity under which the object at a node is tracked: the C++ pointer of
+/// objects (shared with the C++ reached path), the PyObject pointer otherwise
+inline const void *node_identity(nb::handle h, TypeClass cls) {
+    if (cls == TypeClass::Object)
+        return object_ptr(h);
+    return h.ptr();
+}
+
+/// Compare everything two nodes record about their objects and return the
+/// reason for a difference, or an empty string. ``a_base`` is subtracted from
+/// recursive references of ``a``. The state of the variable at a leaf (type,
+/// literal value, gradients, size class) is only compared when
+/// ``leaf_state`` is set.
+extern std::string node_difference(const Layout &a, uint32_t j,
+                                   const Layout &b, uint32_t k,
+                                   uint32_t a_base = 0,
+                                   bool leaf_state = false);
+
+/// Collect the registry pointers of all domains referenced by a layout
+extern void registry_pointers(const Layout &s, drjit::vector<void *> &pointers);
+
+/// Run the traversal callback of a C++ object and return the number of
+/// reported members. ``on_var(index, name, variant, domain)`` returns an
+/// owning replacement index (kept alive until the walk returns) or zero.
+template <typename Var, typename Child>
+uint32_t traverse_members(drjit::TraversableBase *obj, Var &&on_var,
+                          Child &&on_child) {
+    struct Payload {
+        Var &on_var;
+        Child &on_child;
+        drjit::detail::index64_vector owned;
+        uint32_t count;
+    } p { on_var, on_child, {}, 0 };
+
+    for_each_member(
+        obj, drjit::TraverseRole::Freeze,
+        [&p](uint64_t index, const char *name, const char *variant,
+             const char *domain) -> uint64_t {
+            if (!index)
+                return index;
+            p.count++;
+            uint64_t result = p.on_var(index, name, variant, domain);
+            if (!result)
+                return index;
+            p.owned.push_back_steal(result);
+            return result;
+        },
+        [&p](drjit::TraversableBase *child, const char *name) {
+            p.count++;
+            p.on_child(child, name);
+        });
+
+    return p.count;
+}
+
+/// Replace the gradient of the AD variable ``index`` by ``grad`` (resized if literal)
+extern void attach_grad(uint64_t index, uint32_t grad);
+
+/// Owning AD index combining ``ad_index`` with a new value (and gradient)
+inline uint64_t make_ad_index(uint32_t ad_index, uint32_t value,
+                              bool grad_enabled, uint32_t grad) {
+    uint64_t index = ((uint64_t) ad_index << 32) | (uint64_t) value;
+    ad_var_inc_ref(index);
+    if (grad_enabled)
+        attach_grad(index, grad);
+    return index;
+}
+
+/// Shared recursion limit of the walkers
+struct recursion_guard {
+    uint32_t &depth;
+    recursion_guard(uint32_t &depth) : depth(depth) {
+        if (depth >= 50) {
+            PyErr_SetString(PyExc_RecursionError,
+                            "runaway recursion detected");
+            nb::raise_python_error();
+        }
+        depth++;
+    }
+    ~recursion_guard() { depth--; }
+};

--- a/src/python/freeze_output.cpp
+++ b/src/python/freeze_output.cpp
@@ -1,0 +1,449 @@
+/*
+    freeze_output.cpp -- Output planning, result construction and input
+    write-back of frozen functions
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include "freeze_layout.h"
+
+/// Is one variable held by a leaf still bound to the same value?
+static bool var_equal(const Layout &out, const Node &a, const uint32_t *out_bindings,
+                      const Layout &in,  const Node &b, const uint32_t *in_bindings) {
+    bool literal = a.has(NodeFlag::Literal);
+    if (a.vt != b.vt || literal != b.has(NodeFlag::Literal))
+        return false;
+    if (literal)
+        return memcmp(&out.literals[a.ref], &in.literals[b.ref], sizeof(Literal)) == 0;
+    return out_bindings[a.ref] == in_bindings[b.ref];
+}
+
+drjit::vector<uint32_t> plan_outputs(Layout &out, const uint32_t *out_bindings,
+                                     const Layout &in,
+                                     const uint32_t *in_bindings) {
+    ProfilerPhase profile("plan_outputs()");
+
+    uint32_t begin = out.input_begin, end = (uint32_t) out.nodes.size(),
+             n_in = (uint32_t) in.nodes.size();
+
+    // Walk the input part of the output layout and the input layout in
+    // lockstep, flagging the leaves whose variable changed. A leaf may gain or
+    // lose its gradient (an AD leaf is written back as a whole, so value and
+    // gradient share the flag). Everything else must match.
+    uint32_t j = begin, k = 0;
+    for (; j < end && k < n_in; ++j, ++k) {
+        Node &a = out.nodes[j];
+        const Node &b = in.nodes[k];
+
+        std::string diff = node_difference(out, j, in, k, begin);
+        if (!diff.empty()) {
+            if (out.types[a.type_id].cls == TypeClass::Registry)
+                nb::raise("the function registered or unregistered instances "
+                          "of a class that its input refers to through "
+                          "pointer arrays, which a replay cannot reproduce.");
+            nb::raise("the function changed its input at %s (%s). A frozen "
+                      "function may assign new arrays to its input, but it "
+                      "must not change the structure of the input or the "
+                      "Python values it holds, since a replay cannot "
+                      "reproduce such a change.",
+                      out.node_path(j).c_str(), diff.c_str());
+        }
+
+        if (!is_leaf(out, a))
+            continue;
+
+        bool grad_a = a.has(NodeFlag::GradEnabled),
+             grad_b = b.has(NodeFlag::GradEnabled);
+        if (a.has(NodeFlag::Postponed) || grad_a != grad_b ||
+            !var_equal(out, a, out_bindings, in, b, in_bindings) ||
+            (grad_a && grad_b &&
+             !var_equal(out, out.grads[a.grad], out_bindings, in,
+                        in.grads[b.grad], in_bindings)))
+            a.set(NodeFlag::Dirty);
+    }
+
+    if (j != end || k != n_in)
+        nb::raise("freeze(): internal error, the input layouts are not "
+                  "isomorphic.");
+
+    // Propagate to the ancestors
+    drjit::vector<uint32_t> stack;
+    for (uint32_t j = begin; j < end; ++j) {
+        while (!stack.empty() && out.nodes[stack.back()].next <= j)
+            stack.pop_back();
+        if (out.nodes[j].has(NodeFlag::Dirty)) {
+            out.nodes[j].set(NodeFlag::DirtySubtree);
+            for (uint32_t a : stack)
+                out.nodes[a].set(NodeFlag::DirtySubtree);
+        }
+        if (out.nodes[j].next > j + 1)
+            stack.push_back(j);
+    }
+
+    // Assign output positions: every slot of the result, and every dirty slot
+    // of the input
+    out.slot_output.clear();
+    out.slot_output.resize(out.slots.size(), Layout::NoOutput);
+    out.n_outputs = 0;
+    drjit::vector<uint32_t> outputs;
+
+    auto assign = [&](const Node &v) {
+        if (v.has(NodeFlag::Literal))
+            return;
+        uint32_t slot = v.ref;
+        if (out.slot_output[slot] == Layout::NoOutput) {
+            out.slot_output[slot] = out.n_outputs++;
+            outputs.push_back(out_bindings[slot]);
+        }
+    };
+
+    for (uint32_t j = 0; j < end; ++j) {
+        const Node &n = out.nodes[j];
+        if (!is_leaf(out, n))
+            continue;
+        if (j >= begin && !n.has(NodeFlag::Dirty))
+            continue;
+        assign(n);
+        if (n.has(NodeFlag::GradEnabled))
+            assign(out.grads[n.grad]);
+    }
+
+    return outputs;
+}
+
+namespace {
+
+/// Shared leaf logic of the output constructor and the input write-back
+struct OutputWalker {
+    const Layout &s;
+    const uint32_t *values;
+
+    /// Cursor into ``s.nodes``
+    uint32_t cur = 0;
+
+    OutputWalker(const Layout &s, const uint32_t *values, uint32_t cur)
+        : s(s), values(values), cur(cur) { }
+
+    /// Owning reference to one variable held by a leaf. Literal and undefined
+    /// variables are recreated from the layout, the others are outputs of
+    /// the replay.
+    uint32_t var_value(const Node &v) {
+        if (v.has(NodeFlag::Literal)) {
+            const Literal &l = s.literals[v.ref];
+            if (l.undefined)
+                return jit_var_undefined(s.backend, (VarType) v.vt, l.size);
+            return jit_var_literal(s.backend, (VarType) v.vt, &l.value, l.size);
+        }
+
+        uint32_t pos = s.slot_output[v.ref];
+        if (pos == Layout::NoOutput)
+            jit_raise("freeze(): internal error, no output recorded for "
+                      "slot %u.", v.ref);
+        return jit_var_inc_ref(values[pos]);
+    }
+
+    /**
+     * Owning combined index for the leaf at ``node``. ``prev`` is the current
+     * index of the array that receives the value, or zero when constructing a
+     * new one.
+     */
+    uint64_t leaf_index(uint32_t node, uint64_t prev) {
+        const Node &n = s.nodes[node];
+        uint32_t value = var_value(n);
+
+        if (!n.has(NodeFlag::GradEnabled))
+            return value;
+
+        uint32_t grad = var_value(s.grads[n.grad]);
+        uint32_t ad_index = (uint32_t) (prev >> 32);
+        uint64_t index;
+        if (ad_index) {
+            index = ((uint64_t) ad_index << 32) | value;
+            ad_var_inc_ref(index);
+        } else {
+            index = ad_var_new(value);
+        }
+        jit_var_dec_ref(value);
+
+        attach_grad(index, grad);
+        jit_var_dec_ref(grad);
+
+        if (ad_index && n.has(NodeFlag::Postponed))
+            ad_enqueue(drjit::ADMode::Backward, index);
+
+        return index;
+    }
+};
+
+/// Constructs the result of a frozen function
+struct OutputConstructor : OutputWalker {
+    /// Objects constructed so far, to resolve recursive references
+    drjit::vector<nb::object> node_obj;
+
+    OutputConstructor(const Layout &s, const uint32_t *values)
+        : OutputWalker(s, values, 0) {
+        node_obj.resize(s.input_begin);
+    }
+
+    nb::object visit() {
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+        const TypeInfo &ti = s.types[n.type_id];
+        nb::handle tp = ti.tp;
+
+        if (n.has(NodeFlag::RecursiveRef)) {
+            if (!node_obj[n.ref].is_valid())
+                nb::raise("cannot construct an output that refers to an "
+                          "object which is not constructible.");
+            return node_obj[n.ref];
+        }
+
+        nb::object result;
+        switch (ti.cls) {
+            case TypeClass::Leaf: {
+                uint64_t index = leaf_index(node, 0);
+                result = nb::inst_alloc(tp);
+                ti.supp->init_index(index, inst_ptr(result));
+                nb::inst_mark_ready(result);
+                ad_var_dec_ref(index);
+                break;
+            }
+
+            case TypeClass::Tensor: {
+                nb::object array = visit();
+                const uint32_t *rec = s.shapes.data() + n.ref;
+                uint32_t rank = rec[0];
+                nb::tuple_builder shape(rank);
+                if (rank > 0) {
+                    // The first dimension follows from the size of the array
+                    size_t inner = 1;
+                    for (uint32_t i = 1; i < rank; ++i)
+                        inner *= rec[i];
+                    size_t width = nb::len(array);
+                    shape.put(nb::int_(inner > 0 ? width / inner : 0));
+                    for (uint32_t i = 1; i < rank; ++i)
+                        shape.put(nb::int_(rec[i]));
+                }
+                result = tp(array, shape.commit());
+                break;
+            }
+
+            case TypeClass::Nested: {
+                result = nb::inst_alloc_zero(tp);
+                dr::ArrayBase *p = inst_ptr(result);
+                if (ti.supp->shape[0] == DRJIT_DYNAMIC)
+                    ti.supp->init(n.size, p);
+                for (uint32_t i = 0; i < n.size; ++i)
+                    result[i] = visit();
+                nb::inst_mark_ready(result);
+                break;
+            }
+
+            case TypeClass::Tuple: {
+                nb::tuple_builder tb(n.size);
+                for (uint32_t i = 0; i < n.size; ++i)
+                    tb.put(visit());
+                nb::tuple t = tb.commit();
+                result = tp.is(&PyTuple_Type) ? std::move(t) : tp(*t);
+                break;
+            }
+
+            case TypeClass::List: {
+                nb::list_builder lb(n.size);
+                for (uint32_t i = 0; i < n.size; ++i)
+                    lb.put(visit());
+                nb::list l = lb.commit();
+                result = tp.is(&PyList_Type) ? std::move(l) : tp(l);
+                break;
+            }
+
+            case TypeClass::Dict: {
+                result = tp.is(&PyDict_Type) ? nb::dict() : tp();
+                for (uint32_t i = 0; i < n.size; ++i) {
+                    nb::handle key = s.names[n.ref + i];
+                    result[key] = visit();
+                }
+                break;
+            }
+
+            case TypeClass::Struct: {
+                result = tp();
+                for (uint32_t i = 0; i < ti.size; ++i) {
+                    nb::handle name = s.names[ti.name_ref + i];
+                    nb::setattr(result, name, visit());
+                }
+                break;
+            }
+
+            case TypeClass::Dataclass: {
+                nb::dict kwargs;
+                for (uint32_t i = 0; i < ti.size; ++i) {
+                    nb::handle name = s.names[ti.name_ref + i];
+                    kwargs[name] = visit();
+                }
+                result = tp(**kwargs);
+                break;
+            }
+
+            case TypeClass::Opaque:
+                result = nb::borrow(s.opaques[n.ref]);
+                break;
+
+            default:
+                nb::raise("the output contains a value of type %s that "
+                          "cannot be constructed when replaying.",
+                          tp.is_valid() ? nb::type_name(tp).c_str()
+                                        : "(C++ object)");
+        }
+
+        if (is_tracked(ti.cls))
+            node_obj[node] = result;
+
+        return result;
+    }
+};
+
+// Writes the dirty leaves of the output back into an input with known layout.
+struct InputUpdater : OutputWalker {
+    uint32_t depth = 0;
+
+    InputUpdater(const Layout &s, const uint32_t *values)
+        : OutputWalker(s, values, s.input_begin) { }
+
+    void assign_leaf(uint32_t node, nb::handle h, const ArraySupplement *supp_) {
+        uint64_t prev  = supp_->index(inst_ptr(h));
+        uint64_t index = leaf_index(node, prev);
+        supp_->reset_index(index, inst_ptr(h));
+        ad_var_dec_ref(index);
+    }
+
+    void visit_object(uint32_t node, drjit::TraversableBase *obj) {
+        const Node &n = s.nodes[node];
+
+        traverse_members(
+            obj,
+            [&](uint64_t index, const char *, const char *,
+                const char *) -> uint64_t {
+                uint32_t ln = cur++;
+                if (s.nodes[ln].has(NodeFlag::Dirty))
+                    return leaf_index(ln, index);
+                return 0;
+            },
+            [&](drjit::TraversableBase *child, const char *) {
+                visit_cpp(child);
+            });
+
+        if (nb::dict d = traversable_dict(obj); d.is_valid())
+            visit(d);
+
+        if (cur != n.next)
+            jit_raise("freeze(): internal error, the members of a C++ object "
+                      "changed while the input was written back.");
+    }
+
+    void visit_cpp(drjit::TraversableBase *obj) {
+        recursion_guard guard(depth);
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+        if (!n.has(NodeFlag::DirtySubtree)) {
+            cur = n.next;
+            return;
+        }
+        visit_object(node, obj);
+    }
+
+    /// Write the dirty leaves below ``h`` back
+    void visit(nb::handle h) {
+        recursion_guard guard(depth);
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+        const TypeInfo &ti = s.types[n.type_id];
+
+        if (!n.has(NodeFlag::DirtySubtree)) {
+            cur = n.next;
+            return;
+        }
+
+        switch (ti.cls) {
+            case TypeClass::Leaf:
+                assign_leaf(node, h, ti.supp);
+                break;
+
+            case TypeClass::Tensor:
+                visit(nb::steal(ti.supp->tensor_array(h.ptr())));
+                break;
+
+            case TypeClass::Nested:
+                for (uint32_t i = 0; i < n.size; ++i)
+                    visit(nb::steal(ti.supp->item(h.ptr(), (Py_ssize_t) i)));
+                break;
+
+            case TypeClass::Tuple:
+                for (uint32_t i = 0; i < n.size; ++i)
+                    visit(NB_TUPLE_GET_ITEM(h.ptr(), (Py_ssize_t) i));
+                break;
+
+            case TypeClass::List:
+                for (uint32_t i = 0; i < n.size; ++i)
+                    visit(NB_LIST_GET_ITEM(h.ptr(), (Py_ssize_t) i));
+                break;
+
+            case TypeClass::Dict:
+                for (auto [k, v] : nb::borrow<nb::dict>(h))
+                    visit(v);
+                break;
+
+            case TypeClass::Struct:
+            case TypeClass::Dataclass:
+                for (uint32_t i = 0; i < ti.size; ++i)
+                    visit(nb::getattr(h, s.names[ti.name_ref + i]));
+                break;
+
+            case TypeClass::Object:
+                visit_object(node, object_ptr(h));
+                break;
+
+            default:
+                nb::raise("freeze(): internal error, unexpected node while "
+                          "writing the input back.");
+        }
+    }
+
+    void visit_registry() {
+        if (s.domains.empty())
+            return;
+
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+        if (!n.has(NodeFlag::DirtySubtree)) {
+            cur = n.next;
+            return;
+        }
+
+        drjit::vector<void *> pointers;
+        registry_pointers(s, pointers);
+        for (void *ptr : pointers)
+            if (ptr)
+                visit_cpp((drjit::TraversableBase *) ptr);
+    }
+};
+
+} // namespace
+
+nb::object construct_output(const Layout &out, const uint32_t *values) {
+    ProfilerPhase profile("construct_output()");
+    OutputConstructor c(out, values);
+    return c.visit();
+}
+
+void update_input(const Layout &out, nb::handle input,
+                  const uint32_t *values) {
+    ProfilerPhase profile("update_input()");
+    InputUpdater u(out, values);
+    u.visit(input);
+    u.visit_registry();
+}

--- a/src/python/freeze_output.cpp
+++ b/src/python/freeze_output.cpp
@@ -34,23 +34,19 @@ drjit::vector<uint32_t> plan_outputs(Layout &out, const uint32_t *out_bindings,
     // lockstep, flagging the leaves whose variable changed. A leaf may gain or
     // lose its gradient (an AD leaf is written back as a whole, so value and
     // gradient share the flag). Everything else must match.
-    uint32_t j = begin, k = 0;
-    for (; j < end && k < n_in; ++j, ++k) {
-        Node &a = out.nodes[j];
-        const Node &b = in.nodes[k];
+    uint32_t ji = begin, ki = 0;
+    for (; ji < end && ki < n_in; ++ji, ++ki) {
+        Node &a = out.nodes[ji];
+        const Node &b = in.nodes[ki];
 
-        std::string diff = node_difference(out, j, in, k, begin);
+        std::string diff = node_difference(out, ji, in, ki, begin);
         if (!diff.empty()) {
             if (out.types[a.type_id].cls == TypeClass::Registry)
-                nb::raise("the function registered or unregistered instances "
-                          "of a class that its input refers to through "
-                          "pointer arrays, which a replay cannot reproduce.");
-            nb::raise("the function changed its input at %s (%s). A frozen "
-                      "function may assign new arrays to its input, but it "
-                      "must not change the structure of the input or the "
-                      "Python values it holds, since a replay cannot "
-                      "reproduce such a change.",
-                      out.node_path(j).c_str(), diff.c_str());
+                throw InputChanged(
+                    "the function registered or unregistered instances of a "
+                    "class that its input refers to through pointer arrays");
+            throw InputChanged("the function changed its input at " +
+                               out.node_path(ji) + " (" + diff + ")");
         }
 
         if (!is_leaf(out, a))
@@ -66,8 +62,8 @@ drjit::vector<uint32_t> plan_outputs(Layout &out, const uint32_t *out_bindings,
             a.set(NodeFlag::Dirty);
     }
 
-    if (j != end || k != n_in)
-        nb::raise("freeze(): internal error, the input layouts are not "
+    if (ji != end || ki != n_in)
+        nb::raise("drjit.freeze(): internal error, the input layouts are not "
                   "isomorphic.");
 
     // Propagate to the ancestors
@@ -141,7 +137,7 @@ struct OutputWalker {
 
         uint32_t pos = s.slot_output[v.ref];
         if (pos == Layout::NoOutput)
-            jit_raise("freeze(): internal error, no output recorded for "
+            jit_raise("drjit.freeze(): internal error, no output recorded for "
                       "slot %u.", v.ref);
         return jit_var_inc_ref(values[pos]);
     }
@@ -341,7 +337,7 @@ struct InputUpdater : OutputWalker {
             visit(d);
 
         if (cur != n.next)
-            jit_raise("freeze(): internal error, the members of a C++ object "
+            jit_raise("drjit.freeze(): internal error, the members of a C++ object "
                       "changed while the input was written back.");
     }
 
@@ -408,7 +404,7 @@ struct InputUpdater : OutputWalker {
                 break;
 
             default:
-                nb::raise("freeze(): internal error, unexpected node while "
+                nb::raise("drjit.freeze(): internal error, unexpected node while "
                           "writing the input back.");
         }
     }

--- a/src/python/freeze_verify.cpp
+++ b/src/python/freeze_verify.cpp
@@ -1,0 +1,421 @@
+/*
+    freeze_verify.cpp -- quickly check an input for compatibility
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include "freeze_layout.h"
+
+namespace {
+
+/// Thrown by the verifier when the input does not match the layout. The
+/// reason is phrased so that it can be quoted in a sentence, and ``node`` is
+/// ``NoNode`` when the difference concerns the input as a whole.
+struct Mismatch {
+    uint32_t node;
+    const char *reason;
+
+    static constexpr uint32_t NoNode = (uint32_t) -1;
+};
+
+[[noreturn]] NB_NOINLINE static void mismatch(uint32_t node, const char *reason) {
+    throw Mismatch { node, reason };
+}
+
+/**
+ * Walks a PyTree in lockstep with the nodes of an existing ``Layout``, which
+ * is the fast path of a call (see freeze_layout.h). The ``visit*()`` methods
+ * mirror those of the ``LayoutBuilder``: rather than appending a node, each
+ * one compares an object against the node at the cursor ``cur`` and raises
+ * ``Mismatch`` when they disagree. ``bind_var()`` and ``bind_leaf()`` likewise
+ * check the variable of a leaf and bind it to the slot that the node records,
+ * so that a successful walk leaves the arguments of the replay in
+ * ``bindings``.
+ */
+struct LayoutVerifier {
+    const Layout &s;
+    VerifierScratch &scratch;
+    SlotBindings &bindings;
+
+    /// Cursor into ``s.nodes`` that advances in lockstep with the input
+    uint32_t cur = 0;
+
+    LayoutVerifier(const Layout &s, VerifierScratch &scratch,
+                   SlotBindings &bindings)
+        : s(s), scratch(scratch), bindings(bindings) { }
+
+    /// Check the leafe node ``n`` against variable index ``index`` and bind its
+    /// slot. Opaquing replaces ``index`` and sets ``forced=true``.
+    void bind_var(const Node &n, uint32_t node, uint32_t &index, bool &forced) {
+        VarInfo info = jit_var_info(index);
+
+        if ((uint8_t) info.type != n.vt)
+            mismatch(node, "the variable type changed");
+        if (info.backend != s.backend)
+            mismatch(node, "the backend changed");
+
+        if (n.has(NodeFlag::Literal)) {
+            const Literal &l = s.literals[n.ref];
+            bool undefined = info.state == VarState::Undefined;
+            if (info.size != l.size || (uint32_t) undefined != l.undefined ||
+                (!undefined && (info.state != VarState::Literal ||
+                                info.literal != l.value)))
+                mismatch(node, "the literal value changed");
+            return;
+        }
+
+        uint32_t source = index;
+        uint32_t slot = n.ref;
+        uint32_t &bound = bindings.indices[slot];
+        if (bound != VerifierScratch::Unbound) {
+            // The input variable must be the one seen at the first occurrence
+            if (scratch.slot_source[slot] != source)
+                mismatch(node,
+                         "two inputs no longer refer to the same variable");
+            // The first occurrence may have been made opaque
+            if (bound != source) {
+                index  = bound;
+                forced = true;
+            }
+            return;
+        }
+
+        switch (info.state) {
+            case VarState::Evaluated:
+                break;
+
+            case VarState::Literal:
+            case VarState::Undefined: {
+                if (!n.has(NodeFlag::ForceOpaque))
+                    mismatch(node, "a literal arrived where an evaluated "
+                                   "variable was recorded");
+                int rv = 0;
+                uint32_t opaque = jit_var_schedule_force(index, &rv);
+                bindings.owned.push_back(opaque);
+                index  = opaque;
+                forced = true;
+                info   = jit_var_info(index);
+                break;
+            }
+
+            default:
+                jit_var_schedule(index);
+                break;
+        }
+
+        const Slot &si = s.slots[slot];
+        if ((info.size == 1) != si.singleton)
+            mismatch(node, "the variable size changed to or from 1");
+
+        uint32_t &class_size = scratch.class_size[si.size_class];
+        if (class_size == VerifierScratch::Unbound)
+            class_size = (uint32_t) info.size;
+        else if (class_size != info.size)
+            mismatch(node, "the variable sizes are related differently");
+
+        if (info.state == VarState::Evaluated) {
+            if (info.unaligned != si.unaligned)
+                mismatch(node, "the variable alignment changed");
+        } else {
+            scratch.scheduled.push_back(slot);
+        }
+
+        bound = index;
+        scratch.slot_source[slot] = source;
+    }
+
+    /**
+     * Verify a leaf holding a (possibly AD-attached) variable and bind its
+     * slot. When a literal was made opaque, the function returns an owning
+     * combined index that the caller must store in place of ``index``, and
+     * zero otherwise.
+     */
+    uint64_t bind_leaf(uint32_t node, uint64_t index) {
+        const Node &n = s.nodes[node];
+        uint32_t ad_index = (uint32_t) (index >> 32);
+        bool grad_enabled = ad_index != 0 && ad_grad_enabled(index);
+
+        if (grad_enabled != n.has(NodeFlag::GradEnabled))
+            mismatch(node, "the gradient state changed");
+
+        uint32_t value = (uint32_t) index;
+        bool value_forced = false;
+        bind_var(n, node, value, value_forced);
+
+        uint32_t grad = 0;
+        bool grad_forced = false;
+        if (grad_enabled) {
+            grad = ad_grad(index);
+            bindings.owned.push_back(grad);
+            bind_var(s.grads[n.grad], node, grad, grad_forced);
+        }
+
+        if (value_forced || grad_forced)
+            return make_ad_index(ad_index, value, grad_enabled, grad);
+        return 0;
+    }
+
+    /// Verify the leaf held by the Python array ``h``
+    void visit_leaf(uint32_t node, nb::handle h, const ArraySupplement *supp_) {
+        uint64_t forced = bind_leaf(node, supp_->index(inst_ptr(h)));
+        if (forced) {
+            supp_->reset_index(forced, inst_ptr(h));
+            ad_var_dec_ref(forced);
+        }
+    }
+
+    /// Verify a declared field, keeping the value alive in case a property
+    /// produced it
+    void visit_field(uint32_t node, nb::handle h, nb::handle name) {
+        nb::object value = nb::getattr(h, name, nb::handle());
+        if (!value.is_valid())
+            mismatch(node, "an attribute is missing");
+        visit(value);
+        bindings.keep_alive.push_back(std::move(value));
+    }
+
+    /// Verify the members and Python attributes of a C++ object against its
+    /// node. The caller has checked the type table entry.
+    void visit_object(uint32_t node, drjit::TraversableBase *obj) {
+        const Node &n = s.nodes[node];
+
+        if (!same_cpp_type(s.cpp_types[n.ref], cpp_type(obj)))
+            mismatch(node, "the C++ type changed");
+
+        traverse_members(
+            obj,
+            [&](uint64_t index, const char *, const char *,
+                const char *) -> uint64_t {
+                uint32_t ln = cur++;
+                if (ln >= n.next || s.nodes[ln].type_id != BareLeafType)
+                    mismatch(node, "the number of members changed");
+                return bind_leaf(ln, index);
+            },
+            [&](drjit::TraversableBase *child, const char *) {
+                if (cur >= n.next)
+                    mismatch(node, "the number of members changed");
+                visit_cpp(child);
+            });
+
+        if (nb::dict d = traversable_dict(obj); d.is_valid()) {
+            if (cur >= n.next)
+                mismatch(node, "the number of members changed");
+            visit(d);
+        }
+
+        if (cur != n.next)
+            mismatch(node, "the number of members changed");
+    }
+
+    /// Verify a C++ object reached through another object or the registry
+    void visit_cpp(drjit::TraversableBase *obj) {
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+        const TypeInfo &ti = s.types[n.type_id];
+
+        if (ti.cls != TypeClass::Object)
+            mismatch(node, "a C++ object was expected here");
+
+        if (n.has(NodeFlag::RecursiveRef)) {
+            if (scratch.node_obj[n.ref] != obj)
+                mismatch(node,
+                         "the object is shared with a different part of the "
+                         "input");
+            return;
+        }
+        scratch.node_obj[node] = obj;
+
+        // A recorded Python type means that the counterpart was a Python
+        // subclass instance; a plain wrapper may come and go
+        nb::handle self = obj->self_py();
+        if (ti.tp.is_valid() &&
+            (!self.is_valid() || (PyObject *) Py_TYPE(self.ptr()) != ti.tp.ptr()))
+            mismatch(node, "the Python type of the object changed");
+
+        visit_object(node, obj);
+    }
+
+    /// Verify the Python object ``h`` against the node at the cursor
+    void visit(nb::handle h) {
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+        const TypeInfo &ti = s.types[n.type_id];
+
+        if ((PyObject *) Py_TYPE(h.ptr()) != ti.tp.ptr())
+            mismatch(node, "the Python type changed");
+
+        if (n.has(NodeFlag::RecursiveRef)) {
+            if (scratch.node_obj[n.ref] != node_identity(h, ti.cls))
+                mismatch(node,
+                         "the object is shared with a different part of the "
+                         "input");
+            return;
+        }
+
+        if (is_tracked(ti.cls))
+            scratch.node_obj[node] = node_identity(h, ti.cls);
+
+        switch (ti.cls) {
+            case TypeClass::Leaf:
+                visit_leaf(node, h, ti.supp);
+                break;
+
+            case TypeClass::Tensor: {
+                const dr::vector<size_t> &shape = ti.supp->tensor_shape(inst_ptr(h));
+                const uint32_t *rec = s.shapes.data() + n.ref;
+                if (rec[0] != (uint32_t) shape.size())
+                    mismatch(node, "the tensor shape changed");
+                for (uint32_t i = 1; i < rec[0]; ++i)
+                    if (rec[i] != shape[i])
+                        mismatch(node, "the tensor shape changed");
+                visit(nb::steal(ti.supp->tensor_array(h.ptr())));
+                break;
+            }
+
+            case TypeClass::Nested: {
+                Py_ssize_t len = ti.supp->shape[0];
+                if (len == DRJIT_DYNAMIC)
+                    len = (Py_ssize_t) ti.supp->len(inst_ptr(h));
+                if ((uint32_t) len != n.size)
+                    mismatch(node, "the number of entries changed");
+                for (Py_ssize_t i = 0; i < len; ++i)
+                    visit(nb::steal(ti.supp->item(h.ptr(), i)));
+                break;
+            }
+
+            case TypeClass::Tuple: {
+                Py_ssize_t len = NB_TUPLE_GET_SIZE(h.ptr());
+                if ((uint32_t) len != n.size)
+                    mismatch(node, "the number of entries changed");
+                for (Py_ssize_t i = 0; i < len; ++i)
+                    visit(NB_TUPLE_GET_ITEM(h.ptr(), i));
+                break;
+            }
+
+            case TypeClass::List: {
+                Py_ssize_t len = NB_LIST_GET_SIZE(h.ptr());
+                if ((uint32_t) len != n.size)
+                    mismatch(node, "the number of entries changed");
+                for (Py_ssize_t i = 0; i < len; ++i)
+                    visit(NB_LIST_GET_ITEM(h.ptr(), i));
+                break;
+            }
+
+            case TypeClass::Dict: {
+                nb::dict dict = nb::borrow<nb::dict>(h);
+                if ((uint32_t) dict.size() != n.size)
+                    mismatch(node, "the number of entries changed");
+                uint32_t i = 0;
+                for (auto [k, v] : dict) {
+                    if (!py_equal(k, s.names[n.ref + i++]))
+                        mismatch(node, "the dictionary keys changed");
+                    visit(v);
+                }
+                break;
+            }
+
+            case TypeClass::Struct:
+            case TypeClass::Dataclass:
+                for (uint32_t i = 0; i < ti.size; ++i)
+                    visit_field(node, h, s.names[ti.name_ref + i]);
+                break;
+
+            case TypeClass::Object:
+                visit_object(node, object_ptr(h));
+                break;
+
+            case TypeClass::Opaque:
+                if (!py_equal(h, s.opaques[n.ref]))
+                    mismatch(node, "the value changed");
+                break;
+
+            default:
+                mismatch(node, "the recorded node type is not supported");
+        }
+    }
+
+    /// Verify the registry entries of the recorded domains
+    void visit_registry() {
+        if (s.domains.empty())
+            return;
+
+        uint32_t node = cur++;
+        const Node &n = s.nodes[node];
+
+        drjit::vector<void *> &pointers = scratch.registry_ptrs;
+        registry_pointers(s, pointers);
+
+        uint32_t count = 0;
+        for (void *ptr : pointers) {
+            if (!ptr)
+                continue;
+            if (++count > n.size)
+                mismatch(node, "the number of registry entries changed");
+            visit_cpp((drjit::TraversableBase *) ptr);
+        }
+
+        if (count != n.size)
+            mismatch(node, "the number of registry entries changed");
+    }
+};
+
+} // namespace
+
+bool verify_layout(const Layout &s, nb::handle root,
+                   VerifierScratch &scratch, SlotBindings &bindings) {
+    ProfilerPhase profile("verify_layout()");
+    try {
+        if (s.jit_flags != jit_flags())
+            mismatch(Mismatch::NoNode, "the JIT flags changed");
+
+        scratch.node_obj.resize(s.nodes.size());
+        scratch.slot_source.resize(s.slots.size());
+        scratch.class_size.clear();
+        scratch.class_size.resize(s.n_size_classes, VerifierScratch::Unbound);
+        scratch.scheduled.clear();
+        bindings.indices.clear();
+        bindings.indices.resize(s.slots.size(), VerifierScratch::Unbound);
+
+        LayoutVerifier v(s, scratch, bindings);
+        v.visit(root);
+        v.visit_registry();
+        if (v.cur != s.nodes.size())
+            mismatch(v.cur, "the input has fewer entries than the recording");
+
+        // Flush queued evaluations and pending side effects before replay
+        {
+            state_unlock_guard guard;
+            nb::gil_scoped_release guard2;
+            jit_eval();
+        }
+
+        for (uint32_t slot : scratch.scheduled) {
+            VarInfo info = jit_var_info(bindings.indices[slot]);
+            if (info.state != VarState::Evaluated ||
+                info.unaligned != s.slots[slot].unaligned)
+                mismatch(Mismatch::NoNode,
+                         "a variable is in an unexpected state after "
+                         "evaluation");
+        }
+    } catch (const Mismatch &m) {
+        if (log_enabled(LogLevel::Info)) {
+            if (m.node == Mismatch::NoNode)
+                jit_log(LogLevel::Info,
+                        "drjit.freeze(): the input is incompatible with the "
+                        "most recently used recording (%s).", m.reason);
+            else
+                jit_log(LogLevel::Info,
+                        "drjit.freeze(): the input is incompatible with the "
+                        "most recently used recording ('%s': %s).",
+                        s.node_path(m.node).c_str(), m.reason);
+        }
+        bindings.release();
+        return false;
+    }
+
+    return true;
+}

--- a/src/python/funcenv.cpp
+++ b/src/python/funcenv.cpp
@@ -1,0 +1,284 @@
+/*
+    funcenv.cpp -- Extract the environment that a wrapped callable reads for @dr.freeze
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include "funcenv.h"
+#include <nanobind/nanobind.h>
+#include <nanobind/eval.h>
+#include <exception>
+#include <mutex>
+#include <string>
+
+/// Stand-in for a global variable not defined at call time
+static nb::handle missing_global;
+
+/// non-owning reference to ``types.CodeType``
+static nb::handle code_type;
+
+/**
+ * This class scans the bytecode of a Python function to find references to
+ * globals as identified by the ``LOAD_GLOBAL`` opcode. This is far more
+ * selective than ``code.co_names``, which would produce many false positives.
+ *
+ * The Python bytecode encoding is not stable, hence there is a chance that this
+ * code will not work on future Python versions. The ``configure()`` method
+ * therefore first runs a test scan against a function with a known output.
+ * In the case of failure, the implementation warns and then switches to a
+ * ``dis``-based fallback implementation that is roughly 1000x slower(!)
+ */
+struct BytecodeScan {
+    long load_global = -1;  /// Opcode ID of LOAD_GLOBAL
+    long extended_arg = -1; /// Opcode ID of an opcode with a large payload
+
+    /// Right shift turning an operand into an index into ``co_names``
+    uint32_t shift = 0;
+
+    /// Set when the calibration described above succeeded
+    bool valid = false;
+
+    /// Look up the opcodes and determine the operand encoding
+    void configure() {
+        try { valid = probe(); } catch (...) { valid = false; }
+
+        if (!valid &&
+            PyErr_WarnEx(
+                PyExc_RuntimeWarning,
+                "drjit.freeze(): could not interpret the bytecode of this "
+                "Python version. Finding the global variables that a "
+                "frozen function reads falls back to the 'dis' module, "
+                "which has the same effect but takes about a thousand "
+                "times longer, once per decorated function. Please report "
+                "this, as it means that this Dr.Jit binary is older than "
+                "the interpreter that loaded it.", 1) < 0)
+            nb::raise_python_error();
+    }
+
+    /// Configure the bytecode decoder for the current Python version or fail
+    bool probe() {
+        // Resolve opcode IDs
+        nb::object get_fn = nb::module_::import_("opcode").attr("opmap").attr("get");
+        load_global  = nb::cast<long>(get_fn("LOAD_GLOBAL"));
+        extended_arg = nb::cast<long>(get_fn("EXTENDED_ARG"));
+
+        // As of Python 3.11, the LOAD_GLOBAL opcode stores its literal at bit offset 1.
+        // Instead of hardcoding behavior based on the Python version, the following
+        // tests the machinery on a specific function to both infer the shift and
+        // test that this is still working correctly on a new/unseen Python version.
+        constexpr size_t probe_size = 129;
+        std::string src = "def probe():\n    return _g0";
+        for (size_t i = 1; i < probe_size; ++i)
+            src += ",_g" + std::to_string(i);
+        src += "\n";
+
+        nb::dict ns;
+        nb::exec(nb::str(src.c_str()), ns);
+        nb::object code = nb::getattr(ns["probe"], "__code__");
+
+        for (uint32_t s : { 1u, 0u }) {
+            shift = s;
+            nb::list found;
+            collect(code, found);
+            if (found.size() == probe_size)
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Given a function code object, ``collect()`` steps through the bytecode
+     * one word at a time, collecting globals referenced by the ``LOAD_GLOBAL``
+     * opcode, and chaining ``EXTENDED_ARG`` sequences that encode larger
+     * literal parameters. The interpretation of the ``LOAD_GLOBAL`` literal
+     * depends on the Python version and requires a calibrated shift determined
+     * by ``probe()``.
+     */
+    void collect(nb::handle code, nb::list &out) const {
+        nb::tuple names = nb::borrow<nb::tuple>(nb::getattr(code, "co_names"));
+        nb::bytes bc = nb::borrow<nb::bytes>(nb::getattr(code, "co_code"));
+        const uint8_t *p = (const uint8_t *) bc.c_str();
+        drjit::vector<uint8_t> seen(names.size(), 0);
+
+        // Bits contributed by a preceding ``EXTENDED_ARG`` chain
+        uint32_t ext = 0;
+
+        // Walk through the function's byte code one opcode at a time
+        for (size_t i = 0, n = bc.size() / 2; i < n; ++i) {
+            long op      = p[2 * i];
+            uint32_t arg = p[2 * i + 1] | ext;
+
+            // Accumulate longer literals signaled by an ``EXTENDED_ARG`` opcode
+            if (op == extended_arg) {
+                ext = arg << 8;
+                continue;
+            }
+
+            // In Python 3.11, the lowest bit of the LOAD_GLOBAL opcode has a special
+            // meaning and must be shifted out to get the referenced global name
+            uint32_t index = arg >> shift;
+
+            if (op == load_global && index < names.size() && !seen[index]) {
+                seen[index] = 1;
+                out.append(names[index]);
+            }
+
+            ext = 0;
+        }
+    }
+};
+
+static BytecodeScan bytecode_scan;
+static std::once_flag bytecode_scan_configured;
+
+/// Use the ``dis`` module to extract global reads. This is portable but also incredibly inefficient.
+static void collect_via_dis(nb::handle code, nb::list &out) {
+    nb::object instructions =
+        nb::module_::import_("dis").attr("get_instructions")(code);
+    nb::str load_global("LOAD_GLOBAL");
+
+    for (nb::handle i : instructions)
+        if (nb::getattr(i, "opname").equal(load_global))
+            out.append(nb::getattr(i, "argval"));
+}
+
+/**
+ * Append the names that ``code`` and the code objects nested in it read as
+ * global variables to ``out``, with duplicates.
+ *
+ * The recursion matters because a comprehension (before Python 3.12), a
+ * generator expression, a lambda or a nested function compiles to a code
+ * object of its own, which the enclosing one merely refers to as a constant.
+ * A global that only such a body reads would otherwise go unnoticed, and a
+ * change of it would not invalidate a recording.
+ */
+static void collect_globals(nb::handle code, nb::list &out) {
+    if (bytecode_scan.valid)
+        bytecode_scan.collect(code, out);
+    else
+        collect_via_dis(code, out);
+
+    for (nb::handle c : nb::borrow<nb::tuple>(nb::getattr(code, "co_consts")))
+        if (c.type().is(code_type))
+            collect_globals(c, out);
+}
+
+/// Names of the positional parameters of a code object
+static nb::tuple positional_arg_names(nb::handle code) {
+    nb::tuple names = nb::borrow<nb::tuple>(nb::getattr(code, "co_varnames"));
+    size_t n_args   = nb::cast<size_t>(nb::getattr(code, "co_argcount"));
+
+    nb::list result;
+    for (size_t i = 0; i < n_args && i < names.size(); ++i)
+        result.append(names[i]);
+
+    return nb::tuple(result);
+}
+
+/// Names of the global variables that a function reads, deduplicated
+static nb::tuple captured_global_names(nb::handle code, nb::dict globals) {
+    std::call_once(bytecode_scan_configured, [] { bytecode_scan.configure(); });
+
+    nb::list loaded;
+    collect_globals(code, loaded);
+
+    nb::dict builtins = nb::builtins();
+
+    nb::set unique;
+    nb::list result;
+    for (nb::handle name : loaded) {
+        // A name that only resolves to a builtin cannot change
+        if (!globals.contains(name) && builtins.contains(name))
+            continue;
+        if (!unique.contains(name)) {
+            unique.add(name);
+            result.append(name);
+        }
+    }
+
+    return nb::tuple(result);
+}
+
+FunctionEnvironment::FunctionEnvironment(nb::callable func) : func(func) {
+    nb::object code = nb::getattr(func, "__code__");
+
+    arg_names    = positional_arg_names(code);
+    globals      = nb::borrow<nb::dict>(nb::getattr(func, "__globals__"));
+    global_names = captured_global_names(code, globals);
+    free_names   = nb::borrow<nb::tuple>(nb::getattr(code, "co_freevars"));
+    closure      = nb::getattr(func, "__closure__");
+}
+
+nb::dict FunctionEnvironment::capture() const {
+    nb::dict result;
+
+    for (nb::handle name : global_names) {
+        PyObject *value = PyDict_GetItem(globals.ptr(), name.ptr());
+        result[name] = value ? nb::handle(value) : missing_global;
+    }
+
+    if (!closure.is_none()) {
+        size_t i = 0;
+        for (nb::handle cell : nb::borrow<nb::tuple>(closure))
+            result[free_names[i++]] = nb::getattr(cell, DR_STR(cell_contents));
+    }
+
+    return result;
+}
+
+int FunctionEnvironment::tp_traverse(visitproc visit, void *arg) const {
+    Py_VISIT(func.ptr());
+    Py_VISIT(arg_names.ptr());
+    Py_VISIT(global_names.ptr());
+    Py_VISIT(globals.ptr());
+    Py_VISIT(free_names.ptr());
+    Py_VISIT(closure.ptr());
+    return 0;
+}
+
+void FunctionEnvironment::tp_clear() {
+    func.reset();
+    arg_names.reset();
+    global_names.reset();
+    globals.reset();
+    free_names.reset();
+    closure.reset();
+}
+
+static int function_environment_tp_traverse(PyObject *self, visitproc visit,
+                                          void *arg) noexcept {
+    Py_VISIT(Py_TYPE(self));
+    if (!nb::inst_ready(self))
+        return 0;
+    return nb::inst_ptr<FunctionEnvironment>(self)->tp_traverse(visit, arg);
+}
+
+static int function_environment_tp_clear(PyObject *self) noexcept {
+    if (nb::inst_ready(self))
+        nb::inst_ptr<FunctionEnvironment>(self)->tp_clear();
+    return 0;
+}
+
+static PyType_Slot slots[] = {
+    { Py_tp_traverse, (void *) function_environment_tp_traverse },
+    { Py_tp_clear, (void *) function_environment_tp_clear },
+    { 0, nullptr }
+};
+
+void export_funcenv(nb::module_ &m) {
+    missing_global = nb::builtins()["object"]().release();
+    code_type = nb::object(nb::module_::import_("types").attr("CodeType"))
+                    .release();
+
+    nb::class_<FunctionEnvironment>(m, "FunctionEnvironment", nb::type_slots(slots))
+        .def(nb::init<nb::callable>(), "func"_a)
+        .def_ro("arg_names", &FunctionEnvironment::arg_names)
+        .def_ro("global_names", &FunctionEnvironment::global_names)
+        .def_ro("free_names", &FunctionEnvironment::free_names)
+        .def("capture", &FunctionEnvironment::capture);
+}

--- a/src/python/funcenv.h
+++ b/src/python/funcenv.h
@@ -1,0 +1,49 @@
+/*
+    funcenv.h -- Extract the environment that a wrapped callable reads for @dr.freeze
+
+    Dr.Jit: A Just-In-Time-Compiler for Differentiable Rendering
+    Copyright 2023, Realistic Graphics Lab, EPFL.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#pragma once
+
+#include "common.h"
+
+/**
+ * \brief The environment that a wrapped callable reads
+ *
+ * This class finds the global and closure variables that a callable to be
+ * recorded reads, and it can snapshot their values at call time. It also
+ * stores the names of the positional parameters for error reporting.
+ */
+struct FunctionEnvironment {
+    /// The function that is being frozen
+    nb::callable func;
+
+    /// Names of its positional parameters
+    nb::tuple arg_names;
+
+    /// Names of the global variables that it reads, and the ``__globals__``
+    /// dictionary in which their values are looked up
+    nb::tuple global_names;
+    nb::dict globals;
+
+    /// Names of its closure variables (``co_freevars``) and the matching
+    /// cells (``__closure__``, a tuple or ``None``)
+    nb::tuple free_names;
+    nb::object closure;
+
+    explicit FunctionEnvironment(nb::callable func);
+
+    /// Snapshot the current values of the globals and closure variables
+    nb::dict capture() const;
+
+    /// Visit and release the Python references held here (GC support)
+    int tp_traverse(visitproc visit, void *arg) const;
+    void tp_clear();
+};
+
+extern void export_funcenv(nb::module_ &);

--- a/src/python/if_stmt.cpp
+++ b/src/python/if_stmt.cpp
@@ -31,7 +31,7 @@ struct IfState {
         : args(std::move(args)), true_fn(std::move(true_fn)),
           false_fn(std::move(false_fn)),
           arg_labels(std::move(arg_labels)), rv_labels(std::move(rv_labels)),
-          tracker(strict) { }
+          tracker(dr::TraverseRole::Conditional, strict) { }
 };
 
 static void if_stmt_body_cb(void *p, bool cond_val,

--- a/src/python/init.cpp
+++ b/src/python/init.cpp
@@ -1249,7 +1249,7 @@ nb::object full(const char *name, nb::handle dtype, nb::handle value,
                 }
 
                 return result;
-            } else if (nb::object df = get_dataclass_fields(dtype); df.is_valid()) {
+            } else if (nb::object df = dataclass_fields(dtype); df.is_valid()) {
                 nb::object result = nb::dict();
 
                 for (auto field : df) {

--- a/src/python/inspect.cpp
+++ b/src/python/inspect.cpp
@@ -87,7 +87,7 @@ void set_label(nb::handle h, nb::str label) {
         if (nb::dict ds = get_drjit_struct(tp); ds.is_valid()) {
             for (auto [k, v] : ds)
                 set_label(nb::getattr(h, k), nb::str("{}_{}").format(label, k));
-        } else if (nb::dict df = get_dataclass_field_dict(tp); df.is_valid()) {
+        } else if (nb::dict df = dataclass_field_dict(tp); df.is_valid()) {
             for (auto [k, field] : df)
                 if (is_dataclass_field(field))
                     set_label(nb::getattr(h, k), nb::str("{}_{}").format(label, k));

--- a/src/python/local.cpp
+++ b/src/python/local.cpp
@@ -325,7 +325,7 @@ static nb::object traverse(nb::handle tp, nb::handle v1, nb::handle v2,
             if (ret)
                 nb::setattr(result, k, r_k);
         }
-    } else if (nb::object df = get_dataclass_fields(tp); df.is_valid()) {
+    } else if (nb::object df = dataclass_fields(tp); df.is_valid()) {
         if (ret)
             result = nb::dict();
         nb::dict d;

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -24,6 +24,7 @@
 #include "reduce.h"
 #include "eval.h"
 #include "freeze.h"
+#include "funcenv.h"
 #include "iter.h"
 #include "init.h"
 #include "memop.h"
@@ -263,6 +264,7 @@ NB_MODULE(_drjit_ext, m_) {
     export_iter(detail);
     export_reduce(m);
     export_eval(m);
+    export_funcenv(detail);
     export_freeze(m);
     export_memop(m);
     export_slice(m);

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -121,7 +121,6 @@ NB_MODULE(_drjit_ext, m_) {
         .value("ShaderExecutionReordering", JitFlag::ShaderExecutionReordering, doc_JitFlag_ShaderExecutionReordering)
         .value("KernelFreezing", JitFlag::KernelFreezing, doc_JitFlag_KernelFreezing)
         .value("FreezingScope", JitFlag::FreezingScope, doc_JitFlag_FreezingScope)
-        .value("EnableObjectTraversal", JitFlag::EnableObjectTraversal, doc_JitFlag_EnableObjectTraversal)
         .value("SpillToSharedMemory", JitFlag::SpillToSharedMemory, doc_JitFlag_SpillToSharedMemory)
         .value("Default", JitFlag::Default, doc_JitFlag_Default);
 

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -89,7 +89,7 @@ nb::object gather(nb::type_object dtype, nb::object source,
                     nb::setattr(out, k, gather(sub_dtype, nb::getattr(source, k), index, active, mode));
                 }
                 return out;
-            } else if (nb::object df = get_dataclass_fields(dtype); df.is_valid()) {
+            } else if (nb::object df = dataclass_fields(dtype); df.is_valid()) {
                 nb::tuple_builder builder(nb::len(df));
                 for (nb::handle field : df) {
                     nb::object k = field.attr(DR_STR(name));
@@ -272,7 +272,7 @@ static void scatter_generic(const char *name, ReduceOp op, nb::object target,
             return;
         }
 
-        if (nb::dict df = get_dataclass_field_dict(target_tp); df.is_valid()) {
+        if (nb::dict df = dataclass_field_dict(target_tp); df.is_valid()) {
             for (auto [k, field] : df)
                 if (is_dataclass_field(field))
                     scatter_generic(name, op, nb::getattr(target, k),

--- a/src/python/switch.cpp
+++ b/src/python/switch.cpp
@@ -133,7 +133,7 @@ nb::object switch_impl(nb::handle index_, nb::sequence targets,
             nb::gil_scoped_acquire guard;
             State &state = *(State *) ptr;
             state.args_o =
-                nb::borrow<nb::tuple>(update_indices(state.args_o, args_i));
+                nb::borrow<nb::tuple>(update_indices(state.args_o, args_i, dr::TraverseRole::Call));
 
             uintptr_t index = (uintptr_t) self;
             nb::object result =
@@ -143,7 +143,7 @@ nb::object switch_impl(nb::handle index_, nb::sequence targets,
                 check_compatibility(result, state.rv_o, false, "result");
 
             state.rv_o = std::move(result);
-            ::collect_indices(state.rv_o, rv_i);
+            ::collect_indices(state.rv_o, rv_i, dr::TraverseRole::Call);
         };
 
         State *state =
@@ -158,7 +158,7 @@ nb::object switch_impl(nb::handle index_, nb::sequence targets,
 
         vector<uint64_t> args_i;
         dr::detail::index64_vector rv_i;
-        ::collect_indices(state->args_o, args_i);
+        ::collect_indices(state->args_o, args_i, dr::TraverseRole::Call);
 
         if (mask.is_valid() && mask.type().is(&PyBool_Type)) {
             nb::type_object mask_tp = nb::borrow<nb::type_object>(s.mask);
@@ -172,7 +172,7 @@ nb::object switch_impl(nb::handle index_, nb::sequence targets,
             mask.is_valid() ? ((uint32_t) s.index(inst_ptr(mask))) : 0u, args_i,
             rv_i, state, func, cleanup, true);
 
-        nb::object result = ::update_indices(state->rv_o, rv_i);
+        nb::object result = ::update_indices(state->rv_o, rv_i, dr::TraverseRole::Call);
 
         if (done)
             cleanup(state);
@@ -237,7 +237,7 @@ nb::object dispatch_impl(nb::handle_t<dr::ArrayBase> inst,
             nb::gil_scoped_acquire guard;
             State &state = *(State *) ptr;
             state.args_o =
-                nb::borrow<nb::tuple>(update_indices(state.args_o, args_i));
+                nb::borrow<nb::tuple>(update_indices(state.args_o, args_i, dr::TraverseRole::Call));
 
             if (!self) {
                 self = jit_registry_peek(state.variant_name.c_str(),
@@ -255,7 +255,7 @@ nb::object dispatch_impl(nb::handle_t<dr::ArrayBase> inst,
                 check_compatibility(result, state.rv_o, false, "result");
 
             state.rv_o = std::move(result);
-            ::collect_indices(state.rv_o, rv_i);
+            ::collect_indices(state.rv_o, rv_i, dr::TraverseRole::Call);
         };
 
         State *state = new State {
@@ -277,7 +277,7 @@ nb::object dispatch_impl(nb::handle_t<dr::ArrayBase> inst,
 
         vector<uint64_t> args_i;
         dr::detail::index64_vector rv_i;
-        ::collect_indices(state->args_o, args_i);
+        ::collect_indices(state->args_o, args_i, dr::TraverseRole::Call);
 
         if (mask.is_valid() && mask.type().is(&PyBool_Type)) {
             nb::type_object mask_tp = nb::borrow<nb::type_object>(s.mask);
@@ -291,7 +291,7 @@ nb::object dispatch_impl(nb::handle_t<dr::ArrayBase> inst,
                     mask.is_valid() ? ((uint32_t) s.index(inst_ptr(mask))) : 0u,
                     args_i, rv_i, state, target_cb, cleanup, true);
 
-        nb::object result = ::update_indices(state->rv_o, rv_i);
+        nb::object result = ::update_indices(state->rv_o, rv_i, dr::TraverseRole::Call);
 
         if (done)
             cleanup(state);

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -208,7 +208,7 @@ void bind_texture(nb::module_ &m, const char *name) {
     using Float32 = dr::replace_scalar_t<QueryArray, float>;
     using Float64 = dr::replace_scalar_t<QueryArray, double>;
 
-    auto tex = nb::class_<Tex>(m, name)
+    auto tex = nb::class_<Tex, drjit::TraversableBase>(m, name)
         .def("__init__", [](Tex* t, const dr::vector<size_t>& shape,
                          size_t channels, bool use_accel,
                          dr::FilterMode filter_mode, dr::WrapMode wrap_mode,
@@ -274,8 +274,13 @@ void bind_texture(nb::module_ &m, const char *name) {
         .def("use_accel", &Tex::use_accel, doc_Texture_use_accel)
         .def("writable", &Tex::writable, doc_Texture_writable)
         .def("srgb", &Tex::srgb, doc_Texture_srgb)
-        .def_static("from_native_handle", &Tex::from_native_handle, "handle"_a,
-             "writable"_a = false,
+        .def_static("from_native_handle",
+             [](uintptr_t handle, bool writable, dr::FilterMode filter_mode,
+                dr::WrapMode wrap_mode, bool srgb) {
+                 return new Tex(Tex::from_native_handle(
+                     handle, writable, filter_mode, wrap_mode, srgb));
+             },
+             "handle"_a, "writable"_a = false,
              "filter_mode"_a = dr::FilterMode::Linear,
              "wrap_mode"_a = dr::WrapMode::Clamp, "srgb"_a = false,
              doc_Texture_from_native_handle)

--- a/src/python/tracker.cpp
+++ b/src/python/tracker.cpp
@@ -21,6 +21,9 @@
 #include <string_view>
 #include <drjit/autodiff.h>
 #include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
+#include <drjit-core/hash.h>
+#include "apply.h"
 
 // #define DEBUG_TRACKER
 
@@ -119,8 +122,11 @@ using VariableMap =
 // so that callers don't inherit the STL header file dependencies required
 // by the VariableMap declaration above
 struct VariableTracker::Impl {
-    Impl(bool strict, bool check_size)
-        : strict(strict), check_size(check_size) { }
+    Impl(dr::TraverseRole role, bool strict, bool check_size)
+        : role(role), strict(strict), check_size(check_size) { }
+
+    /// Purpose of the traversal, reported to C++ objects
+    dr::TraverseRole role;
 
     /// Pointer to a hash table storing the variable state
     VariableMap state;
@@ -243,8 +249,9 @@ static void raise_changed(const dr::string &label, nb::handle tp, nb::handle h,
               label.c_str(), nb::type_name(tp).c_str(), s0.c_str(), s1.c_str());
 }
 
-VariableTracker::VariableTracker(bool strict, bool check_size)
-    : m_impl(new Impl(strict, check_size)) {
+VariableTracker::VariableTracker(dr::TraverseRole role, bool strict,
+                                 bool check_size)
+    : m_impl(new Impl(role, strict, check_size)) {
 }
 
 VariableTracker::~VariableTracker() {
@@ -616,21 +623,38 @@ bool VariableTracker::Impl::traverse(Context &ctx, nb::handle h) {
         if (strict && !new_variable && !py_equal(h, prev))
             raise_changed(ctx.label, tp, h, prev);
     } else {
-        nb::object traverse_cb = nb::getattr(
-            h, ctx.write ? DR_STR(_traverse_1_cb_rw) : DR_STR(_traverse_1_cb_ro),
-            nb::handle());
+        if (dr::TraversableBase *tb = traversable_ptr(h); tb) {
+            // The arrays of the object graph are tracked under one label,
+            // and the Python side of each object under its own
+            struct State {
+                Impl &impl;
+                Context &ctx;
+                bool &changed;
+                dr::TraverseRole role;
+                tsl::robin_set<dr::TraversableBase *, PointerHasher> visited;
+                uint32_t n_objects = 0;
 
-        if (nb::dict ds = get_drjit_struct(tp); ds.is_valid()) {
+                uint64_t var(uint64_t idx, const char *v, const char *d) {
+                    if (ctx.write)
+                        return ctx._traverse_write(idx, v, d);
+                    ctx._traverse_read(idx, v, d);
+                    return idx;
+                }
+
+                void py(nb::dict d) {
+                    ScopedAppendLabel guard(ctx, ".__dict__", n_objects++);
+                    changed |= impl.traverse(ctx, d);
+                }
+            } st { *this, ctx, changed, role, {} };
+
+            ScopedAppendLabel guard(ctx, "._traverse_cb()");
+            traverse_object(st, tb);
+        } else if (nb::dict ds = get_drjit_struct(tp); ds.is_valid()) {
             for (auto [k, _] : ds) {
                 ScopedAppendLabel guard(ctx, ".", nb::str(k).c_str());
                 changed |= traverse(ctx, nb::getattr(h, k));
             }
-        } else if (traverse_cb.is_valid()) {
-            ScopedAppendLabel guard(ctx, "._traverse_cb()");
-            traverse_cb(
-                nb::cast(ctx, nb::rv_policy::reference)
-                    .attr(ctx.write ? DR_STR(_traverse_write) : DR_STR(_traverse_read)));
-        } else if (nb::dict df = get_dataclass_field_dict(tp); df.is_valid()) {
+        } else if (nb::dict df = dataclass_field_dict(tp); df.is_valid()) {
             for (auto [k, field] : df) {
                 if (!is_dataclass_field(field))
                     continue;
@@ -818,7 +842,7 @@ nb::object VariableTracker::Impl::restore(dr::string &label) {
                 ScopedAppendLabel guard(label, ".", nb::str(k).c_str());
                 nb::setattr(value, k, restore(label));
             }
-        } else if (nb::dict df = get_dataclass_field_dict(tp); df.is_valid()) {
+        } else if (nb::dict df = dataclass_field_dict(tp); df.is_valid()) {
             for (auto [k, field] : df) {
                 if (!is_dataclass_field(field))
                     continue;
@@ -966,7 +990,7 @@ std::pair<nb::object, bool> VariableTracker::Impl::rebuild(dr::string &label) {
                 value = tmp;
             }
         }
-    } else if (nb::dict df = get_dataclass_field_dict(tp); df.is_valid()) {
+    } else if (nb::dict df = dataclass_field_dict(tp); df.is_valid()) {
         nb::dict tmp;
         for (auto [k, field] : df) {
             if (!is_dataclass_field(field))
@@ -1024,8 +1048,8 @@ void export_tracker(nb::module_ &m) {
 
     auto trk = nb::class_<VariableTracker>(m, "VariableTracker",
                                            doc_detail_VariableTracker)
-        .def(nb::init<bool, bool>(),
-             "strict"_a = true, "check_size"_a = true,
+        .def(nb::init<dr::TraverseRole, bool, bool>(),
+             "role"_a, "strict"_a = true, "check_size"_a = true,
              doc_detail_VariableTracker_VariableTracker)
         .def("write",
              [](VariableTracker &vt, nb::handle state,
@@ -1059,11 +1083,5 @@ void export_tracker(nb::module_ &m) {
              "default_label"_a = "state",
              doc_detail_VariableTracker_rebuild);
 
-    nb::class_<VariableTracker::Context>(trk, "Context")
-        .def("_traverse_read", &VariableTracker::Context::_traverse_read)
-        .def("_traverse_write", &VariableTracker::Context::_traverse_write)
-        .freeze();
-
-    // Only now, after the nested 'Context' class was installed on it
     trk.freeze();
 }

--- a/src/python/tracker.h
+++ b/src/python/tracker.h
@@ -43,7 +43,11 @@ public:
     /*
      * \brief Create a new variable tracker
      *
-     * The constructor accepts two parameters:
+     * The constructor accepts three parameters:
+     *
+     * - ``role``: The purpose of the traversal that is reported to C++
+     *   objects (see ``drjit::TraverseRole``), e.g. ``Loop`` when tracking
+     *   the state of a symbolic loop.
      *
      * - ``strict``: Certain types of Python objects (e.g. custom Python classes
      *   without ``DRJIT_STRUCT`` field, scalar Python numeric types) are not
@@ -58,7 +62,8 @@ public:
      *   inactive elements are pruned, which causes the array size to
      *   progressively shrink).
      */
-    VariableTracker(bool strict = true, bool check_size = true);
+    VariableTracker(dr::TraverseRole role, bool strict = true,
+                    bool check_size = true);
 
     /// Free all state, decrease reference counts, etc.
     ~VariableTracker();

--- a/src/python/while_loop.cpp
+++ b/src/python/while_loop.cpp
@@ -47,7 +47,7 @@ struct LoopState {
     LoopState(nb::tuple &&state, nb::callable &&cond, nb::callable &&body,
               dr::vector<dr::string> &&labels, bool strict, bool check_size)
         : state(std::move(state)), cond(std::move(cond)), body(std::move(body)),
-          labels(std::move(labels)), tracker(strict, check_size), active_size(1) { }
+          labels(std::move(labels)), tracker(dr::TraverseRole::Loop, strict, check_size), active_size(1) { }
 };
 
 /// Helper function to check that the type+size of the state variable returned
@@ -135,7 +135,7 @@ static void while_loop_read_cb(void *p, dr::vector<uint64_t> &indices) {
         };
 
         DealiasShareOp op;
-        ls->state = nb::borrow<nb::tuple>(transform("drjit.while_loop.dealias", op, ls->state));
+        ls->state = nb::borrow<nb::tuple>(transform("drjit.while_loop.dealias", op, ls->state, dr::TraverseRole::Loop));
         ls->dealiased = true;
     }
 

--- a/tests/call_ext.cpp
+++ b/tests/call_ext.cpp
@@ -247,7 +247,7 @@ void bind(nb::module_ &m) {
     using UInt32 = dr::uint32_array_t<Float>;
     using Sampler = ::Sampler<Float>;
 
-    auto sampler = nb::class_<Sampler>(m, "Sampler")
+    auto sampler = nb::class_<Sampler, dr::TraversableBase>(m, "Sampler")
         .def(nb::init<>())
         .def(nb::init<size_t>())
         .def("next", &Sampler::next)
@@ -255,7 +255,7 @@ void bind(nb::module_ &m) {
 
     bind_traverse(sampler);
 
-    auto base_cls = nb::class_<BaseT, nb::intrusive_base>(m, "Base")
+    auto base_cls = nb::class_<BaseT, drjit::TraversableBase>(m, "Base")
         .def("f", &BaseT::f)
         .def("f_masked", &BaseT::f_masked)
         .def("g", &BaseT::g)

--- a/tests/custom_type_ext.cpp
+++ b/tests/custom_type_ext.cpp
@@ -159,6 +159,13 @@ template <JitBackend Backend> void bind(nb::module_ &m) {
 
     drjit::bind_traverse(nested);
 
+    // Creates the children on the C++ side so that they have no Python
+    // counterpart until they are accessed from Python
+    m.def("make_nested", [](const Float &value, const Float &base_value) {
+        return nb::ref<Nested>(new Nested(new CustomA(value, base_value),
+                                          new CustomA(value + 1, base_value + 1)));
+    });
+
     m.def("cpp_make_opaque",
           [](CustomFloatHolder &holder) { dr::make_opaque(holder); }
     );

--- a/tests/custom_type_ext.cpp
+++ b/tests/custom_type_ext.cpp
@@ -73,7 +73,7 @@ public:
 
     Value &value() override { NB_OVERRIDE_PURE(value); }
 
-    DR_TRAMPOLINE_TRAVERSE_CB(Base);
+    DR_TRAVERSE_CB(Base)
 };
 
 template <typename Value>
@@ -92,7 +92,7 @@ private:
 };
 
 template<typename Value>
-class Nested: Object{
+class Nested : public Object {
     using Base = Object;
 
     std::vector<std::pair<nb::ref<Object>, size_t>> m_nested;
@@ -102,6 +102,8 @@ public:
         m_nested.push_back(std::make_pair(a, 0));
         m_nested.push_back(std::make_pair(b, 1));
     }
+
+    nb::ref<Object> child(size_t i) const { return m_nested.at(i).first; }
 
     DR_TRAVERSE_CB(Base, m_nested);
 };
@@ -133,7 +135,7 @@ template <JitBackend Backend> void bind(nb::module_ &m) {
     using CustomA      = CustomA<Float>;
     using Nested       = Nested<Float>;
 
-    auto object = nb::class_<Object>(
+    auto object = nb::class_<Object, drjit::TraversableBase>(
         m, "Object",
         nb::intrusive_ptr<Object>(
             [](Object *o, PyObject *po) noexcept { o->set_self_py(po); }));
@@ -151,8 +153,9 @@ template <JitBackend Backend> void bind(nb::module_ &m) {
 
     drjit::bind_traverse(a);
 
-    auto nested = nb::class_<Nested>(m, "Nested")
-                      .def(nb::init<nb::ref<Object>, nb::ref<Object>>());
+    auto nested = nb::class_<Nested, Object>(m, "Nested")
+                      .def(nb::init<nb::ref<Object>, nb::ref<Object>>())
+                      .def("child", &Nested::child);
 
     drjit::bind_traverse(nested);
 

--- a/tests/test_batched_gemm.py
+++ b/tests/test_batched_gemm.py
@@ -20,6 +20,10 @@ would go undetected if the test were changed or removed.
 import drjit as dr
 import pytest
 
+# The Accelerate BLAS kernels used by NumPy's '@' operator on macOS/arm64 leave
+# the hardware floating point exception flags set for masked-off SIMD lanes.
+pytestmark = pytest.mark.filterwarnings("ignore:.*encountered in matmul:RuntimeWarning")
+
 
 _TOL_BY_TYPE = {
     dr.VarType.Float16: 1e-1,

--- a/tests/test_custom_type_ext.py
+++ b/tests/test_custom_type_ext.py
@@ -88,29 +88,18 @@ def test04_traverse_opaque(t):
 
 
 @pytest.test_arrays("float32,-diff,shape=(*),jit")
-def test05_traverse_py(t):
+def test05_shared_object_traversal(t):
     """
-    Tests the implementation of ``traverse_py_cb_ro``, which is used to traverse
-    python objects in trampoline classes.
+    Tests that an object reachable through several references is traversed
+    once.
     """
+    pkg = get_pkg(t)
     Float = t
 
-    v = dr.arange(Float, 10)
+    a = pkg.CustomA(dr.arange(Float, 10), dr.arange(Float, 10) + 1)
+    nested = pkg.Nested(a, a)
 
-    class PyClass:
-        def __init__(self, v) -> None:
-            self.v = v
-
-    c = PyClass(v)
-
-    result = []
-
-    def callback(index, domain, variant):
-        result.append(index)
-
-    dr.detail.traverse_py_cb_ro(c, callback)
-
-    assert result == [v.index]
+    assert dr.detail.collect_indices(nested) == dr.detail.collect_indices(a)
 
 
 @pytest.test_arrays("float32,-diff,shape=(*),jit")
@@ -167,9 +156,8 @@ def test07_nested_traversal(t):
 @pytest.test_arrays("float32,-diff,shape=(*),jit")
 def test08_custom_type_refcycle(t):
     """
-    Tests that it is possible to collect indices from PyTrees with refcycles,
-    without throwing runaway recursion errors, if ``EnableObjectTraversal`` is
-    set to ``True``.
+    Tests that it is possible to collect indices from PyTrees with refcycles
+    through C++ objects. Each object is visited once.
     """
     pkg = get_pkg(t)
     Float = t
@@ -199,6 +187,106 @@ def test08_custom_type_refcycle(t):
     c = C(value, base_value, b)
     b.child = c
 
-    with pytest.raises(RuntimeError):
-        indices = dr.detail.collect_indices(b)
+    assert dr.detail.collect_indices(b) == [
+        base_value.index, value.index, base_value.index, value.index
+    ]
 
+
+@pytest.test_arrays("float32,-diff,shape=(*),jit")
+def test09_python_subclass_loop_state(t):
+    """
+    Tests that the Dr.Jit attributes of a Python subclass of a C++ class are
+    tracked as state of a symbolic loop.
+    """
+    pkg = get_pkg(t)
+    UInt32 = dr.uint32_array_t(t)
+
+    class Holder(pkg.CustomBase):
+        def __init__(self, value, base_value):
+            super().__init__(base_value)
+            self.v = value
+
+    def body(i, h):
+        h.v = h.v + 2
+        return i + 1, h
+
+    results = []
+    for symbolic in [False, True]:
+        h = Holder(dr.arange(t, 4), dr.full(t, 2, 4))
+        with dr.scoped_set_flag(dr.JitFlag.SymbolicLoops, symbolic):
+            _, h = dr.while_loop((UInt32(0), h), lambda i, h: i < 3, body)
+        results.append(h.v)
+
+    assert dr.all(results[0] == dr.arange(t, 4) + 6)
+    assert dr.all(results[1] == results[0])
+
+
+@pytest.test_arrays("float32,-diff,shape=(*),jit")
+def test10_python_subclass_traversal(t):
+    """
+    Tests that a Python subclass of a C++ class is traversed on both sides:
+    the members of the C++ base and the Python attributes.
+    """
+    pkg = get_pkg(t)
+
+    class Holder(pkg.CustomBase):
+        def __init__(self, value, base_value):
+            super().__init__(base_value)
+            self.v = value
+
+    value, base_value = dr.arange(t, 4), dr.arange(t, 4) * 2
+    h = Holder(value, base_value)
+    assert dr.detail.collect_indices(h) == [base_value.index, value.index]
+
+
+@pytest.test_arrays("float32,-diff,shape=(*),jit")
+def test11_python_subclass_as_child_loop_state(t):
+    """
+    Tests that the Python attributes of a Python subclass instance that is
+    reached through another C++ object are tracked as symbolic loop state.
+    """
+    pkg = get_pkg(t)
+    UInt32 = dr.uint32_array_t(t)
+
+    class Holder(pkg.CustomBase):
+        def __init__(self, value, base_value):
+            super().__init__(base_value)
+            self.v = value
+
+    def body(i, n):
+        h = n.child(0)
+        h.v = h.v + 2
+        return i + 1, n
+
+    results = []
+    for symbolic in [False, True]:
+        h = Holder(dr.arange(t, 4), dr.full(t, 2, 4))
+        n = pkg.Nested(h, h)
+        with dr.scoped_set_flag(dr.JitFlag.SymbolicLoops, symbolic):
+            _, n = dr.while_loop((UInt32(0), n), lambda i, n: i < 3, body)
+        results.append(n.child(0).v)
+
+    assert dr.all(results[0] == dr.arange(t, 4) + 6)
+    assert dr.all(results[1] == results[0])
+
+
+
+@pytest.test_arrays("float32,-diff,shape=(*),jit")
+def test12_python_subclass_transform_in_place(t):
+    """
+    Tests that transformations (``dr.detach()``, ``dr.grad()``) treat a
+    Python subclass of a C++ class like the C++ object itself: the object is
+    returned as is, and its attributes are left alone.
+    """
+    pkg = get_pkg(t)
+
+    class Holder(pkg.CustomBase):
+        def __init__(self, value, base_value):
+            super().__init__(base_value)
+            self.v = value
+
+    v = dr.arange(t, 4)
+    h = Holder(v, dr.arange(t, 4) + 1)
+
+    assert dr.detach(h) is h and h.v is v
+    assert dr.grad(h) is h and h.v is v

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -4125,3 +4125,51 @@ def test109_replay_frees_temporaries(t, auto_opaque):
     assert dr.all(y == x + steps)
 
     assert dr.detail.malloc_watermark(backend) - base < 6 * nbytes
+
+
+def get_custom_type_pkg(t):
+    with dr.detail.scoped_rtld_deepbind():
+        m = pytest.importorskip("custom_type_ext")
+    backend = dr.backend_v(t)
+    if backend == dr.JitBackend.LLVM:
+        return m.llvm
+    elif backend == dr.JitBackend.CUDA:
+        return m.cuda
+    elif backend == dr.JitBackend.Metal:
+        return getattr(m, "metal", None)
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+@pytest.mark.parametrize("auto_opaque", [False, True])
+def test111_cpp_objects(t, auto_opaque):
+    """
+    Tests frozen functions whose inputs are C++ objects: an object that is
+    reachable through several references, and a Python subclass of a C++
+    class with Dr.Jit arrays in its attributes.
+    """
+    pkg = get_custom_type_pkg(t)
+
+    class Holder(pkg.CustomBase):
+        def __init__(self, value, base_value):
+            super().__init__(base_value)
+            self.v = value
+
+        def value(self):
+            return self.v
+
+    @dr.freeze(auto_opaque=auto_opaque)
+    def func(nested, a, h):
+        return a.value() + a.base_value(), h.value() * h.base_value()
+
+    for i in range(3):
+        value = dr.arange(t, 4) + i
+        base_value = dr.arange(t, 4) * 2 + i
+        a = pkg.CustomA(value, base_value)
+        nested = pkg.Nested(a, a)
+        h = Holder(value + 1, base_value + 1)
+
+        r0, r1 = func(nested, a, h)
+        assert dr.all(r0 == value + base_value)
+        assert dr.all(r1 == (value + 1) * (base_value + 1))
+
+    assert func.n_recordings == 1

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -4173,3 +4173,69 @@ def test111_cpp_objects(t, auto_opaque):
         assert dr.all(r1 == (value + 1) * (base_value + 1))
 
     assert func.n_recordings == 1
+
+
+def test120_function_environment():
+    """
+    ``FunctionEnvironment`` extracts what a frozen function reads from the
+    callable that it wraps: the names of its positional parameters, of the
+    global variables that it loads and of its closure variables. The
+    extraction reaches into CPython internals, hence this test.
+    """
+    env = dr.detail.FunctionEnvironment
+
+    # Only the positional parameters are named, in declaration order.
+    # Keyword-only parameters, ``*args`` and ``**kwargs`` are left out: a
+    # call passes them by name, or beyond the end of the parameter list.
+    def f0(a, b, /, c, d=1, *rest, e, g=2, **kw):
+        pass
+
+    assert env(f0).arg_names == ("a", "b", "c", "d")
+    assert env(lambda: None).arg_names == ()
+    assert env(lambda *args, **kwargs: None).arg_names == ()
+
+    # The object of a method is an ordinary parameter
+    class MyClass:
+        def method(self, x):
+            pass
+
+    assert env(MyClass.method).arg_names == ("self", "x")
+
+    # A global that the function reads is captured, an attribute name that
+    # happens to look like one is not
+    ns = dict(scale=1, zeros=2)
+    exec("def func(x):\n    return x * scale + dr.zeros(x, 3)\n", ns)
+    e = env(ns["func"])
+    assert "scale" in e.global_names
+    assert "dr" in e.global_names
+    assert "zeros" not in e.global_names
+
+    # Builtins cannot change and are skipped
+    exec("def func2(x):\n    return len(x) + scale\n", ns)
+    assert env(ns["func2"]).global_names == ("scale",)
+
+    # The captured values are read when the call happens
+    assert e.capture()["scale"] == 1
+    ns["scale"] = 5
+    assert e.capture()["scale"] == 5
+
+    # A global that only a nested code object reads (a lambda, a
+    # comprehension or a nested function) is captured too
+    exec("def func3(x):\n"
+         "    fn = lambda y: y * inner\n"
+         "    return [fn(y) + comp for y in x]\n", ns)
+    names = env(ns["func3"]).global_names
+    assert "inner" in names and "comp" in names
+
+    # Closure variables are captured by name as well
+    def outer():
+        captured = 7
+
+        def inner(y):
+            return y + captured
+
+        return inner
+
+    e = env(outer())
+    assert e.free_names == ("captured",)
+    assert e.capture()["captured"] == 7

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -427,26 +427,38 @@ def test12_resized(t, auto_opaque):
 @pytest.mark.parametrize("auto_opaque", [False, True])
 def test13_changed_input_dict(t, auto_opaque):
     """
-    Test that it is possible to pass a dictionary to a frozen function, that is
-    inserting the result at a new key in said dictionary. This ensures that the
-    input is evaluated correctly, and the dictionary is back-assigned to the input.
+    Tests that a frozen function may replace the value stored under a key of
+    an input dictionary, and that adding a key (a structural change of the
+    input) costs one extra recording.
     """
 
     @dr.freeze(auto_opaque=auto_opaque)
     def func(d: dict):
+        d["x"] = d["x"] + 1
+
+    for i in range(2):
+        d = {"x": t(i, i + 1, i + 2)}
+        func(d)
+        assert dr.all(t(i + 1, i + 2, i + 3) == d["x"])
+    assert func.n_recordings == 1
+
+    # The first call adds the key, which changes the structure of the input.
+    # The function is recorded again, starting from the dictionary that now
+    # holds the key, and the recording replaces its value from then on.
+    @dr.freeze(auto_opaque=auto_opaque)
+    def func2(d: dict):
         d["y"] = d["x"] + 1
 
-    x = t(0, 1, 2)
-    d = {"x": x}
-
-    func(d)
+    d = {"x": t(0, 1, 2)}
+    func2(d)
     assert dr.all(t(1, 2, 3) == d["y"])
+    assert func2.n_recordings == 2
 
-    x = t(1, 2, 3)
-    d = {"x": x}
-
-    func(d)
-    assert dr.all(t(2, 3, 4) == d["y"])
+    for i in range(2):
+        d["x"] = t(i, i + 1, i + 2)
+        func2(d)
+        assert dr.all(t(i + 1, i + 2, i + 3) == d["y"])
+    assert func2.n_recordings == 2
 
 
 @pytest.test_arrays("uint32, jit, shape=(*)")
@@ -3762,17 +3774,12 @@ def test98_changing_list(t, auto_opaque):
     """
     Tests that changing the number of elements in a list fails gracefully.
     """
-    mod = sys.modules[t.__module__]
-
     @dr.freeze
     def frozen(x: list):
         x.append(x[0] + 1)
 
     x = [t(1, 2, 3)]
-    frozen(x)
-
-    x = [t(1, 2, 3, 4)]
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="changed its input"):
         frozen(x)
 
 
@@ -3925,34 +3932,38 @@ def test102_assignment(t, auto_opaque):
 @pytest.test_arrays("float32, jit, diff, shape=(*)")
 def test103_rng(t, auto_opaque):
     """
-    This tests, that calling a frozen function with a re-seeded random number
-    generator does not result in a crash. When the rng is initialized with a
-    python integer, it will convert it to a Dr.Jit UInt64 in the first call to
-    ``rng.random``. The frozen function will therefore be recorded twice once
-    with the python ``int`` as an input, and then again with a ``UInt64``
-    variable as input. The first recording cannot be replayed, and Dr.Jit
-    should therefore discard this recording. The RNG should therefore call
-    ``jit_freeze_discard``.
+    Tests a random number generator that is passed to a frozen function and
+    advances across calls. A generator seeded with a Python integer converts
+    its state to arrays on first use. That changes the structure of the input,
+    so the function is recorded a second time and this first call draws twice.
+    Seeded with an array, the generator is replayed.
     """
+    UInt64 = dr.uint64_array_t(t)
+
     def func(rng: dr.random.Generator, _):
         return rng.random(t, 10)
 
     frozen = dr.freeze(func, auto_opaque=auto_opaque)
-
-    rng_ref = dr.rng(42)
-    rng_frozen = dr.rng(42)
-
     x = t(1)
+
+    rng_int = dr.rng()
+    assert dr.width(frozen(rng_int, x)) == 10
+    assert frozen.n_recordings == 2
+
+    rng_ref = dr.rng(UInt64(0))
+    rng_frozen = dr.rng(UInt64(0))
 
     for i in range(3):
         res = frozen(rng_frozen, x)
         ref = func(rng_ref, x)
-
         assert dr.allclose(ref, res)
 
-    res = frozen(dr.rng(42), x)
-    ref = func(dr.rng(42), x)
+    # Re-seeding replays an existing recording
+    n = frozen.n_recordings
+    res = frozen(dr.rng(UInt64(0)), x)
+    ref = func(dr.rng(UInt64(0)), x)
     assert dr.allclose(ref, res)
+    assert frozen.n_recordings == n
 
 
 @pytest.mark.parametrize("auto_opaque", [False, True])
@@ -4089,6 +4100,7 @@ def test108_tensor_slicing_advanced_trailing(t, auto_opaque):
         assert dr.allclose(res, ref)
 
 
+
 @pytest.test_arrays("uint32, jit, shape=(*)")
 @pytest.mark.parametrize("auto_opaque", [False, True])
 def test109_replay_frees_temporaries(t, auto_opaque):
@@ -4125,6 +4137,31 @@ def test109_replay_frees_temporaries(t, auto_opaque):
     assert dr.all(y == x + steps)
 
     assert dr.detail.malloc_watermark(backend) - base < 6 * nbytes
+
+
+@pytest.test_arrays("uint32, jit, shape=(*)")
+@pytest.mark.parametrize("auto_opaque", [False, True])
+def test110_namedtuple(t, auto_opaque):
+    """
+    Tests that namedtuples can be passed to and returned from frozen
+    functions.
+    """
+    from collections import namedtuple
+
+    Pair = namedtuple("Pair", ["a", "b"])
+
+    @dr.freeze(auto_opaque=auto_opaque)
+    def func(p):
+        return Pair(p.a + p.b, p.a * p.b)
+
+    for i in range(2):
+        p = Pair(t(1 + i, 2, 3), t(4, 5 + i, 6))
+        res = func(p)
+        assert type(res) is Pair
+        assert dr.all(res.a == p.a + p.b)
+        assert dr.all(res.b == p.a * p.b)
+
+    assert func.n_recordings == 1
 
 
 def get_custom_type_pkg(t):
@@ -4173,6 +4210,283 @@ def test111_cpp_objects(t, auto_opaque):
         assert dr.all(r1 == (value + 1) * (base_value + 1))
 
     assert func.n_recordings == 1
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+def test112_late_python_binding(t):
+    """
+    Tests that a C++ object which acquires a Python counterpart while the
+    frozen function runs (or in between calls) does not invalidate the
+    recording.
+    """
+    pkg = get_custom_type_pkg(t)
+
+    @dr.freeze
+    def func(nested):
+        # Accessing the child creates its Python object during the recording
+        c = nested.child(0)
+        return c.value() + c.base_value()
+
+    for i in range(3):
+        value = dr.arange(t, 4) + i
+        base_value = dr.arange(t, 4) * 2 + i
+        nested = pkg.make_nested(value, base_value)
+        res = func(nested)
+        assert dr.all(res == value + base_value)
+        # Bind the second child in between calls
+        nested.child(1)
+        res = func(nested)
+        assert dr.all(res == value + base_value)
+
+    assert func.n_recordings == 1
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+def test113_python_subclass_of_cpp_class(t):
+    """
+    Tests that a Python subclass of a C++ class is traversed on both sides:
+    the Python attributes and the members of the C++ base, whether the object
+    is passed directly or reached through another C++ object.
+    """
+    pkg = get_custom_type_pkg(t)
+
+    class Holder(pkg.CustomBase):
+        def __init__(self, value, base_value):
+            super().__init__(base_value)
+            self.v = value
+
+        def value(self):
+            return self.v
+
+    @dr.freeze
+    def func(h, nested):
+        c = nested.child(0)
+        return h.value() + h.base_value(), c.value() * c.base_value()
+
+    for i in range(3):
+        value = dr.arange(t, 4) + i
+        base_value = dr.arange(t, 4) * 2 + i
+        h = Holder(value, base_value)
+        nested = pkg.Nested(Holder(value + 1, base_value + 1),
+                            Holder(value + 2, base_value + 2))
+
+        r0, r1 = func(h, nested)
+        assert dr.all(r0 == value + base_value)
+        assert dr.all(r1 == (value + 1) * (base_value + 1))
+
+    assert func.n_recordings == 1
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+def test114_tensor_rank(t):
+    """
+    Tests that tensors keep their rank through a frozen function, including
+    0-dimensional tensors.
+    """
+    Tensor = dr.tensor_t(t)
+
+    @dr.freeze
+    def func(x):
+        return x * 2
+
+    x0 = Tensor(3.0)
+    x1 = Tensor(t(3.0))
+    assert x0.shape == () and x1.shape == (1,)
+
+    assert func(x0).shape == ()
+    assert func(x1).shape == (1,)
+    assert func(x0).shape == ()
+    assert func.n_recordings == 2
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+def test115_registry_type_change(t):
+    """
+    Tests that replacing a registered object by an instance of another class
+    with the same variable layout forces a new recording, since the recorded
+    kernels contain the code of the class seen while recording.
+    """
+    pkg = get_pkg(t)
+    A, B, BasePtr = pkg.A, pkg.B, pkg.BasePtr
+
+    @dr.freeze
+    def func(c, xi, yi):
+        return c.f(xi, yi)
+
+    xi = t(1, 2, 3)
+    yi = t(5, 6, 7)
+
+    a = A()
+    c = BasePtr(a, a, a)
+    xo, yo = func(c, xi, yi)
+    assert dr.all(xo == 2 * yi) and dr.all(yo == -xi)
+    del c, a
+
+    b = B()
+    c = BasePtr(b, b, b)
+    xo, yo = func(c, xi, yi)
+    assert dr.all(xo == 3 * yi) and dr.all(yo == xi)
+    assert func.n_recordings == 2
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+def test116_property_field(t):
+    """
+    Tests a ``DRJIT_STRUCT`` field implemented as a property whose getter
+    builds a new array on every access.
+    """
+    class Holder:
+        DRJIT_STRUCT = { 'x': t }
+
+        def __init__(self, x):
+            self._x = x
+
+        @property
+        def x(self):
+            return self._x + 0
+
+        @x.setter
+        def x(self, value):
+            self._x = value
+
+    @dr.freeze
+    def func(h):
+        return h.x * 2
+
+    for i in range(4):
+        h = Holder(dr.arange(t, 8) + i)
+        assert dr.all(func(h) == (dr.arange(t, 8) + i) * 2)
+    assert func.n_recordings == 1
+
+
+@pytest.test_arrays("float32, jit, -is_diff, shape=(*)")
+def test117_self_reference_collected(t):
+    """
+    Tests that a frozen function whose layouts refer back to the function
+    itself (a reference cycle) is collected by the garbage collector.
+    """
+    import gc, weakref
+
+    @dr.freeze
+    def func(x, f):
+        return x + 1
+
+    x = t(1, 2, 3)
+    assert dr.all(func(x, func) == x + 1)
+    ref = weakref.ref(func)
+    del func
+    gc.collect()
+    assert ref() is None
+
+
+@pytest.test_arrays("uint32, jit, shape=(*)")
+def test118_input_changes_rejected(t):
+    """
+    Tests how a frozen function that changes anything but the arrays held by
+    its input is treated. A change that the function repeats on every call
+    raises, since a replay could not reproduce it. A change that the function
+    performs only once, such as the reordering of dictionary keys or the
+    reshaping of a tensor, costs one extra recording.
+    """
+    Tensor = dr.tensor_t(t)
+
+    # The diagnostic refers to the modified input by the name of the
+    # parameter that holds it, rather than by its position
+    def check_raises(func, arg):
+        with pytest.raises(RuntimeError, match="changed its input at d"):
+            func(arg)
+
+    def check_retraced(func, arg):
+        func(arg)
+        assert func.n_recordings == 2
+        func(arg)
+        assert func.n_recordings == 2
+
+    @dr.freeze
+    def f1(d):
+        d["n"] += 1
+    check_raises(f1, {"n": 5, "x": t(1, 2, 3)})
+
+    @dr.freeze
+    def f2(d):
+        x = d.pop("a")
+        d["a"] = x + 10
+    check_retraced(f2, {"a": t(0, 1, 2), "b": t(3, 4, 5)})
+
+    @dr.freeze
+    def f3(d):
+        d["x"] = Tensor(d["x"].array, (2, 3))
+    check_retraced(f3, {"x": Tensor(dr.arange(t, 6), (3, 2))})
+
+    @dr.freeze
+    def f4(d):
+        d["x"] = d["y"] + 1
+    check_retraced(f4, {"x": None, "y": t(1, 2, 3)})
+
+    # Assigning a new array is fine
+    @dr.freeze
+    def f5(d):
+        d["x"] = d["x"] + 1
+    d = {"x": t(1, 2, 3)}
+    f5(d)
+    assert dr.all(d["x"] == t(2, 3, 4))
+
+
+@pytest.test_arrays("uint32, jit, shape=(*)")
+def test119_captured_globals(t):
+    """
+    Tests the set of global variables that a frozen function captures. It is
+    determined by scanning the bytecode of the function, whose format depends
+    on the Python version, so the two properties that matter are checked
+    directly: a global that the function reads must be captured, and an
+    attribute name must not be mistaken for one.
+    """
+    x = t(1, 2, 3)
+
+    # The functions are compiled in a namespace of their own, which stands in
+    # for the globals of a module
+    def make_frozen(source, **names):
+        ns = dict(dr=dr, t=t, **names)
+        exec(source, ns)
+        return ns, dr.freeze(ns["func"])
+
+    # A global that the function reads is captured, even when its name sits
+    # at a high index of the name table (which needs an EXTENDED_ARG prefix)
+    attrs = "".join(f" + holder.a{i}" for i in range(300))
+    holder = type("Holder", (), { f"a{i}": 0 for i in range(300) })()
+    ns, func = make_frozen(f"def func(x):\n    return x{attrs} + scale\n",
+                           holder=holder, scale=1)
+
+    assert dr.all(func(x) == x + 1)
+    ns["scale"] = 2
+    assert dr.all(func(x) == x + 2)
+    assert func.n_recordings == 2
+
+    # An attribute name that happens to also be a global is not captured,
+    # so that changing that global does not trigger a new recording
+    ns, func = make_frozen("def func(x):\n    return x + dr.zeros(t, 3)\n",
+                           zeros=1)
+
+    assert dr.all(func(x) == x)
+    ns["zeros"] = 2
+    assert dr.all(func(x) == x)
+    assert func.n_recordings == 1
+
+
+    # A global that is only read from a lambda, a comprehension or a nested
+    # function lives in a code object of its own, which is scanned as well
+    ns, func = make_frozen(
+        "def func(x):\n"
+        "    scale = lambda y: y * factor\n"
+        "    return scale(x) + sum(y * weight for y in [x])\n",
+        factor=1, weight=0)
+
+    assert dr.all(func(x) == x)
+    ns["factor"] = 2
+    assert dr.all(func(x) == x * 2)
+    ns["weight"] = 1
+    assert dr.all(func(x) == x * 3)
+    assert func.n_recordings == 3
 
 
 def test120_function_environment():
@@ -4239,3 +4553,56 @@ def test120_function_environment():
     e = env(outer())
     assert e.free_names == ("captured",)
     assert e.capture()["captured"] == 7
+
+
+@pytest.test_arrays("float32, jit, shape=(*)")
+def test121_scalar_arrays(t):
+    """
+    Tests that Dr.Jit arrays without a JIT backend (the ``drjit.scalar.*``
+    types) can appear anywhere in the input and output. Their entries are
+    captured by value, just like a Python ``float``, hence a change of the
+    value triggers a new recording.
+    """
+    @dr.freeze
+    def func(v, m, x):
+        return {"y": v.x * x + m[1, 1], "v": v}
+
+    v, m = dr.scalar.Array3f(1, 2, 3), dr.scalar.Matrix4f(2)
+    x = t(1, 2, 3)
+
+    r = func(v, m, x)
+    assert dr.all(r["y"] == t(3, 4, 5))
+    assert dr.all(r["v"] == v)
+
+    r = func(v, m, t(4, 5, 6))
+    assert dr.all(r["y"] == t(6, 7, 8))
+    assert func.n_recordings == 1
+
+    r = func(dr.scalar.Array3f(10, 2, 3), m, t(1, 2, 3))
+    assert dr.all(r["y"] == t(12, 22, 32))
+    assert func.n_recordings == 2
+
+
+@pytest.test_arrays("float32, jit, is_diff, shape=(*)")
+def test122_input_init_gradients(t):
+    """
+    Tests that the extra recording of a callable that initializes its input
+    does not accumulate the gradients of its aborted first attempt.
+    """
+
+    @dr.freeze
+    def func(d):
+        d.setdefault("y", d["x"] * 2)
+        dr.backward(dr.sum(d["x"] * d["p"]))
+
+    p = t(1, 2, 3)
+    dr.enable_grad(p)
+    d = {"x": t(1, 1, 1), "p": p}
+    func(d)
+    assert func.n_recordings == 2
+    assert dr.all(dr.grad(p) == t(1, 1, 1))
+
+    dr.set_grad(p, 0)
+    func(d)
+    assert func.n_recordings == 2
+    assert dr.all(dr.grad(p) == t(1, 1, 1))

--- a/tests/while_loop_ext.cpp
+++ b/tests/while_loop_ext.cpp
@@ -36,17 +36,9 @@ struct Sampler {
 
     T next() { return rng.next_float32(); }
 
-    void traverse_1_cb_ro(void *payload,
-                          dr::detail::traverse_callback_ro fn) const {
-        traverse_1_fn_ro(rng, payload, fn);
-    }
-
-    void traverse_1_cb_rw(void *payload,
-                          dr::detail::traverse_callback_rw fn) {
-        traverse_1_fn_rw(rng, payload, fn);
-    }
-
     dr::PCG32<dr::uint64_array_t<T>> rng;
+
+    DRJIT_TRAVERSE(Sampler, rng)
 };
 
 template <typename UInt> UInt loop_with_rng() {


### PR DESCRIPTION
This PR replaces the frontend part of function freezing with a new implementation that significantly reduces replay overheads.

### Input layouts

Replaying a frozen function requires the input to be structurally equivalent to that of a previous recording. The new implementation captures this structure in a compact layout: a flat array of small nodes plus side tables for types, deduplicated input variables, literals, tensor shapes, dictionary keys, and C++ object types. Compared to the flattened variable list it replaces, this brings several improvements:

- Checking whether two layouts are compatible mostly reduces to comparing memory. Python callbacks are only needed for opaque objects.

- The common case no longer builds a layout at all. The replay optimistically walks the input alongside the layout of the last used recording, checking compatibility and collecting the deduplicated JIT variable indices in one pass with minimal use of the CPython API and no dynamic allocation. Building a fresh layout and searching the cache remains as a fallback when this check fails.

- Python types are analyzed only once per layout instead of once per occurrence. This was a big source of cost.

- The layout tracks which subtrees the function modified, so a structurally complex input that remains unchanged costs nothing during replay. Only modified leaves are written back.

- The auto-opaque feature used to be a separate pass over the variable list and now happens on the fly while traversing the inputs.

- Shared objects, cycles, and deduplication of mutable containers are handled by a single mechanism that keys objects by pointer and records repeat visits as references into the tree.

- Warnings about repeated recordings now quote the first difference to the previous recording, naming the argument or captured variable that changed.

### C++ object traversal

Traversing the Dr.Jit arrays inside C++ objects (e.g. Mitsuba scene objects) used to go through a Python → C++ → Python roundtrip that allocated a Python function object per visited instance. The traversal now stays entirely in C++ via a single virtual callback that replaces the previous separate read and write variants. Traversal also keeps track of visited objects so that DAGs are no longer walked redundantly.

Downstream C++ code that implements traversable objects needs to migrate to the new callback signature.

### Function introspection

Freezing must know the globals and closure variables accessed by a function, plus its argument names for error reporting. This previously relied on `inspect.getclosurevars()`, which disassembles the function using `dis` and is shockingly slow. The new implementation scans the bytecode directly and is about 1000x faster. Tested on Python 3.10 through 3.15.

### Documentation

`docs/freeze.rst` was rewritten to be more approachable, with a focus on what "structurally compatible input" means in practice and how to work with methods and custom classes.

### Unrelated fixes

- Texture: clamp coordinates on the emulated lookup path to avoid undefined float → int conversions with out-of-range UVs.
- Silence a benign NumPy warning on macOS.
