### PR TITLE
``Optimizer``: don't scale array-valued learning rates in place

### DIFF
--- a/drjit/opt.py
+++ b/drjit/opt.py
@@ -550,7 +550,9 @@ class _LRCache(Dict[Tuple[Type[dr.ArrayBase], float], dr.ArrayBase]):
             elif scale_o is None:
                 scale_o = arg
             else:
-                scale_o *= arg
+                # don't `*=`: `scale_o` may alias a parameter's stored
+                # learning rate, which `*=` would decay on every step
+                scale_o = scale_o * arg
 
         key = (tp, scale_f)
         result = self.get(key, None)

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -459,3 +459,19 @@ def test12_promote_fp16(optimizer_class, promote_fp16, t):
     if not success:
         print(f"  Target: {target}, Final: {final_value[0]:.8f}")
     assert success
+
+
+@pytest.test_arrays("is_diff,float32,shape=(*)")
+def test13_array_valued_lr(t):
+    # An array-valued learning rate is stored by reference. Ensure that the
+    # optimizer does not scale it in place while assembling the step size.
+    lr = dr.opaque(t, 1e-2)
+    opt = Adam(lr=lr, params={"x": t(1)})
+
+    prev = t(1)
+    for _ in range(4):
+        dr.backward(dr.sum(dr.square(opt["x"])))
+        opt.step()
+        assert dr.allclose(lr, 1e-2)
+        assert dr.all(opt["x"] < prev)
+        prev = dr.detach(opt["x"])


### PR DESCRIPTION
``_LRCache.product()`` binds ``scale_o`` to the first array-valued factor it receives, which is the learning rate held in the optimizer state. Folding the remaining factors into it with ``*=`` modifies that array in place, so Adam's EMA debiasing factor was permanently baked into the learning rate on every ``Optimizer.step()``.