### PR TITLE
Enable jit variable bounds in dr.binary_search

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -3733,20 +3733,20 @@ def rng(seed: Union[ArrayBase, int] = 0, method='philox4x32', symbolic: bool = F
         raise RuntimeError("Only generator='philox4x32' is currently supported.")
 
 
-def binary_search(start, end, pred):
+def binary_search(start: Union[ArrayBase, int], end: Union[ArrayBase, int], pred: Callable) -> Union[ArrayBase, int]:
     '''
     Perform a binary search over a range given a predicate ``pred``, which
     monotonically decreases over this range (i.e. max one ``True`` -> ``False``
     transition).
 
-    Given a (scalar) ``start`` and ``end`` index of a range, this function
-    evaluates a predicate ``floor(log2(end-start) + 1)`` times with index
-    values on the interval [start, end] (inclusive) to find the first index
-    that no longer satisfies it. Note that the template parameter ``Index`` is
-    automatically inferred from the supplied predicate. Specifically, the
-    predicate takes an index array as input argument. When ``pred`` is ``False``
-    for all entries, the function returns ``start``, and when it is ``True`` for
-    all cases, it returns ``end``.
+    Given ``start`` and ``end`` indices of a range, this function evaluates a
+    predicate ``floor(log2(end-start) + 1)`` times with index values on the
+    interval [start, end] (inclusive) to find the first index that no longer
+    satisfies it. Note that the template parameter ``Index`` is automatically
+    inferred from the supplied predicate. Specifically, the predicate takes an
+    index array as input argument. When ``pred`` is ``False`` for all entries,
+    the function returns ``start``, and when it is ``True`` for all cases, it
+    returns ``end``.
 
     The following code example shows a typical use case: ``data`` contains a
     sorted list of floating point numbers, and the goal is to map floating
@@ -3765,23 +3765,46 @@ def binary_search(start, end, pred):
         )
 
     Args:
-        start (int): Starting index for the search range
-        end (int): Ending index for the search range
+        start (int | drjit.ArrayBase): Starting index for the search range.
+            Can be a scalar Python ``int`` or a Dr.Jit integer array.
+        end (int | drjit.ArrayBase): Ending index for the search range.
+            Can be a scalar Python ``int`` or a Dr.Jit integer array.
         pred (function): The predicate function to be evaluated
 
     Returns:
         Index array resulting from the binary search
     '''
-    assert isinstance(start, int) and isinstance(end, int)
+    if depth_v(start) > 1 or depth_v(end) > 1 :
+        raise ValueError(f"`start` and `end` arguments should have depth <= 1, got {depth_v(start)} and {depth_v(end)}")
 
-    iterations = log2i(end - start) + 1 if start < end else 0
+    # Transform range indices to a consistent type
+    tp = expr_t(start, end)
+    start = tp(start)
+    end = tp(end)
 
-    for _ in range(iterations):
+    iterations = select(start < end, log2i(abs(end - start)) + 1, 0)
+    index = zeros(type(iterations))
+
+    def cond_fn(start, end, index):
+        return index < iterations
+
+    def body_fn(start, end, index):
         middle = (start + end) >> 1
 
         cond = pred(middle)
         start = select(cond, minimum(middle + 1, end), start)
         end = select(cond, end, middle)
+
+        index = index + 1
+        return start, end, index
+
+    start, end, index = while_loop(
+        state=(start, end, index),
+        cond=cond_fn,
+        body=body_fn,
+        labels=("start", "end", "index"),
+        label="dr.binary_search()"
+    )
 
     return start
 

--- a/tests/test_binary_search.py
+++ b/tests/test_binary_search.py
@@ -1,0 +1,104 @@
+import drjit as dr
+import numpy as np
+import pytest
+
+
+def _ref(start, end, values, thresholds):
+    """
+    Reference search using NumPy's ``searchsorted`` (binary search).
+    Clamps the searchsorted result to the per-lane ``[start, end]`` range.
+    """
+    idx = np.searchsorted(values, thresholds, side='left')
+    return np.clip(idx, start, end)
+
+# Fixed, strictly increasing haystack shared by most tests.
+_VALUES = [1, 2, 3, 4, 5, 6, 7, 8]
+
+@pytest.mark.parametrize('case', ["scalar_bounds", "jit_bounds", "jit_end", "jit_start"])
+@pytest.test_arrays('uint32,is_jit,shape=(*)')
+def test01_various_bound_types(t, case):
+    Float = dr.float_array_t(t)
+
+    cases = {
+        "scalar_bounds": (0,             len(_VALUES) - 1),
+        "jit_bounds":    (t(0, 0, 2, 0), t(7, 5, 7, 7)),
+        "jit_end":       (0,             t(7, 7, 3, 7)),
+        "jit_start":     (t(0, 1, 2, 3), len(_VALUES) - 1)
+    }
+    start, end = cases[case]
+
+    data = Float(_VALUES)
+    threshold = Float(0.5, 3.5, 6.5, 100.0)
+
+    idx = dr.binary_search(
+        start, end,
+        lambda i: dr.gather(Float, data, i) < threshold)
+
+    assert dr.all(idx == _ref(start, end, _VALUES, threshold))
+
+@pytest.test_arrays('uint32,is_jit,shape=(*)')
+def test02_edge_cases(t):
+    # Predicate all-True -> returns 'end'; all-False -> returns 'start';
+    # empty range (start == end or start > end) -> returns start;
+    # single-element range (end == start + 1);
+    # mixed per-lane bounds where some lanes are empty and some are not.
+    Float = dr.float_array_t(t)
+    data = Float(_VALUES)
+
+    # Predicate always True (every value < 100) -> should return 'end'.
+    idx_all_true = dr.binary_search(
+        t(0, 0), t(7, 7),
+        lambda i: dr.gather(Float, data, i) < Float(100.0))
+    assert dr.all(idx_all_true == t(7, 7))
+
+    # Predicate always False (no value < 0) -> should return 'start'.
+    idx_all_false = dr.binary_search(
+        t(0, 2), t(7, 7),
+        lambda i: dr.gather(Float, data, i) < Float(0.0))
+    assert dr.all(idx_all_false == t(0, 2))
+
+    # Empty range: start == end -> returns that index unchanged.
+    idx_empty = dr.binary_search(
+        t(3, 5), t(3, 5),
+        lambda i: dr.gather(Float, data, i) < Float(100.0))
+    assert dr.all(idx_empty == t(3, 5))
+
+    # Inverted range: start > end -> returns start.
+    idx_inverted = dr.binary_search(
+        t(10, 5), t(5, 2),
+        lambda i: dr.gather(Float, data, i) < Float(100.0))
+    assert dr.all(idx_inverted == t(10, 5))
+
+    # Single-element range: end == start + 1.
+    # True predicate -> returns end
+    idx_single_t = dr.binary_search(
+        t(3), t(4),
+        lambda i: i < t(4))
+    assert dr.all(idx_single_t == t(4))
+
+    # False predicate -> returns start
+    idx_single_f = dr.binary_search(
+        t(3), t(4),
+        lambda i: i > t(100))
+    assert dr.all(idx_single_f == t(3))
+
+    # Mixed per-lane: some lanes empty, some non-empty
+    start_mix = t(0, 10, 5)
+    end_mix = t(9, 10, 5)
+    idx_mix = dr.binary_search(start_mix, end_mix, lambda i: t(1) > t(0))
+    assert dr.all(idx_mix == t(9, 10, 5))
+
+    array_t = dr.replace_shape_t(t, (3, -1), "array")
+    with pytest.raises(ValueError, match="depth <= 1"):
+        dr.binary_search(array_t([0], [0], [0]), array_t([10], [10], [10]), lambda i: i < 5)
+
+
+def test03_pure_scalar_int():
+    """Verify binary_search with pure Python int bounds and Python bool predicate."""
+    assert dr.binary_search(0, 100, lambda i: i < 42) == 42
+    assert dr.binary_search(0, 100, lambda i: i < -10) == 0
+    assert dr.binary_search(0, 100, lambda i: i < 200) == 100
+    assert dr.binary_search(5, 5, lambda i: i < 10) == 5
+    assert dr.binary_search(10, 5, lambda i: i < 10) == 10
+    assert dr.binary_search(5, 6, lambda i: i < 6) == 6
+    assert dr.binary_search(5, 6, lambda i: i > 100) == 5


### PR DESCRIPTION
This commit adds a missing functionality that is present in CPP where the binary search supports jit variable bounds.

It also adds missing typing to the function.

New tests were added as none were present for the `dr.binary_search`.