### PR TITLE
Fix reverse-mode loop gradients for differently sized invariants

### DIFF
--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -968,8 +968,9 @@ public:
         size_t N = m_inputs.size();
 
         m_state2.release();
+        // Keep invariant identities stable during trajectory re-recording.
         for (size_t i = 0; i < N; ++i)
-            m_state2.push_back_borrow(m_state[i]);
+            m_state2.push_back_borrow(m_inputs[i].is_invariant ? m_inputs[i].index : m_state[i]);
         m_write_cb(m_payload, m_state2, m_reset);
         m_reset = false;
         m_state2.release();
@@ -1020,6 +1021,8 @@ public:
         m_state2.release();
         m_read_cb(m_payload, m_state2);
         for (size_t i = 0; i < N; ++i) {
+            if (m_inputs[i].is_invariant)
+                continue;
             uint32_t new_jit = (uint32_t) m_state2[i];
             jit_var_inc_ref(new_jit);
             jit_var_dec_ref((uint32_t) m_state[i]);

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -1115,8 +1115,15 @@ public:
             if (!in.is_diff)
                 continue;
             uint32_t new_grad = ad_grad(m_state2[i]);
-            jit_var_dec_ref((uint32_t) m_state[diff_off]);
-            m_state[diff_off] = new_grad;
+            uint32_t old_grad = (uint32_t) m_state[diff_off];
+            // Keep constant accumulators invariant across loop re-recording.
+            if (in.is_invariant && jit_var_is_zero_literal(old_grad) &&
+                jit_var_is_zero_literal(new_grad)) {
+                jit_var_dec_ref(new_grad);
+            } else {
+                jit_var_dec_ref(old_grad);
+                m_state[diff_off] = new_grad;
+            }
             diff_off++;
         }
 
@@ -1178,7 +1185,7 @@ public:
             } else {
                 uint64_t zero = 0;
                 grad = jit_var_literal(m_backend, jit_var_type(in.index),
-                                       &zero, loop_size);
+                                       &zero, in.is_invariant ? jit_var_size(in.index) : loop_size);
             }
             m_state.push_back_steal(grad);
         }

--- a/tests/test_while_loop_ad.py
+++ b/tests/test_while_loop_ad.py
@@ -777,3 +777,49 @@ def test46_fwd_partial_seed_multiple_implicit(t, mode, seed):
 
     dr.forward_from(x if seed == 'x' else y)
     dr.assert_allclose(dr.grad(acc), 12 if seed == 'x' else 8)
+
+
+@pytest.mark.parametrize('width', [1, 2, 5])
+@pytest.mark.parametrize('enable_unused_grad', [False, True])
+@pytest.test_arrays('float16,is_diff,shape=(*)', 'float32,is_diff,shape=(*)',
+                    'float64,is_diff,shape=(*)')
+def test47_general_bwd_unused_invariant_width(t, width, enable_unused_grad):
+    UInt = dr.uint32_array_t(t)
+    x, scale, captured = t([1, 2, 3, 4]), t(2), t(3)
+    unused = dr.full(t, 7, width)
+    dr.enable_grad(x, scale, captured)
+    if enable_unused_grad:
+        dr.enable_grad(unused)
+
+    _, value, _, _, passenger = dr.while_loop(
+        (UInt(0), t(1), x, scale, unused),
+        lambda i, *_: i < 2,
+        lambda i, v, x, scale, unused:
+            (i + 1, v * x * scale * captured, x, scale, unused),
+        mode='symbolic', max_iterations=2)
+
+    dr.backward(dr.sum(value))
+    dr.assert_allclose(value, [36, 144, 324, 576])
+    dr.assert_allclose(dr.grad(x), [72, 144, 216, 288])
+    dr.assert_allclose(dr.grad(scale), 1080)
+    dr.assert_allclose(dr.grad(captured), 720)
+    dr.assert_allclose(passenger, unused)
+    dr.assert_allclose(dr.grad(unused), 0)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test48_general_bwd_invariant_gradient_cancellation(t):
+    UInt = dr.uint32_array_t(t)
+    x, scale = t([1, 2, 3, 4]), t(2)
+    dr.enable_grad(x, scale)
+    _, value, _ = dr.while_loop(
+        (UInt(0), x, scale),
+        lambda i, *_: i < 2,
+        lambda i, v, scale:
+            (i + 1, v + x * scale * (1 - 2 * t(i)), scale),
+        mode='symbolic', max_iterations=2)
+
+    dr.backward(dr.sum(value))
+    dr.assert_allclose(value, x)
+    dr.assert_allclose(dr.grad(x), 1)
+    dr.assert_allclose(dr.grad(scale), 0)

--- a/tests/test_while_loop_ad.py
+++ b/tests/test_while_loop_ad.py
@@ -780,29 +780,31 @@ def test46_fwd_partial_seed_multiple_implicit(t, mode, seed):
 
 
 @pytest.mark.parametrize('width', [1, 2, 5])
+@pytest.mark.parametrize('divergent', [False, True])
 @pytest.mark.parametrize('enable_unused_grad', [False, True])
 @pytest.test_arrays('float16,is_diff,shape=(*)', 'float32,is_diff,shape=(*)',
                     'float64,is_diff,shape=(*)')
-def test47_general_bwd_unused_invariant_width(t, width, enable_unused_grad):
+def test47_general_bwd_unused_invariant_width(t, width, divergent, enable_unused_grad):
     UInt = dr.uint32_array_t(t)
     x, scale, captured = t([1, 2, 3, 4]), t(2), t(3)
-    unused = dr.full(t, 7, width)
+    unused = t([7 + i for i in range(width)])
+    limit = UInt([0, 1, 2, 2]) if divergent else UInt(2)
     dr.enable_grad(x, scale, captured)
     if enable_unused_grad:
         dr.enable_grad(unused)
 
     _, value, _, _, passenger = dr.while_loop(
         (UInt(0), t(1), x, scale, unused),
-        lambda i, *_: i < 2,
+        lambda i, *_: i < limit,
         lambda i, v, x, scale, unused:
             (i + 1, v * x * scale * captured, x, scale, unused),
         mode='symbolic', max_iterations=2)
 
     dr.backward(dr.sum(value))
-    dr.assert_allclose(value, [36, 144, 324, 576])
-    dr.assert_allclose(dr.grad(x), [72, 144, 216, 288])
-    dr.assert_allclose(dr.grad(scale), 1080)
-    dr.assert_allclose(dr.grad(captured), 720)
+    dr.assert_allclose(value, [1, 12, 324, 576] if divergent else [36, 144, 324, 576])
+    dr.assert_allclose(dr.grad(x), [0, 6, 216, 288] if divergent else [72, 144, 216, 288])
+    dr.assert_allclose(dr.grad(scale), 906 if divergent else 1080)
+    dr.assert_allclose(dr.grad(captured), 604 if divergent else 720)
     dr.assert_allclose(passenger, unused)
     dr.assert_allclose(dr.grad(unused), 0)
 
@@ -823,3 +825,25 @@ def test48_general_bwd_invariant_gradient_cancellation(t):
     dr.assert_allclose(value, x)
     dr.assert_allclose(dr.grad(x), 1)
     dr.assert_allclose(dr.grad(scale), 0)
+
+
+@pytest.mark.parametrize('width', [1, 2, 5])
+@pytest.mark.parametrize('kind', ['uint', 'bool'])
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test49_general_bwd_nonfloating_invariant_width(t, width, kind):
+    UInt = dr.uint32_array_t(t)
+    unused_t = UInt if kind == 'uint' else dr.mask_t(t)
+    unused = unused_t([i % 2 for i in range(width)] if kind == 'uint'
+                      else [i % 2 == 0 for i in range(width)])
+    x = t([1, 2, 3, 4])
+    dr.enable_grad(x)
+    _, value, passenger = dr.while_loop(
+        (UInt(0), t(1), unused),
+        lambda i, *_: i < UInt([0, 1, 2, 2]),
+        lambda i, v, unused: (i + 1, v * x, unused),
+        mode='symbolic', max_iterations=2)
+
+    dr.backward(dr.sum(value))
+    dr.assert_allclose(value, [1, 2, 9, 16])
+    dr.assert_allclose(dr.grad(x), [0, 1, 6, 8])
+    assert dr.all(passenger == unused)


### PR DESCRIPTION
Fixes #536.

I preserve the original width of loop-invariant state when initializing reverse-mode gradient accumulators. I also retain an invariant accumulator's index when its old and new values are both zero literals, keeping its shape stable during replay re-recording.

During trajectory recording, I pass each invariant's original index to the Python callbacks and preserve its internal loop-state index when reading the body results. This keeps invariant identities stable across re-recording, including loops with divergent conditions.

The regression tests cover unused floating-point state with widths 1, 2, and 5 in a four-lane loop, uniform and divergent conditions, and gradient tracking enabled and disabled. They check gradients through explicit inputs, a used scalar invariant, and an implicit capture. Additional cases cover gradient cancellation and unused integer and Boolean state.

### Validation

After merging `master@51bb70ee` into `1a4b0fff`, I rebuilt on macOS arm64 with LLVM 23.1.1 and Python 3.12.14. The upstream scalar-state regression and the three invariant regression groups are preserved.

- `test_while_loop_ad.py`: 210 tests passed across LLVM and Metal.
- `test_while_loop.py`, `test_while_loop_ad.py`, and `test_autodiff.py`: 1,592 tests passed together across LLVM and Metal.
- `git diff --check`: passed.

On the original base revision `c5cdf4a`, the focused LLVM cases produced 40 failures and 3 passes. The previous contribution head also passed 74 focused cases with `OptimizeLoops` disabled.

The [Windows rerun](https://rgl-ci.epfl.ch/buildConfiguration/DrJitMSVC/38890), Linux Clang, Linux GCC, and macOS checks passed on the previous head `6fa8c635`. The current merge triggers a fresh upstream CI round. CUDA execution remains outside the verified scope.
